### PR TITLE
feat: add TPC-C data generation support

### DIFF
--- a/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
+++ b/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Generates one component (dimension) of a row-ordered cartesian product, which
+ * is what is needed to populate composite primary/foreign keys densely and
+ * without collisions.
+ *
+ * <p>For the n-th row (0-based) the value is
+ * {@code start + ((n / repeat) % cycle)}, where:
+ * <ul>
+ *   <li>{@code cycle} is the size of this dimension, and</li>
+ *   <li>{@code repeat} is how many consecutive rows share a value — i.e. the
+ *       product of the sizes of all dimensions nested inside this one.</li>
+ * </ul>
+ *
+ * <p>Example — a composite key over warehouses (W) × items (I), filled in
+ * row-major order with warehouse outermost: configure the warehouse component
+ * with {@code repeat=I, cycle=W} and the item component with
+ * {@code repeat=1, cycle=I}. Filling exactly {@code W * I} rows then yields every
+ * {@code (w, i)} pair exactly once.
+ *
+ * <p>The produced values do not depend on the random source; counter state is
+ * held by the generator instance and advances on every {@link #generate()}.
+ */
+public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Integer> {
+
+    private final int start;
+    private final long repeat;
+    private final int cycle;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    @Override
+    public Integer generate() {
+        long n = counter.getAndIncrement();
+        return start + (int) ((n / repeat) % cycle);
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getInt(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private int start = 1;
+        private long repeat = 1;
+        private int cycle = 1;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder start(int start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder repeat(long repeat) {
+            this.repeat = repeat;
+            return this;
+        }
+
+        public Builder cycle(int cycle) {
+            this.cycle = cycle;
+            return this;
+        }
+
+        @Override
+        public CompositeKeyComponentGenerator build() {
+            return new CompositeKeyComponentGenerator(this);
+        }
+    }
+
+    private CompositeKeyComponentGenerator(Builder builder) {
+        super(builder.random);
+        this.start = builder.start;
+        this.repeat = builder.repeat;
+        this.cycle = builder.cycle;
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.gen.AbstractBuilder;
+import io.bloviate.gen.AbstractDataGenerator;
+import io.bloviate.util.SeededRandomUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates the TPC-C customer credit rating (clause 4.3.2.7): "GC" (good credit)
+ * 90% of the time and "BC" (bad credit) 10% of the time.
+ */
+public class CreditGenerator extends AbstractDataGenerator<String> {
+
+    public static final String GOOD_CREDIT = "GC";
+    public static final String BAD_CREDIT = "BC";
+
+    @Override
+    public String generate() {
+        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
+        return randomUtils.nextInt(1, 101) <= 10 ? BAD_CREDIT : GOOD_CREDIT;
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public CreditGenerator build() {
+            return new CreditGenerator(random);
+        }
+    }
+
+    private CreditGenerator(Random random) {
+        super(random);
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.gen.AbstractBuilder;
+import io.bloviate.gen.AbstractDataGenerator;
+import io.bloviate.util.SeededRandomUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates TPC-C customer last names (clause 4.3.2.3): three concatenated
+ * syllables selected from a fixed set using a number drawn via {@code NURand}.
+ * The result is at most 15 characters, fitting the {@code c_last varchar(16)} column.
+ */
+public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
+
+    private static final String[] SYLLABLES = {
+            "BAR", "OUGHT", "ABLE", "PRI", "PRES", "ESE", "ANTI", "CALLY", "ATION", "EING"
+    };
+
+    // The C constant used while loading data, which must be in the range [0, 255] (clause 2.1.6.1).
+    // Only the load-time constant is relevant to a data generator; the run-time constant is unused.
+    private static final int C_LOAD = 157;
+
+    @Override
+    public String generate() {
+        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
+        int num = TPCCUtils.nonUniformRandom(255, C_LOAD, 0, 999, randomUtils);
+        return SYLLABLES[num / 100] + SYLLABLES[(num / 10) % 10] + SYLLABLES[num % 10];
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public CustomerLastNameGenerator build() {
+            return new CustomerLastNameGenerator(random);
+        }
+    }
+
+    private CustomerLastNameGenerator(Random random) {
+        super(random);
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.gen.AbstractBuilder;
+import io.bloviate.gen.AbstractDataGenerator;
+import io.bloviate.util.SeededRandomUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates the TPC-C i_data / s_data values (clause 4.3.3.1): a random
+ * alphabetic string of length 26..50 that, 10% of the time, contains the literal
+ * "ORIGINAL" at a random position.
+ */
+public class DataColumnGenerator extends AbstractDataGenerator<String> {
+
+    public static final String ORIGINAL = "ORIGINAL";
+
+    @Override
+    public String generate() {
+        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
+
+        int dataLength = randomUtils.nextInt(26, 51);
+        String data = randomUtils.randomAlphabetic(dataLength);
+
+        if (randomUtils.nextInt(1, 101) <= 10) {
+            int start = randomUtils.nextInt(0, data.length() - ORIGINAL.length() + 1);
+            data = data.substring(0, start) + ORIGINAL + data.substring(start + ORIGINAL.length());
+        }
+
+        return data;
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public DataColumnGenerator build() {
+            return new DataColumnGenerator(random);
+        }
+    }
+
+    private DataColumnGenerator(Random random) {
+        super(random);
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.db.ColumnConfiguration;
+import io.bloviate.db.ColumnGeneratorFactory;
+import io.bloviate.db.TableConfiguration;
+import io.bloviate.gen.CompositeKeyComponentGenerator;
+import io.bloviate.gen.StaticIntegerGenerator;
+import io.bloviate.gen.StaticStringGenerator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Builds a complete set of {@link TableConfiguration}s for the TPC-C schema
+ * (see {@code create_tpcc.*.sql}), suitable for passing to a
+ * {@code DatabaseConfiguration}.
+ *
+ * <p>The composite primary/foreign keys are populated as a dense, row-ordered
+ * cartesian product using {@link CompositeKeyComponentGenerator}, so each table
+ * receives exactly its cartesian cardinality of rows with unique keys and valid
+ * references. Realistic values (last names, zip codes, credit, i_data/s_data) use
+ * the TPC-C generators in this package; remaining columns fall back to the
+ * database's auto-detected generators.
+ *
+ * <p>Simplifications relative to a strict benchmark load: orders-per-district
+ * equals customers-per-district (one order per customer), {@code new_order}
+ * mirrors every order, and each order has a fixed number of lines.
+ */
+public final class TPCCConfiguration {
+
+    public static final int DEFAULT_ITEMS = 100_000;
+    public static final int DEFAULT_DISTRICTS_PER_WAREHOUSE = 10;
+    public static final int DEFAULT_CUSTOMERS_PER_DISTRICT = 3_000;
+    public static final int DEFAULT_LINES_PER_ORDER = 10;
+
+    private TPCCConfiguration() {
+    }
+
+    /**
+     * Builds a TPC-C configuration using the default per-warehouse cardinalities.
+     *
+     * @param warehouses the number of warehouses (the TPC-C scale factor)
+     * @return the set of table configurations
+     */
+    public static Set<TableConfiguration> build(int warehouses) {
+        return build(warehouses, DEFAULT_ITEMS, DEFAULT_DISTRICTS_PER_WAREHOUSE, DEFAULT_CUSTOMERS_PER_DISTRICT, DEFAULT_LINES_PER_ORDER);
+    }
+
+    /**
+     * Builds a TPC-C configuration with explicit cardinalities (useful for tests).
+     *
+     * @param warehouses           number of warehouses (W)
+     * @param items                number of items (I)
+     * @param districtsPerWarehouse districts per warehouse (D)
+     * @param customersPerDistrict  customers per district (C); also used as orders per district
+     * @param linesPerOrder         order lines per order (L)
+     * @return the set of table configurations
+     */
+    public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int linesPerOrder) {
+
+        final int w = warehouses;
+        final int i = items;
+        final int d = districtsPerWarehouse;
+        final int c = customersPerDistrict;
+        final int o = customersPerDistrict; // one order per customer
+        final int l = linesPerOrder;
+
+        final long stockRows = (long) w * i;
+        final long districtRows = (long) w * d;
+        final long customerRows = (long) w * d * c;
+        final long orderRows = (long) w * d * o;
+        final long orderLineRows = (long) w * d * o * l;
+
+        Set<TableConfiguration> tables = new HashSet<>();
+
+        tables.add(new TableConfiguration("warehouse", w, set(
+                key("w_id", 1, 1, w),
+                col("w_zip", zip()))));
+
+        tables.add(new TableConfiguration("item", i, set(
+                key("i_id", 1, 1, i),
+                col("i_data", data()))));
+
+        tables.add(new TableConfiguration("stock", stockRows, set(
+                key("s_w_id", 1, i, w),
+                key("s_i_id", 1, 1, i),
+                col("s_data", data()))));
+
+        tables.add(new TableConfiguration("district", districtRows, set(
+                key("d_w_id", 1, d, w),
+                key("d_id", 1, 1, d),
+                col("d_zip", zip()))));
+
+        tables.add(new TableConfiguration("customer", customerRows, set(
+                key("c_w_id", 1, (long) d * c, w),
+                key("c_d_id", 1, c, d),
+                key("c_id", 1, 1, c),
+                col("c_zip", zip()),
+                col("c_last", lastName()),
+                col("c_credit", credit()),
+                col("c_middle", staticString("OE")))));
+
+        tables.add(new TableConfiguration("history", customerRows, set(
+                key("h_c_w_id", 1, (long) d * c, w),
+                key("h_c_d_id", 1, c, d),
+                key("h_c_id", 1, 1, c),
+                key("h_w_id", 1, (long) d * c, w),
+                key("h_d_id", 1, c, d))));
+
+        tables.add(new TableConfiguration("open_order", orderRows, set(
+                key("o_w_id", 1, (long) d * o, w),
+                key("o_d_id", 1, o, d),
+                key("o_id", 1, 1, o),
+                key("o_c_id", 1, 1, c),
+                col("o_ol_cnt", staticInt(l)),
+                col("o_all_local", staticInt(1)))));
+
+        tables.add(new TableConfiguration("new_order", orderRows, set(
+                key("no_w_id", 1, (long) d * o, w),
+                key("no_d_id", 1, o, d),
+                key("no_o_id", 1, 1, o))));
+
+        tables.add(new TableConfiguration("order_line", orderLineRows, set(
+                key("ol_w_id", 1, (long) d * o * l, w),
+                key("ol_d_id", 1, (long) o * l, d),
+                key("ol_o_id", 1, l, o),
+                key("ol_number", 1, 1, l),
+                key("ol_supply_w_id", 1, (long) d * o * l, w),
+                key("ol_i_id", 1, 1, i))));
+
+        return tables;
+    }
+
+    /**
+     * A composite-key component: emits {@code start + ((row / repeat) % cycle)}.
+     */
+    private static ColumnConfiguration key(String name, int start, long repeat, int cycle) {
+        return new ColumnConfiguration(name,
+                random -> new CompositeKeyComponentGenerator.Builder(random).start(start).repeat(repeat).cycle(cycle).build());
+    }
+
+    private static ColumnConfiguration col(String name, ColumnGeneratorFactory factory) {
+        return new ColumnConfiguration(name, factory);
+    }
+
+    private static ColumnGeneratorFactory zip() {
+        return random -> new ZipCodeGenerator.Builder(random).build();
+    }
+
+    private static ColumnGeneratorFactory data() {
+        return random -> new DataColumnGenerator.Builder(random).build();
+    }
+
+    private static ColumnGeneratorFactory lastName() {
+        return random -> new CustomerLastNameGenerator.Builder(random).build();
+    }
+
+    private static ColumnGeneratorFactory credit() {
+        return random -> new CreditGenerator.Builder(random).build();
+    }
+
+    private static ColumnGeneratorFactory staticString(String value) {
+        return random -> new StaticStringGenerator.Builder(random).value(value).build();
+    }
+
+    private static ColumnGeneratorFactory staticInt(int value) {
+        return random -> new StaticIntegerGenerator.Builder(random).value(value).build();
+    }
+
+    private static Set<ColumnConfiguration> set(ColumnConfiguration... configurations) {
+        return new HashSet<>(Set.of(configurations));
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/TPCCUtils.java
+++ b/src/main/java/io/bloviate/gen/tpcc/TPCCUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.util.SeededRandomUtils;
+
+/**
+ * Utilities implementing pieces of the TPC-C specification.
+ */
+public final class TPCCUtils {
+
+    private TPCCUtils() {
+    }
+
+    /**
+     * The TPC-C non-uniform random function {@code NURand} (clause 2.1.6):
+     * {@code NURand(A, x, y) = (((random(0, A) | random(x, y)) + C) % (y - x + 1)) + x}.
+     *
+     * @param a    the {@code A} constant (a bit-mask bound; one of 255, 1023 or 8191)
+     * @param c    the run-time constant {@code C}, chosen within {@code [0, A]}
+     * @param min  the inclusive lower bound {@code x}
+     * @param max  the inclusive upper bound {@code y}
+     * @param randomUtils the seeded random source
+     * @return a non-uniformly distributed value in {@code [min, max]}
+     */
+    public static int nonUniformRandom(int a, int c, int min, int max, SeededRandomUtils randomUtils) {
+        return (((randomUtils.nextInt(0, a + 1) | randomUtils.nextInt(min, max + 1)) + c) % (max - min + 1)) + min;
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.gen.AbstractBuilder;
+import io.bloviate.gen.AbstractDataGenerator;
+import io.bloviate.util.SeededRandomUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates TPC-C zip codes (clause 4.3.2.7): four random digits followed by the
+ * constant suffix "11111", producing a 9-character value.
+ */
+public class ZipCodeGenerator extends AbstractDataGenerator<String> {
+
+    private static final String SUFFIX = "11111";
+
+    @Override
+    public String generate() {
+        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
+        return StringUtils.leftPad(Integer.toString(randomUtils.nextInt(0, 10000)), 4, '0') + SUFFIX;
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public ZipCodeGenerator build() {
+            return new ZipCodeGenerator(random);
+        }
+    }
+
+    private ZipCodeGenerator(Random random) {
+        super(random);
+    }
+}

--- a/src/test/java/io/bloviate/db/BaseCockroachTest.java
+++ b/src/test/java/io/bloviate/db/BaseCockroachTest.java
@@ -25,6 +25,11 @@ import java.sql.SQLException;
 class BaseCockroachTest extends BaseDatabaseTestCase {
 
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration) throws SQLException {
+        fillDatabase(initScript, configuration, null);
+    }
+
+    @SuppressWarnings("resource")
+    protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
         try (CockroachContainer database = new CockroachContainer("cockroachdb/cockroach:latest")
                 .withUrlParam("rewriteBatchedInserts", "true")
@@ -37,6 +42,10 @@ class BaseCockroachTest extends BaseDatabaseTestCase {
 
             try (Connection connection = dataSource.getConnection()) {
                 new DatabaseFiller.Builder(connection, configuration).build().fill();
+
+                if (verifier != null) {
+                    verifier.verify(connection);
+                }
             }
 
         }

--- a/src/test/java/io/bloviate/db/BaseCockroachTest.java
+++ b/src/test/java/io/bloviate/db/BaseCockroachTest.java
@@ -16,9 +16,9 @@
 
 package io.bloviate.db;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.testcontainers.containers.CockroachContainer;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -28,7 +28,6 @@ class BaseCockroachTest extends BaseDatabaseTestCase {
         fillDatabase(initScript, configuration, null);
     }
 
-    @SuppressWarnings("resource")
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
         try (CockroachContainer database = new CockroachContainer("cockroachdb/cockroach:latest")
@@ -38,9 +37,8 @@ class BaseCockroachTest extends BaseDatabaseTestCase {
 
             database.start();
 
-            DataSource dataSource = getDataSource(database);
-
-            try (Connection connection = dataSource.getConnection()) {
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database);
+                 Connection connection = dataSource.getConnection()) {
                 new DatabaseFiller.Builder(connection, configuration).build().fill();
 
                 if (verifier != null) {

--- a/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -24,7 +24,11 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BaseDatabaseTestCase {
 
@@ -46,5 +50,17 @@ public class BaseDatabaseTestCase {
     @FunctionalInterface
     protected interface Verifier {
         void verify(Connection connection) throws SQLException;
+    }
+
+    protected static void assertRowCount(Connection connection, String table, long expected) throws SQLException {
+        assertCount(connection, "select count(*) from " + table, expected);
+    }
+
+    protected static void assertCount(Connection connection, String query, long expected) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
+            resultSet.next();
+            assertEquals(expected, resultSet.getLong(1), query);
+        }
     }
 }

--- a/src/test/java/io/bloviate/db/BaseMySqlTest.java
+++ b/src/test/java/io/bloviate/db/BaseMySqlTest.java
@@ -16,9 +16,9 @@
 
 package io.bloviate.db;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.testcontainers.containers.MySQLContainer;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -28,7 +28,6 @@ class BaseMySqlTest extends BaseDatabaseTestCase {
         fillDatabase(initScript, configuration, null);
     }
 
-    @SuppressWarnings("resource")
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
         try (MySQLContainer<?> database = new MySQLContainer<>("mysql:9.7")
@@ -38,9 +37,8 @@ class BaseMySqlTest extends BaseDatabaseTestCase {
                 .withInitScript(initScript)) {
             database.start();
 
-            DataSource dataSource = getDataSource(database);
-
-            try (Connection connection = dataSource.getConnection()) {
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database);
+                 Connection connection = dataSource.getConnection()) {
                 new DatabaseFiller.Builder(connection, configuration).build().fill();
 
                 if (verifier != null) {

--- a/src/test/java/io/bloviate/db/BaseMySqlTest.java
+++ b/src/test/java/io/bloviate/db/BaseMySqlTest.java
@@ -25,6 +25,11 @@ import java.sql.SQLException;
 class BaseMySqlTest extends BaseDatabaseTestCase {
 
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration) throws SQLException {
+        fillDatabase(initScript, configuration, null);
+    }
+
+    @SuppressWarnings("resource")
+    protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
         try (MySQLContainer<?> database = new MySQLContainer<>("mysql:9.7")
                 .withConfigurationOverride("mysql-conf")
@@ -37,6 +42,10 @@ class BaseMySqlTest extends BaseDatabaseTestCase {
 
             try (Connection connection = dataSource.getConnection()) {
                 new DatabaseFiller.Builder(connection, configuration).build().fill();
+
+                if (verifier != null) {
+                    verifier.verify(connection);
+                }
             }
 
         }

--- a/src/test/java/io/bloviate/db/CockroachDBFillerTest.java
+++ b/src/test/java/io/bloviate/db/CockroachDBFillerTest.java
@@ -17,6 +17,7 @@
 package io.bloviate.db;
 
 import io.bloviate.ext.CockroachDBSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -48,6 +49,34 @@ class CockroachDBFillerTest extends BaseCockroachTest {
         DatabaseConfiguration configuration = new DatabaseConfiguration(128, 10, new CockroachDBSupport(), tableConfigurations);
         fillDatabase("create_tpcc.cockroachdb.sql", configuration);
 
+    }
+
+    @Test
+    void fillTPCCWithColumnConfigs() throws SQLException {
+
+        int w = 2;
+        int i = 10;
+        int d = 2;
+        int c = 3;
+        int l = 2;
+
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                128, 10, new CockroachDBSupport(), TPCCConfiguration.build(w, i, d, c, l));
+
+        fillDatabase("create_tpcc.cockroachdb.sql", configuration, connection -> {
+            assertRowCount(connection, "warehouse", w);
+            assertRowCount(connection, "item", i);
+            assertRowCount(connection, "stock", (long) w * i);
+            assertRowCount(connection, "district", (long) w * d);
+            assertRowCount(connection, "customer", (long) w * d * c);
+            assertRowCount(connection, "history", (long) w * d * c);
+            assertRowCount(connection, "open_order", (long) w * d * c);
+            assertRowCount(connection, "new_order", (long) w * d * c);
+            assertRowCount(connection, "order_line", (long) w * d * c * l);
+
+            assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
+            assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
+        });
     }
 
     @Test

--- a/src/test/java/io/bloviate/db/MySqlFillerTest.java
+++ b/src/test/java/io/bloviate/db/MySqlFillerTest.java
@@ -17,6 +17,7 @@
 package io.bloviate.db;
 
 import io.bloviate.ext.MySQLSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -47,5 +48,33 @@ class MySqlFillerTest extends BaseMySqlTest {
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(128, 10, new MySQLSupport(), tableConfigurations);
         fillDatabase("create_tpcc.mysql.sql", configuration);
+    }
+
+    @Test
+    void fillTPCCWithColumnConfigs() throws SQLException {
+
+        int w = 2;
+        int i = 10;
+        int d = 2;
+        int c = 3;
+        int l = 2;
+
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                128, 10, new MySQLSupport(), TPCCConfiguration.build(w, i, d, c, l));
+
+        fillDatabase("create_tpcc.mysql.sql", configuration, connection -> {
+            assertRowCount(connection, "warehouse", w);
+            assertRowCount(connection, "item", i);
+            assertRowCount(connection, "stock", (long) w * i);
+            assertRowCount(connection, "district", (long) w * d);
+            assertRowCount(connection, "customer", (long) w * d * c);
+            assertRowCount(connection, "history", (long) w * d * c);
+            assertRowCount(connection, "open_order", (long) w * d * c);
+            assertRowCount(connection, "new_order", (long) w * d * c);
+            assertRowCount(connection, "order_line", (long) w * d * c * l);
+
+            assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
+            assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
+        });
     }
 }

--- a/src/test/java/io/bloviate/db/PostgresFillerTest.java
+++ b/src/test/java/io/bloviate/db/PostgresFillerTest.java
@@ -21,7 +21,6 @@ import io.bloviate.gen.IntegerGenerator;
 import io.bloviate.gen.tpcc.TPCCConfiguration;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;

--- a/src/test/java/io/bloviate/db/PostgresFillerTest.java
+++ b/src/test/java/io/bloviate/db/PostgresFillerTest.java
@@ -18,8 +18,10 @@ package io.bloviate.db;
 
 import io.bloviate.ext.PostgresSupport;
 import io.bloviate.gen.IntegerGenerator;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -90,6 +92,39 @@ class PostgresFillerTest extends BasePostgresTest {
 
                 assertEquals(rows, actualRows, "row count should match the table configuration");
             }
+        });
+    }
+
+    @Test
+    void fillTPCCWithColumnConfigs() throws SQLException {
+
+        int w = 2;   // warehouses
+        int i = 10;  // items
+        int d = 2;   // districts per warehouse
+        int c = 3;   // customers (and orders) per district
+        int l = 2;   // lines per order
+
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                128, 10, new PostgresSupport(), TPCCConfiguration.build(w, i, d, c, l));
+
+        fillDatabase("create_tpcc.postgres.sql", configuration, connection -> {
+            // cardinalities of the dense cartesian-product fill; if any composite key
+            // collided or any FK were invalid, the fill itself would have thrown
+            assertRowCount(connection, "warehouse", w);
+            assertRowCount(connection, "item", i);
+            assertRowCount(connection, "stock", (long) w * i);
+            assertRowCount(connection, "district", (long) w * d);
+            assertRowCount(connection, "customer", (long) w * d * c);
+            assertRowCount(connection, "history", (long) w * d * c);
+            assertRowCount(connection, "open_order", (long) w * d * c);
+            assertRowCount(connection, "new_order", (long) w * d * c);
+            assertRowCount(connection, "order_line", (long) w * d * c * l);
+
+            // realistic value generators were applied
+            assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
+            assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
+            assertCount(connection, "select count(*) from customer where c_middle <> 'OE'", 0);
+            assertCount(connection, "select count(*) from open_order where o_ol_cnt <> " + l, 0);
         });
     }
 }

--- a/src/test/java/io/bloviate/gen/CompositeKeyComponentGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/CompositeKeyComponentGeneratorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CompositeKeyComponentGeneratorTest {
+
+    @Test
+    void enumeratesEveryPairOfATwoDimensionalCartesianProductExactlyOnce() {
+        int warehouses = 2;
+        int items = 3;
+
+        // warehouse outermost: repeat = items, cycle = warehouses
+        CompositeKeyComponentGenerator outer =
+                new CompositeKeyComponentGenerator.Builder(new Random()).start(1).repeat(items).cycle(warehouses).build();
+        // item innermost: repeat = 1, cycle = items
+        CompositeKeyComponentGenerator inner =
+                new CompositeKeyComponentGenerator.Builder(new Random()).start(1).repeat(1).cycle(items).build();
+
+        Set<String> pairs = new HashSet<>();
+        for (int n = 0; n < warehouses * items; n++) {
+            pairs.add(outer.generate() + "," + inner.generate());
+        }
+
+        assertEquals(warehouses * items, pairs.size(), "every (w, i) pair should be unique");
+        assertEquals(Set.of("1,1", "1,2", "1,3", "2,1", "2,2", "2,3"), pairs);
+    }
+
+    @Test
+    void outerComponentHoldsValueForRepeatRowsThenWraps() {
+        CompositeKeyComponentGenerator outer =
+                new CompositeKeyComponentGenerator.Builder(new Random()).start(1).repeat(3).cycle(2).build();
+
+        int[] expected = {1, 1, 1, 2, 2, 2, 1, 1, 1};
+        for (int value : expected) {
+            assertEquals(value, outer.generate().intValue());
+        }
+    }
+}

--- a/src/test/java/io/bloviate/gen/tpcc/TpccGeneratorsTest.java
+++ b/src/test/java/io/bloviate/gen/tpcc/TpccGeneratorsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.util.SeededRandomUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TpccGeneratorsTest {
+
+    @Test
+    void nonUniformRandomStaysWithinInclusiveBounds() {
+        SeededRandomUtils randomUtils = new SeededRandomUtils(new Random(42));
+        for (int i = 0; i < 5000; i++) {
+            int value = TPCCUtils.nonUniformRandom(255, 157, 0, 999, randomUtils);
+            assertTrue(value >= 0 && value <= 999, "out of bounds: " + value);
+        }
+    }
+
+    @Test
+    void nonUniformRandomIsDeterministicForAFixedSeed() {
+        int first = TPCCUtils.nonUniformRandom(255, 157, 0, 999, new SeededRandomUtils(new Random(7)));
+        int second = TPCCUtils.nonUniformRandom(255, 157, 0, 999, new SeededRandomUtils(new Random(7)));
+        assertEquals(first, second);
+    }
+
+    @Test
+    void creditIsAlwaysGoodOrBadAndBothOccur() {
+        CreditGenerator generator = new CreditGenerator.Builder(new Random(1)).build();
+        boolean sawGood = false;
+        boolean sawBad = false;
+        for (int i = 0; i < 2000; i++) {
+            String value = generator.generate();
+            assertTrue(CreditGenerator.GOOD_CREDIT.equals(value) || CreditGenerator.BAD_CREDIT.equals(value), "unexpected credit: " + value);
+            sawGood |= CreditGenerator.GOOD_CREDIT.equals(value);
+            sawBad |= CreditGenerator.BAD_CREDIT.equals(value);
+        }
+        assertTrue(sawGood && sawBad, "expected both GC and BC over many samples");
+    }
+
+    @Test
+    void zipCodeIsFourDigitsFollowedBy11111() {
+        ZipCodeGenerator generator = new ZipCodeGenerator.Builder(new Random(1)).build();
+        for (int i = 0; i < 2000; i++) {
+            String value = generator.generate();
+            assertEquals(9, value.length());
+            assertTrue(value.matches("\\d{4}11111"), "unexpected zip: " + value);
+        }
+    }
+
+    @Test
+    void dataColumnHasValidLengthAndSometimesContainsOriginal() {
+        DataColumnGenerator generator = new DataColumnGenerator.Builder(new Random(1)).build();
+        boolean sawOriginal = false;
+        for (int i = 0; i < 5000; i++) {
+            String value = generator.generate();
+            assertTrue(value.length() >= 26 && value.length() <= 50, "unexpected length: " + value.length());
+            sawOriginal |= value.contains(DataColumnGenerator.ORIGINAL);
+        }
+        assertTrue(sawOriginal, "expected some values to contain ORIGINAL");
+    }
+
+    @Test
+    void customerLastNameIsThreeSyllables() {
+        CustomerLastNameGenerator generator = new CustomerLastNameGenerator.Builder(new Random(1)).build();
+        for (int i = 0; i < 2000; i++) {
+            String value = generator.generate();
+            // three syllables, each 3..5 uppercase letters -> length 9..15
+            assertTrue(value.length() >= 9 && value.length() <= 15, "unexpected length: " + value);
+            assertTrue(value.chars().allMatch(Character::isUpperCase), "expected upper-case letters: " + value);
+        }
+    }
+}


### PR DESCRIPTION
Part of the ColumnConfig revival (stacked PR series). **Base: `feat/general-generators`** (merge that first).

- `CompositeKeyComponentGenerator` emits one dimension of a row-ordered cartesian product (`start + ((row/repeat)%cycle)`), enabling dense, collision-free composite PKs and valid composite FKs — the problem that blocked the original effort (the `stock (s_w_id, s_i_id)` collision). O(1) memory, `long` counter (scales to billions).
- `io.bloviate.gen.tpcc`: NURand (`TPCCUtils`), `CustomerLastName`/`ZipCode`/`Credit`/`DataColumn` generators, and `TPCCConfiguration` building all 9 tables.
- `fillTPCCWithColumnConfigs` integration tests on PostgreSQL, MySQL and CockroachDB assert exact cardinalities with composite PKs/FKs enforced.

`mvn clean verify` green on JDK 25 (39 tests). Note: stricter TPC-C fidelity improvements are in progress and will be added to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)