### PR TITLE
feat: support per-column generator overrides

### DIFF
--- a/src/main/java/io/bloviate/db/ColumnConfiguration.java
+++ b/src/main/java/io/bloviate/db/ColumnConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+/**
+ * Overrides the data generator used for a single column, replacing the
+ * generator that would otherwise be auto-detected from the column's JDBC type.
+ *
+ * <p>The column name is matched case-insensitively. The generator is built lazily
+ * by the fill engine via {@link ColumnGeneratorFactory#create(java.util.Random)},
+ * using a column-seeded {@link java.util.Random} so overridden columns remain
+ * reproducible.
+ *
+ * @param columnName the name of the column to override (matched case-insensitively)
+ * @param generatorFactory builds the generator for the column
+ * @see TableConfiguration
+ * @since 1.0.0
+ */
+public record ColumnConfiguration(String columnName, ColumnGeneratorFactory generatorFactory) {
+}

--- a/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java
+++ b/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.gen.DataGenerator;
+
+import java.util.Random;
+
+/**
+ * Builds the {@link DataGenerator} used to override generation for a single column.
+ *
+ * <p>The fill engine supplies a {@link Random} that is already seeded for the
+ * target column, so generators created here participate in the same
+ * reproducible, per-column seeding (and foreign-key reseeding) as
+ * auto-detected generators. Implementations should build their generator from
+ * the supplied {@code random} rather than creating their own.
+ *
+ * @see ColumnConfiguration
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface ColumnGeneratorFactory {
+
+    /**
+     * Creates the generator for the configured column.
+     *
+     * @param random the column-seeded random source provided by the fill engine
+     * @return the generator to use for the column
+     */
+    DataGenerator<?> create(Random random);
+}

--- a/src/main/java/io/bloviate/db/TableConfiguration.java
+++ b/src/main/java/io/bloviate/db/TableConfiguration.java
@@ -16,14 +16,46 @@
 
 package io.bloviate.db;
 
+import java.util.Set;
+
 /**
  * Configuration for customizing how a specific table should be filled with data.
- * This record allows users to specify custom row counts for individual tables,
- * overriding the default row count specified in the DatabaseConfiguration.
+ * This record allows users to specify a custom row count for an individual table
+ * (overriding the default row count specified in the DatabaseConfiguration) and,
+ * optionally, per-column generator overrides.
  *
  * @param tableName the name of the table to configure
  * @param rowCount the number of rows to generate for this table
+ * @param columnConfigurations optional per-column generator overrides; may be null or empty
  * @since 1.0.0
  */
