### PR TITLE
feat: add general-purpose data generators

### DIFF
--- a/src/main/java/io/bloviate/gen/CurrentSqlTimestampGenerator.java
+++ b/src/main/java/io/bloviate/gen/CurrentSqlTimestampGenerator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Random;
+
+/**
+ * Generates the current timestamp at the moment of generation. The random
+ * source is ignored.
+ */
+public class CurrentSqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
+
+    @Override
+    public Timestamp generate() {
+        return Timestamp.from(Instant.now());
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Timestamp value) throws SQLException {
+        statement.setTimestamp(parameterIndex, value);
+    }
+
+    @Override
+    public Timestamp get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getTimestamp(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Timestamp> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public CurrentSqlTimestampGenerator build() {
+            return new CurrentSqlTimestampGenerator(this);
+        }
+    }
+
+    private CurrentSqlTimestampGenerator(Builder builder) {
+        super(builder.random);
+    }
+}

--- a/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Generates a monotonically increasing sequence of integers over the inclusive
+ * range {@code [startInclusive, endInclusive]}, wrapping back to the start after
+ * the end is emitted. Useful for surrogate keys that must be dense and unique.
+ *
+ * <p>Unlike most generators the produced values do not depend on the random
+ * source; the counter state is held by the generator instance and advances on
+ * every call to {@link #generate()}.
+ */
+public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> {
+
+    private final int startInclusive;
+    private final int endInclusive;
+    private final AtomicInteger counter;
+
+    @Override
+    public Integer generate() {
+        return counter.getAndUpdate(current -> current >= endInclusive ? startInclusive : current + 1);
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getInt(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private int startInclusive = 1;
+        private int endInclusive = Integer.MAX_VALUE;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder start(int start) {
+            this.startInclusive = start;
+            return this;
+        }
+
+        public Builder end(int end) {
+            this.endInclusive = end;
+            return this;
+        }
+
+        @Override
+        public SequentialIntegerGenerator build() {
+            return new SequentialIntegerGenerator(this);
+        }
+    }
+
+    private SequentialIntegerGenerator(Builder builder) {
+        super(builder.random);
+        this.startInclusive = builder.startInclusive;
+        this.endInclusive = builder.endInclusive;
+        this.counter = new AtomicInteger(builder.startInclusive);
+    }
+}

--- a/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -74,6 +74,10 @@ public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> {
 
         @Override
         public SequentialIntegerGenerator build() {
+            if (endInclusive < startInclusive) {
+                throw new IllegalArgumentException(
+                        "end (" + endInclusive + ") must be >= start (" + startInclusive + ")");
+            }
             return new SequentialIntegerGenerator(this);
         }
     }

--- a/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
+++ b/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
@@ -63,7 +63,7 @@ public class SimpleStringGenerator extends AbstractDataGenerator<String> {
         }
 
         public Builder numbers(boolean numbers) {
-            this.numbers = letters;
+            this.numbers = numbers;
             return this;
         }
 

--- a/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Always generates the same configured double value. The random source is ignored.
+ */
+public class StaticDoubleGenerator extends AbstractDataGenerator<Double> {
+
+    private final Double value;
+
+    @Override
+    public Double generate() {
+        return value;
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Double value) throws SQLException {
+        statement.setDouble(parameterIndex, value);
+    }
+
+    @Override
+    public Double get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getDouble(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Double> {
+
+        private Double value = 0d;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder value(Double value) {
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public StaticDoubleGenerator build() {
+            return new StaticDoubleGenerator(this);
+        }
+    }
+
+    private StaticDoubleGenerator(Builder builder) {
+        super(builder.random);
+        this.value = builder.value;
+    }
+}

--- a/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Always generates the same configured float value. The random source is ignored.
+ */
+public class StaticFloatGenerator extends AbstractDataGenerator<Float> {
+
+    private final Float value;
+
+    @Override
+    public Float generate() {
+        return value;
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Float value) throws SQLException {
+        statement.setFloat(parameterIndex, value);
+    }
+
+    @Override
+    public Float get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getFloat(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Float> {
+
+        private Float value = 0f;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder value(Float value) {
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public StaticFloatGenerator build() {
+            return new StaticFloatGenerator(this);
+        }
+    }
+
+    private StaticFloatGenerator(Builder builder) {
+        super(builder.random);
+        this.value = builder.value;
+    }
+}

--- a/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Always generates the same configured integer value. The random source is ignored.
+ */
+public class StaticIntegerGenerator extends AbstractDataGenerator<Integer> {
+
+    private final Integer value;
+
+    @Override
+    public Integer generate() {
+        return value;
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getInt(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private Integer value = 0;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder value(Integer value) {
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public StaticIntegerGenerator build() {
+            return new StaticIntegerGenerator(this);
+        }
+    }
+
+    private StaticIntegerGenerator(Builder builder) {
+        super(builder.random);
+        this.value = builder.value;
+    }
+}

--- a/src/main/java/io/bloviate/gen/StaticStringGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticStringGenerator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Always generates the same configured string value. The random source is ignored.
+ */
+public class StaticStringGenerator extends AbstractDataGenerator<String> {
+
+    private final String value;
+
+    @Override
+    public String generate() {
+        return value;
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        private String value = "";
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        @Override
+        public StaticStringGenerator build() {
+            return new StaticStringGenerator(this);
+        }
+    }
+
+    private StaticStringGenerator(Builder builder) {
+        super(builder.random);
+        this.value = builder.value;
+    }
+}

--- a/src/main/java/io/bloviate/gen/VariableStringGenerator.java
+++ b/src/main/java/io/bloviate/gen/VariableStringGenerator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import io.bloviate.util.SeededRandomUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates strings whose length varies randomly within an inclusive
+ * {@code [minLength, maxLength]} range. The character set (letters and/or
+ * numbers) is configurable.
+ */
+public class VariableStringGenerator extends AbstractDataGenerator<String> {
+
+    private final int minLength;
+    private final int maxLength;
+    private final boolean letters;
+    private final boolean numbers;
+
+    @Override
+    public String generate() {
+        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
+        int length = randomUtils.nextInt(Math.max(minLength, 1), maxLength + 1);
+        return randomUtils.random(length, letters, numbers);
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        private int minLength = 1;
+        private int maxLength = 10;
+        private boolean letters = true;
+        private boolean numbers = false;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder minLength(int minLength) {
+            this.minLength = minLength;
+            return this;
+        }
+
+        public Builder maxLength(int maxLength) {
+            this.maxLength = maxLength;
+            return this;
+        }
+
+        public Builder letters(boolean letters) {
+            this.letters = letters;
+            return this;
+        }
+
+        public Builder numbers(boolean numbers) {
+            this.numbers = numbers;
+            return this;
+        }
+
+        @Override
+        public VariableStringGenerator build() {
+            return new VariableStringGenerator(this);
+        }
+    }
+
+    private VariableStringGenerator(Builder builder) {
+        super(builder.random);
+        this.minLength = builder.minLength;
+        this.maxLength = builder.maxLength;
+        this.letters = builder.letters;
+        this.numbers = builder.numbers;
+    }
+}

--- a/src/test/java/io/bloviate/gen/CurrentSqlTimestampGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/CurrentSqlTimestampGeneratorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CurrentSqlTimestampGeneratorTest {
+
+    @Test
+    void generatesATimestampNearNow() {
+        long before = System.currentTimeMillis();
+        Timestamp value = new CurrentSqlTimestampGenerator.Builder(new Random()).build().generate();
+        long after = System.currentTimeMillis();
+
+        assertNotNull(value);
+        assertTrue(value.getTime() >= before - 1000 && value.getTime() <= after + 1000,
+                "timestamp not within expected window: " + value.getTime());
+    }
+}

--- a/src/test/java/io/bloviate/gen/SequentialIntegerGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/SequentialIntegerGeneratorTest.java
@@ -23,8 +23,15 @@ import java.util.Random;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SequentialIntegerGeneratorTest {
+
+    @Test
+    void rejectsAnInvalidRange() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new SequentialIntegerGenerator.Builder(new Random()).start(5).end(3).build());
+    }
 
     @Test
     void emitsInclusiveRangeThenWraps() {

--- a/src/test/java/io/bloviate/gen/SequentialIntegerGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/SequentialIntegerGeneratorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SequentialIntegerGeneratorTest {
+
+    @Test
+    void emitsInclusiveRangeThenWraps() {
+        SequentialIntegerGenerator generator = new SequentialIntegerGenerator.Builder(new Random()).start(1).end(3).build();
+
+        assertEquals(1, generator.generate().intValue());
+        assertEquals(2, generator.generate().intValue());
+        assertEquals(3, generator.generate().intValue());
+        assertEquals(1, generator.generate().intValue());
+        assertEquals(2, generator.generate().intValue());
+    }
+
+    @Test
+    void producesUniqueValuesAcrossTheSpanBeforeWrapping() {
+        int start = 10;
+        int end = 30;
+
+        SequentialIntegerGenerator generator = new SequentialIntegerGenerator.Builder(new Random()).start(start).end(end).build();
+
+        Set<Integer> seen = new HashSet<>();
+        for (int i = 0; i <= (end - start); i++) {
+            seen.add(generator.generate());
+        }
+
+        assertEquals(end - start + 1, seen.size());
+        assertEquals(start, generator.generate().intValue());
+    }
+}

--- a/src/test/java/io/bloviate/gen/SimpleStringGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/SimpleStringGeneratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SimpleStringGeneratorTest {
+
+    @Test
+    void numbersOnlyProducesDigits() {
+        // regression for the numbers() builder bug (this.numbers = letters)
+        SimpleStringGenerator generator = new SimpleStringGenerator.Builder(new Random())
+                .size(12).letters(false).numbers(true).build();
+
+        for (int i = 0; i < 500; i++) {
+            String value = generator.generate();
+            assertEquals(12, value.length());
+            assertTrue(value.chars().allMatch(Character::isDigit), "expected digits only: " + value);
+        }
+    }
+
+    @Test
+    void lettersOnlyProducesLetters() {
+        SimpleStringGenerator generator = new SimpleStringGenerator.Builder(new Random())
+                .size(12).letters(true).numbers(false).build();
+
+        for (int i = 0; i < 500; i++) {
+            String value = generator.generate();
+            assertEquals(12, value.length());
+            assertTrue(value.chars().allMatch(Character::isLetter), "expected letters only: " + value);
+        }
+    }
+}

--- a/src/test/java/io/bloviate/gen/StaticGeneratorsTest.java
+++ b/src/test/java/io/bloviate/gen/StaticGeneratorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StaticGeneratorsTest {
+
+    @Test
+    void staticIntegerAlwaysReturnsConfiguredValue() {
+        StaticIntegerGenerator generator = new StaticIntegerGenerator.Builder(new Random()).value(42).build();
+        assertEquals(42, generator.generate().intValue());
+        assertEquals(42, generator.generate().intValue());
+    }
+
+    @Test
+    void staticDoubleAlwaysReturnsConfiguredValue() {
+        StaticDoubleGenerator generator = new StaticDoubleGenerator.Builder(new Random()).value(3.5).build();
+        assertEquals(3.5, generator.generate().doubleValue());
+        assertEquals(3.5, generator.generate().doubleValue());
+    }
+
+    @Test
+    void staticFloatAlwaysReturnsConfiguredValue() {
+        StaticFloatGenerator generator = new StaticFloatGenerator.Builder(new Random()).value(2.5f).build();
+        assertEquals(2.5f, generator.generate().floatValue());
+        assertEquals(2.5f, generator.generate().floatValue());
+    }
+
+    @Test
+    void staticStringAlwaysReturnsConfiguredValue() {
+        StaticStringGenerator generator = new StaticStringGenerator.Builder(new Random()).value("CONSTANT").build();
+        assertEquals("CONSTANT", generator.generate());
+        assertEquals("CONSTANT", generator.generate());
+    }
+}

--- a/src/test/java/io/bloviate/gen/VariableStringGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/VariableStringGeneratorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VariableStringGeneratorTest {
+
+    @Test
+    void lengthStaysWithinInclusiveBoundsAndUsesLettersByDefault() {
+        VariableStringGenerator generator = new VariableStringGenerator.Builder(new Random()).minLength(5).maxLength(10).build();
+
+        for (int i = 0; i < 500; i++) {
+            String value = generator.generate();
+            assertTrue(value.length() >= 5 && value.length() <= 10, "unexpected length: " + value.length());
+            assertTrue(value.chars().allMatch(Character::isLetter), "expected letters only: " + value);
+        }
+    }
+
+    @Test
+    void numbersOnlyProducesDigits() {
+        // regression for the numbers() builder bug (this.numbers = letters)
+        VariableStringGenerator generator = new VariableStringGenerator.Builder(new Random())
+                .minLength(8).maxLength(8).letters(false).numbers(true).build();
+
+        for (int i = 0; i < 500; i++) {
+            String value = generator.generate();
+            assertEquals(8, value.length());
+            assertTrue(value.chars().allMatch(Character::isDigit), "expected digits only: " + value);
+        }
+    }
+
+    @Test
+    void lettersAndNumbersProducesAlphanumeric() {
+        VariableStringGenerator generator = new VariableStringGenerator.Builder(new Random())
+                .minLength(20).maxLength(20).letters(true).numbers(true).build();
+
+        for (int i = 0; i < 500; i++) {
+            String value = generator.generate();
+            assertEquals(20, value.length());
+            assertTrue(value.chars().allMatch(Character::isLetterOrDigit), "expected alphanumeric: " + value);
+        }
+    }
+}


### PR DESCRIPTION
Part of the ColumnConfig revival (stacked PR series). **Base: `feat/column-config`** (merge that first).

- New generators on the generic `Builder<T>` contract: `SequentialIntegerGenerator`, `VariableStringGenerator`, `Static{Integer,Double,Float,String}Generator`, `CurrentSqlTimestampGenerator`.
- Fix: `SimpleStringGenerator.numbers()` ignored its argument (`this.numbers = letters`).

12 unit tests (bounds, wrap/uniqueness, character sets, constants, timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)