### PR TITLE
ci: harden dependabot auto-merge with workflow_run fallback

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,14 @@
 name: Dependabot Auto-Merge
 
 on:
+  # Primary path: enable auto-merge as soon as Dependabot opens/updates a PR.
   pull_request_target:
     types: [opened, synchronize, reopened]
+  # Fallback path: retry enabling auto-merge once CI finishes, in case the PR was
+  # still in an "unstable" merge state when the primary path ran (race condition).
+  workflow_run:
+    workflows: ["Java CI with Maven"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -11,7 +17,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -25,3 +31,41 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Fallback: re-attempt auto-merge after the CI workflow completes successfully.
+  # fetch-metadata can't run on workflow_run events (no pull_request payload), so
+  # the allowlist is re-applied by matching the Dependabot branch name, which
+  # encodes "<group>-<artifact>" (e.g. dependabot/maven/com.fasterxml.jackson...).
+  auto-merge-retry:
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    steps:
+      - name: Enable auto-merge for the originating PR
+        env:
+          GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          case "$HEAD_BRANCH" in
+            *com.zaxxer*|*org.apache.commons*|*com.fasterxml.jackson*|*org.slf4j*|*org.junit.jupiter*|*org.testcontainers*|*org.postgresql*|*mysql*|*org.jgrapht*|*org.apache.maven.plugins*|*org.codehaus.mojo*) ;;
+            *)
+              echo "Branch '$HEAD_BRANCH' is not in the auto-merge allowlist; skipping."
+              exit 0
+              ;;
+          esac
+
+          PR_URL=$(gh pr list --head "$HEAD_BRANCH" --state open --json url --jq '.[0].url')
+          if [ -z "$PR_URL" ]; then
+            echo "No open PR found for branch '$HEAD_BRANCH'; nothing to do."
+            exit 0
+          fi
+
+          # If checks are still pending the PR is "blocked" and --auto enables
+          # auto-merge; if everything is already green the PR is "clean" and
+          # --auto is rejected, so fall back to merging directly.
+          gh pr merge --auto --merge "$PR_URL" || gh pr merge --merge "$PR_URL"


### PR DESCRIPTION
## Why

Open Dependabot PRs weren't auto-merging. Root cause: the auto-merge job ran only on `pull_request_target` at PR open/sync, while CI checks were still pending. In that window the PR's merge state is **UNSTABLE**, and GitHub's `enablePullRequestAutoMerge` mutation rejects with:

```
GraphQL: Pull request is in unstable status (enablePullRequestAutoMerge)
```

The job exited 1 (the red `dependabot` check), and nothing re-ran it after checks went green.

## Changes

This complements the new branch protection on `main` (required checks: `build`, `Analyze (java)`, `commitlint`) by adding a **`workflow_run` fallback job**:

- **`dependabot`** (unchanged) — primary path on `pull_request_target`; uses `fetch-metadata` + the dependency allowlist.
- **`auto-merge-retry`** (new) — fires after **Java CI with Maven** completes successfully and re-attempts enabling auto-merge, closing the race window.
  - `fetch-metadata` can't run on `workflow_run` events (the action errors without a `pull_request` payload), so the allowlist is re-applied by matching the Dependabot branch name, which encodes `<group>-<artifact>`.
  - Guards against forks via `head_repository.full_name == github.repository`.
  - Falls back to a direct `gh pr merge --merge` if the PR is already in a clean (all-green) state, where `--auto` would be rejected.

## Testing

- YAML validated; both triggers and both jobs parse.
- Real validation happens on the next Dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)