-public record TableConfiguration(String tableName, long rowCount) {
+public record TableConfiguration(String tableName, long rowCount, Set<ColumnConfiguration> columnConfigurations) {
+
+    /**
+     * Creates a table configuration with no per-column overrides.
+     *
+     * @param tableName the name of the table to configure
+     * @param rowCount the number of rows to generate for this table
+     */
+    public TableConfiguration(String tableName, long rowCount) {
+        this(tableName, rowCount, null);
+    }
+
+    /**
+     * Retrieves the per-column configuration for the given column name.
+     *
+     * @param columnName the name of the column (matched case-insensitively)
+     * @return the column configuration if one is defined, or null otherwise
+     */
+    public ColumnConfiguration columnConfiguration(String columnName) {
+        if (columnConfigurations != null) {
+            for (ColumnConfiguration columnConfiguration : columnConfigurations) {
+                if (columnConfiguration.columnName().equalsIgnoreCase(columnName)) {
+                    return columnConfiguration;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/io/bloviate/db/TableFiller.java
+++ b/src/main/java/io/bloviate/db/TableFiller.java
@@ -78,6 +78,8 @@ public class TableFiller implements Fillable {
 
         DatabaseSupport databaseSupport = databaseConfiguration.databaseSupport();
 
+        TableConfiguration tableConfiguration = databaseConfiguration.tableConfiguration(table.name());
+
         for (Column column : filteredColumns) {
 
             long seed;
@@ -99,13 +101,21 @@ public class TableFiller implements Fillable {
                 seed = column.hashCode();
             }
 
-            generatorMap.put(column, databaseSupport.getDataGenerator(column, new Random(seed)));
+            // an explicit per-column configuration overrides the auto-detected generator;
+            // either way the generator is seeded by the engine so it stays reproducible
+            ColumnConfiguration columnConfiguration = tableConfiguration != null
+                    ? tableConfiguration.columnConfiguration(column.name())
+                    : null;
+
+            DataGenerator<?> dataGenerator = columnConfiguration != null
+                    ? columnConfiguration.generatorFactory().create(new Random(seed))
+                    : databaseSupport.getDataGenerator(column, new Random(seed));
+
+            generatorMap.put(column, dataGenerator);
             seedMap.put(column, seed);
         }
 
         int batchSize = databaseConfiguration.batchSize();
-
-        TableConfiguration tableConfiguration = databaseConfiguration.tableConfiguration(table.name());
 
         long rowCount = databaseConfiguration.defaultRowCount();
         if (tableConfiguration != null) {

--- a/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 public class BaseDatabaseTestCase {
 
@@ -35,5 +37,14 @@ public class BaseDatabaseTestCase {
         hikariConfig.setPassword(container.getPassword());
         hikariConfig.setDriverClassName(container.getDriverClassName());
         return new HikariDataSource(hikariConfig);
+    }
+
+    /**
+     * Callback invoked against the live connection after a database has been filled,
+     * allowing a test to assert on the generated data before the container is torn down.
+     */
+    @FunctionalInterface
+    protected interface Verifier {
+        void verify(Connection connection) throws SQLException;
     }
 }

--- a/src/test/java/io/bloviate/db/BasePostgresTest.java
+++ b/src/test/java/io/bloviate/db/BasePostgresTest.java
@@ -16,9 +16,9 @@
 
 package io.bloviate.db;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -28,7 +28,6 @@ class BasePostgresTest extends BaseDatabaseTestCase {
         fillDatabase(initScript, configuration, null);
     }
 
-    @SuppressWarnings("resource")
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
         try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:14-alpine")
@@ -38,9 +37,8 @@ class BasePostgresTest extends BaseDatabaseTestCase {
 
             database.start();
 
-            DataSource dataSource = getDataSource(database);
-
-            try (Connection connection = dataSource.getConnection()) {
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database);
+                 Connection connection = dataSource.getConnection()) {
                 new DatabaseFiller.Builder(connection, configuration).build().fill();
 
                 if (verifier != null) {

--- a/src/test/java/io/bloviate/db/BasePostgresTest.java
+++ b/src/test/java/io/bloviate/db/BasePostgresTest.java
@@ -25,6 +25,11 @@ import java.sql.SQLException;
 class BasePostgresTest extends BaseDatabaseTestCase {
 
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration) throws SQLException {
+        fillDatabase(initScript, configuration, null);
+    }
+
+    @SuppressWarnings("resource")
+    protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
         try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:14-alpine")
                 .withDatabaseName("bloviate")
@@ -37,6 +42,10 @@ class BasePostgresTest extends BaseDatabaseTestCase {
 
             try (Connection connection = dataSource.getConnection()) {
                 new DatabaseFiller.Builder(connection, configuration).build().fill();
+
+                if (verifier != null) {
+                    verifier.verify(connection);
+                }
             }
 
         }

--- a/src/test/java/io/bloviate/db/ColumnConfigurationTest.java
+++ b/src/test/java/io/bloviate/db/ColumnConfigurationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.gen.IntegerGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ColumnConfigurationTest {
+
+    private static ColumnConfiguration codeAlwaysSeven() {
+        // start=7, end=8 (exclusive) -> always 7
+        return new ColumnConfiguration("code", random -> new IntegerGenerator.Builder(random).start(7).end(8).build());
+    }
+
+    @Test
+    void backCompatConstructorHasNoColumnConfigurations() {
+        TableConfiguration configuration = new TableConfiguration("widget", 10);
+
+        assertNull(configuration.columnConfigurations());
+        assertNull(configuration.columnConfiguration("anything"));
+    }
+
+    @Test
+    void columnConfigurationLookupIsCaseInsensitive() {
+        ColumnConfiguration code = codeAlwaysSeven();
+        TableConfiguration configuration = new TableConfiguration("widget", 10, Set.of(code));
+
+        assertSame(code, configuration.columnConfiguration("code"));
+        assertSame(code, configuration.columnConfiguration("CODE"));
+        assertNull(configuration.columnConfiguration("label"));
+    }
+
+    @Test
+    void factoryBuildsGeneratorFromSuppliedRandom() {
+        ColumnConfiguration code = codeAlwaysSeven();
+
+        assertEquals(7, code.generatorFactory().create(new Random(1)).generate());
+        assertEquals(7, code.generatorFactory().create(new Random(999)).generate());
+    }
+}

--- a/src/test/java/io/bloviate/db/PostgresFillerTest.java
+++ b/src/test/java/io/bloviate/db/PostgresFillerTest.java
@@ -17,11 +17,18 @@
 package io.bloviate.db;
 
 import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.IntegerGenerator;
 import org.junit.jupiter.api.Test;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PostgresFillerTest extends BasePostgresTest {
 
@@ -48,5 +55,41 @@ class PostgresFillerTest extends BasePostgresTest {
         DatabaseConfiguration configuration = new DatabaseConfiguration(128, 10, new PostgresSupport(), tableConfigurations);
         fillDatabase("create_tpcc.postgres.sql", configuration);
 
+    }
+
+    @Test
+    void fillWithColumnConfiguration() throws SQLException {
+
+        long rows = 25;
+
+        // override the "code" column with a generator that always produces 7 (start inclusive, end exclusive)
+        Set<ColumnConfiguration> columnConfigurations = Set.of(
+                new ColumnConfiguration("code", random -> new IntegerGenerator.Builder(random).start(7).end(8).build()));
+
+        Set<TableConfiguration> tableConfigurations = Set.of(
+                new TableConfiguration("widget", rows, columnConfigurations));
+
+        DatabaseConfiguration configuration = new DatabaseConfiguration(128, rows, new PostgresSupport(), tableConfigurations);
+
+        fillDatabase("create_column_config_test.postgres.sql", configuration, connection -> {
+            try (Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery("select code, label from widget")) {
+
+                long actualRows = 0;
+                while (resultSet.next()) {
+                    actualRows++;
+
+                    // overridden column: always 7
+                    assertEquals(7, resultSet.getInt("code"));
+
+                    // non-configured column: still auto-generated within the varchar(50) bound
+                    String label = resultSet.getString("label");
+                    assertNotNull(label);
+                    assertTrue(label.length() <= 50, "label exceeded column size: " + label);
+                }
+
+                assertEquals(rows, actualRows, "row count should match the table configuration");
+            }
+        });
     }
 }

--- a/src/test/resources/create_column_config_test.postgres.sql
+++ b/src/test/resources/create_column_config_test.postgres.sql
@@ -1,0 +1,5 @@
+CREATE TABLE widget (
+    id    serial PRIMARY KEY,
+    code  integer NOT NULL,
+    label varchar(50) NOT NULL
+);


### PR DESCRIPTION
Part of the ColumnConfig revival (stacked PR series). **Base: `feat/generics-audit`** (merge that first).

- `ColumnConfiguration(columnName, ColumnGeneratorFactory)` overrides the auto-detected generator for a named column (case-insensitive).
- `TableConfiguration` gains an optional `Set<ColumnConfiguration>` + `columnConfiguration(name)` lookup; back-compatible 2-arg constructor preserved.
- `TableFiller` consults it per column using the engine-managed per-column seed (reproducible, FK-reseed compatible).

Tests: unit test for the plumbing + PostgreSQL integration test proving an override is applied while non-configured columns still auto-generate. Reusable post-fill `Verifier` added to the test base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)