### PR TITLE
fix: implement get(ResultSet, int) for generators that returned null

### DIFF
--- a/src/main/java/io/bloviate/gen/DateGenerator.java
+++ b/src/main/java/io/bloviate/gen/DateGenerator.java
@@ -18,6 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -38,7 +39,8 @@ public class DateGenerator extends AbstractDataGenerator<Date> {
 
     @Override
     public Date get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return null;
+        Timestamp timestamp = resultSet.getTimestamp(columnIndex);
+        return timestamp != null ? new Date(timestamp.getTime()) : null;
     }
 
     public static class Builder extends AbstractBuilder<Date> {

--- a/src/main/java/io/bloviate/gen/InstantGenerator.java
+++ b/src/main/java/io/bloviate/gen/InstantGenerator.java
@@ -18,6 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Random;
@@ -36,7 +37,8 @@ public class InstantGenerator extends AbstractDataGenerator<Instant> {
 
     @Override
     public Instant get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return null;
+        Timestamp timestamp = resultSet.getTimestamp(columnIndex);
+        return timestamp != null ? timestamp.toInstant() : null;
     }
 
     public static class Builder extends AbstractBuilder<Instant> {

--- a/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
+++ b/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
@@ -42,7 +42,20 @@ public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
 
     @Override
     public Integer[] get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return null;
+        Array array = resultSet.getArray(columnIndex);
+
+        if (array == null) {
+            return null;
+        }
+
+        Object[] elements = (Object[]) array.getArray();
+        Integer[] result = new Integer[elements.length];
+
+        for (int i = 0; i < elements.length; i++) {
+            result[i] = elements[i] != null ? ((Number) elements[i]).intValue() : null;
+        }
+
+        return result;
     }
 
     public static class Builder extends AbstractBuilder<Integer[]> {

--- a/src/main/java/io/bloviate/gen/JsonbGenerator.java
+++ b/src/main/java/io/bloviate/gen/JsonbGenerator.java
@@ -30,7 +30,7 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return null;
+        return resultSet.getString(columnIndex);
     }
 
     public static class Builder extends AbstractBuilder<String> {

--- a/src/main/java/io/bloviate/gen/JsonbGenerator.java
+++ b/src/main/java/io/bloviate/gen/JsonbGenerator.java
@@ -16,16 +16,52 @@
 
 package io.bloviate.gen;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.bloviate.util.SeededRandomUtils;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Random;
 
+/**
+ * Generator for JSON / JSONB columns. Produces a JSON object literal (as a {@link String}) with a
+ * configurable number of randomly named fields whose values cycle through the common JSON scalar
+ * types (string, integer, double, boolean). Generation is deterministic for a given seed.
+ *
+ * <p>The value is emitted as a {@code String}; databases that accept a textual JSON representation
+ * (e.g. PostgreSQL / CockroachDB {@code jsonb}) consume it via the default {@code setObject}
+ * binding, mirroring the other textual generators ({@code InetGenerator}, {@code IntervalGenerator}).
+ */
 public class JsonbGenerator extends AbstractDataGenerator<String> {
-    // todo
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final int fields;
 
     @Override
     public String generate() {
-        return null;
+        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
+        ObjectNode node = MAPPER.createObjectNode();
+
+        for (int i = 0; i < fields; i++) {
+            String key = randomUtils.randomAlphabetic(8);
+
+            switch (i % 4) {
+                case 0 -> node.put(key, randomUtils.randomAlphabetic(12));
+                case 1 -> node.put(key, randomUtils.nextInt(0, Integer.MAX_VALUE));
+                case 2 -> node.put(key, randomUtils.nextDouble(0, Double.MAX_VALUE));
+                default -> node.put(key, random.nextBoolean());
+            }
+        }
+
+        try {
+            return MAPPER.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            // ObjectNode built here is always serializable; treat any failure as fatal
+            throw new IllegalStateException("unable to serialize generated JSON", e);
+        }
     }
 
     @Override
@@ -35,8 +71,15 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
+        private int fields = 3;
+
         public Builder(Random random) {
             super(random);
+        }
+
+        public Builder fields(int fields) {
+            this.fields = fields;
+            return this;
         }
 
         @Override
@@ -47,6 +90,6 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
 
     private JsonbGenerator(Builder builder) {
         super(builder.random);
-
+        this.fields = builder.fields;
     }
 }

--- a/src/main/java/io/bloviate/gen/SqlStructGenerator.java
+++ b/src/main/java/io/bloviate/gen/SqlStructGenerator.java
@@ -36,7 +36,7 @@ public class SqlStructGenerator extends AbstractDataGenerator<Struct> {
 
     @Override
     public Struct get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return null;
+        return (Struct) resultSet.getObject(columnIndex);
     }
 
     public static class Builder extends AbstractBuilder<Struct> {

--- a/src/main/java/io/bloviate/gen/SqlStructGenerator.java
+++ b/src/main/java/io/bloviate/gen/SqlStructGenerator.java
@@ -21,9 +21,29 @@ import java.sql.SQLException;
 import java.sql.Struct;
 import java.util.Random;
 
+/**
+ * Generator for SQL {@code STRUCT} (structured / user-defined type) columns.
+ *
+ * <p><strong>{@link #generate()} intentionally returns {@code null}.</strong> A {@link Struct}
+ * cannot be synthesized in memory: the only portable way to create one is
+ * {@code Connection.createStruct(typeName, attributes)}, which requires a live {@link
+ * java.sql.Connection}, the SQL type name, and one correctly typed value per attribute. The
+ * {@link #generate()} contract exposes none of these, and the JDBC drivers this library targets
+ * (PostgreSQL, MySQL, CockroachDB) do not implement {@code createStruct} — it throws
+ * {@link java.sql.SQLFeatureNotSupportedException}. Returning {@code null} lets nullable
+ * {@code STRUCT} columns fill; a non-nullable one will fail at insert.
+ *
+ * <p>{@link #get(ResultSet, int)} reads an existing {@code Struct} normally, so round-tripping a
+ * value already present in a {@link ResultSet} works.
+ */
 public class SqlStructGenerator extends AbstractDataGenerator<Struct> {
-    //todo
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Always returns {@code null}; see the class documentation for why a {@code Struct} cannot
+     * be generated.
+     */
     @Override
     public Struct generate() {
         return null;

--- a/src/main/java/io/bloviate/gen/StringArrayGenerator.java
+++ b/src/main/java/io/bloviate/gen/StringArrayGenerator.java
@@ -52,7 +52,20 @@ public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
 
     @Override
     public String[] get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return null;
+        Array array = resultSet.getArray(columnIndex);
+
+        if (array == null) {
+            return null;
+        }
+
+        Object[] elements = (Object[]) array.getArray();
+        String[] result = new String[elements.length];
+
+        for (int i = 0; i < elements.length; i++) {
+            result[i] = elements[i] != null ? elements[i].toString() : null;
+        }
+
+        return result;
     }
 
     public static class Builder extends AbstractBuilder<String[]> {

--- a/src/test/java/io/bloviate/file/FlatFileTest.java
+++ b/src/test/java/io/bloviate/file/FlatFileTest.java
@@ -51,9 +51,7 @@ class FlatFileTest {
         definitions.add(new ColumnDefinition("sql_uuid_col", new UUIDGenerator.Builder(random).build()));
         definitions.add(new ColumnDefinition("instant_col", new InstantGenerator.Builder(random).build()));
         definitions.add(new ColumnDefinition("interval_col", new IntervalGenerator.Builder(random).build()));
-
-        // need to implement as JsonbGenerator still returns null
-        //definitions.add(new ColumnDefinition("jsonb_col", new JsonbGenerator.Builder().build()));
+        definitions.add(new ColumnDefinition("jsonb_col", new JsonbGenerator.Builder(random).build()));
 
         FlatFileGenerator csv = new FlatFileGenerator.Builder("target/csv-test").addAll(definitions).build();
         csv.generate();

--- a/src/test/java/io/bloviate/gen/JsonbGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/JsonbGeneratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonbGeneratorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void generatesValidJsonObjectWithRequestedFieldCount() throws Exception {
+        JsonbGenerator generator = new JsonbGenerator.Builder(new Random()).fields(5).build();
+
+        for (int i = 0; i < 100; i++) {
+            String json = generator.generate();
+            assertNotNull(json);
+
+            JsonNode node = MAPPER.readTree(json);
+            assertTrue(node.isObject(), "expected a JSON object: " + json);
+            assertEquals(5, node.size(), "unexpected field count: " + json);
+        }
+    }
+
+    @Test
+    void defaultsToThreeFields() throws Exception {
+        JsonbGenerator generator = new JsonbGenerator.Builder(new Random()).build();
+
+        JsonNode node = MAPPER.readTree(generator.generate());
+        assertEquals(3, node.size());
+    }
+
+    @Test
+    void isDeterministicForAGivenSeed() {
+        JsonbGenerator a = new JsonbGenerator.Builder(new Random()).fields(4).build();
+        JsonbGenerator b = new JsonbGenerator.Builder(new Random()).fields(4).build();
+        a.setSeed(42L);
+        b.setSeed(42L);
+
+        assertEquals(a.generate(), b.generate());
+    }
+}

--- a/src/test/java/io/bloviate/gen/ResultSetGetterTest.java
+++ b/src/test/java/io/bloviate/gen/ResultSetGetterTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.sql.Struct;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Regression tests for generators whose {@code get(ResultSet, int)} previously returned a
+ * hard-coded {@code null} (see issue #422). Each generator should read the column and return a
+ * value, mapping a SQL {@code NULL} column to {@code null}.
+ */
+class ResultSetGetterTest {
+
+    private static final int COLUMN = 1;
+    private static final Random RANDOM = new Random();
+
+    @Test
+    void instantGeneratorReadsTimestamp() throws SQLException {
+        InstantGenerator generator = new InstantGenerator.Builder(RANDOM).build();
+        Instant expected = Instant.ofEpochMilli(1_600_000_000_000L);
+
+        Instant value = generator.get(StubResultSet.returning("getTimestamp", Timestamp.from(expected)), COLUMN);
+
+        assertEquals(expected, value);
+    }
+
+    @Test
+    void instantGeneratorReturnsNullForSqlNull() throws SQLException {
+        InstantGenerator generator = new InstantGenerator.Builder(RANDOM).build();
+
+        assertNull(generator.get(StubResultSet.returning("getTimestamp", null), COLUMN));
+    }
+
+    @Test
+    void dateGeneratorReadsTimestamp() throws SQLException {
+        DateGenerator generator = new DateGenerator.Builder(RANDOM).build();
+        long millis = 1_600_000_000_000L;
+
+        Date value = generator.get(StubResultSet.returning("getTimestamp", new Timestamp(millis)), COLUMN);
+
+        assertEquals(new Date(millis), value);
+    }
+
+    @Test
+    void dateGeneratorReturnsNullForSqlNull() throws SQLException {
+        DateGenerator generator = new DateGenerator.Builder(RANDOM).build();
+
+        assertNull(generator.get(StubResultSet.returning("getTimestamp", null), COLUMN));
+    }
+
+    @Test
+    void integerArrayGeneratorReadsArray() throws SQLException {
+        IntegerArrayGenerator generator = new IntegerArrayGenerator.Builder(RANDOM).build();
+        Object[] elements = {1, 2, 3};
+
+        Integer[] value = generator.get(StubResultSet.returning("getArray", StubResultSet.array(elements)), COLUMN);
+
+        assertArrayEquals(new Integer[]{1, 2, 3}, value);
+    }
+
+    @Test
+    void integerArrayGeneratorReturnsNullForSqlNull() throws SQLException {
+        IntegerArrayGenerator generator = new IntegerArrayGenerator.Builder(RANDOM).build();
+
+        assertNull(generator.get(StubResultSet.returning("getArray", null), COLUMN));
+    }
+
+    @Test
+    void stringArrayGeneratorReadsArray() throws SQLException {
+        StringArrayGenerator generator = new StringArrayGenerator.Builder(RANDOM).build();
+        Object[] elements = {"alpha", "beta"};
+
+        String[] value = generator.get(StubResultSet.returning("getArray", StubResultSet.array(elements)), COLUMN);
+
+        assertArrayEquals(new String[]{"alpha", "beta"}, value);
+    }
+
+    @Test
+    void stringArrayGeneratorReturnsNullForSqlNull() throws SQLException {
+        StringArrayGenerator generator = new StringArrayGenerator.Builder(RANDOM).build();
+
+        assertNull(generator.get(StubResultSet.returning("getArray", null), COLUMN));
+    }
+
+    @Test
+    void jsonbGeneratorReadsString() throws SQLException {
+        JsonbGenerator generator = new JsonbGenerator.Builder(RANDOM).build();
+        String json = "{\"key\":\"value\"}";
+
+        assertEquals(json, generator.get(StubResultSet.returning("getString", json), COLUMN));
+    }
+
+    @Test
+    void jsonbGeneratorReturnsNullForSqlNull() throws SQLException {
+        JsonbGenerator generator = new JsonbGenerator.Builder(RANDOM).build();
+
+        assertNull(generator.get(StubResultSet.returning("getString", null), COLUMN));
+    }
+
+    @Test
+    void sqlStructGeneratorReadsObject() throws SQLException {
+        SqlStructGenerator generator = new SqlStructGenerator.Builder(RANDOM).build();
+        Struct struct = stubStruct();
+
+        assertSame(struct, generator.get(StubResultSet.returning("getObject", struct), COLUMN));
+    }
+
+    @Test
+    void sqlStructGeneratorReturnsNullForSqlNull() throws SQLException {
+        SqlStructGenerator generator = new SqlStructGenerator.Builder(RANDOM).build();
+
+        assertNull(generator.get(StubResultSet.returning("getObject", null), COLUMN));
+    }
+
+    private static Struct stubStruct() {
+        return (Struct) Proxy.newProxyInstance(
+                ResultSetGetterTest.class.getClassLoader(),
+                new Class<?>[]{Struct.class},
+                (proxy, method, args) -> null);
+    }
+}

--- a/src/test/java/io/bloviate/gen/StubResultSet.java
+++ b/src/test/java/io/bloviate/gen/StubResultSet.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.lang.reflect.Proxy;
+import java.sql.Array;
+import java.sql.ResultSet;
+
+/**
+ * Lightweight, dependency-free fakes for {@link ResultSet} and {@link Array} backed by
+ * {@link Proxy dynamic proxies}. Only the getter exercised by a generator's
+ * {@code get(ResultSet, int)} needs to return a meaningful value; every other method
+ * falls back to a type-appropriate default. Returning {@code null} from the configured
+ * getter simulates a SQL {@code NULL} column.
+ */
+final class StubResultSet {
+
+    private StubResultSet() {
+    }
+
+    /**
+     * Builds a {@link ResultSet} that returns {@code value} from the named single-int-argument
+     * getter (e.g. {@code "getTimestamp"}, {@code "getString"}, {@code "getArray"},
+     * {@code "getObject"}).
+     */
+    static ResultSet returning(String getterName, Object value) {
+        return (ResultSet) Proxy.newProxyInstance(
+                StubResultSet.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals(getterName)) {
+                        return value;
+                    }
+                    if (method.getName().equals("wasNull")) {
+                        return value == null;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    /**
+     * Builds a {@link java.sql.Array} whose {@link Array#getArray()} returns {@code elements}.
+     */
+    static Array array(Object[] elements) {
+        return (Array) Proxy.newProxyInstance(
+                StubResultSet.class.getClassLoader(),
+                new Class<?>[]{Array.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getArray") && (args == null || args.length == 0)) {
+                        return elements;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == void.class) {
+            return null;
+        }
+        return 0;
+    }
+}

--- a/src/test/java/io/bloviate/gen/StubResultSet.java
+++ b/src/test/java/io/bloviate/gen/StubResultSet.java
@@ -42,7 +42,7 @@ final class StubResultSet {
                 StubResultSet.class.getClassLoader(),
                 new Class<?>[]{ResultSet.class},
                 (proxy, method, args) -> {
-                    if (method.getName().equals(getterName)) {
+                    if (method.getName().equals(getterName) && isSingleIntArg(args)) {
                         return value;
                     }
                     if (method.getName().equals("wasNull")) {
@@ -67,6 +67,10 @@ final class StubResultSet {
                 });
     }
 
+    private static boolean isSingleIntArg(Object[] args) {
+        return args != null && args.length == 1 && args[0] instanceof Integer;
+    }
+
     private static Object defaultValue(Class<?> returnType) {
         if (!returnType.isPrimitive()) {
             return null;
@@ -74,9 +78,28 @@ final class StubResultSet {
         if (returnType == boolean.class) {
             return false;
         }
-        if (returnType == void.class) {
-            return null;
+        if (returnType == byte.class) {
+            return (byte) 0;
         }
-        return 0;
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0f;
+        }
+        if (returnType == double.class) {
+            return 0d;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        // void.class
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes for `io.bloviate.gen` generators.

### 1. `get(ResultSet, int)` returned null (fixes #422)

Six `DataGenerator` implementations implemented `get(ResultSet, int)` by simply `return null;`, violating the `DataGenerator` contract and silently dropping values when reading generated data back out of a `ResultSet`. Now implemented symmetrically with each generator's `generate()` / `set(...)`:

| Generator | Now reads via |
|---|---|
| `InstantGenerator` | `getTimestamp().toInstant()` |
| `DateGenerator` | `new Date(getTimestamp().getTime())` |
| `IntegerArrayGenerator` | `getArray()` → `Integer[]` |
| `StringArrayGenerator` | `getArray()` → `String[]` |
| `JsonbGenerator` | `getString()` |
| `SqlStructGenerator` | `(Struct) getObject()` |

Each returns `null` only for a SQL `NULL` column.

### 2. `JsonbGenerator` / `SqlStructGenerator` stubs

- **`JsonbGenerator.generate()`** now produces a valid, deterministic JSON object literal via Jackson (configurable field count, default 3) instead of returning `null`. This makes the CockroachDB `jsonb` path and flat-file output functional, and re-enables the previously-disabled `jsonb` column in `FlatFileTest`.
- **`SqlStructGenerator.generate()`** is left returning `null` but is now documented. A `java.sql.Struct` cannot be synthesized in memory — it requires `Connection.createStruct(typeName, attributes)`, which the supported JDBC drivers (PostgreSQL, MySQL, CockroachDB) do not implement (they throw `SQLFeatureNotSupportedException`). Returning `null` lets nullable `STRUCT` columns fill; `get()` still reads an existing `Struct`.

## Tests

- `ResultSetGetterTest` — 12 tests (round-trip + SQL `NULL` per generator), backed by a dependency-free `StubResultSet` helper that fakes `ResultSet`/`Array` via dynamic proxies (no Mockito / TestContainers needed for these unit checks).
- `JsonbGeneratorTest` — valid-JSON, field-count, and determinism checks.
- `FlatFileTest` — now exercises a `jsonb` column end-to-end.

Full `io.bloviate.gen.*Test` + `FlatFileTest` suite passes (31 tests).

Fixes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)