### PR TITLE
refactor: cache SeededRandomUtils to remove per-call allocation

### DIFF
--- a/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
+++ b/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
@@ -16,6 +16,7 @@
 
 package io.bloviate.gen;
 
+import io.bloviate.util.SeededRandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,8 +53,17 @@ public abstract class AbstractDataGenerator<T> implements DataGenerator<T> {
 
     protected final Random random;
 
+    /**
+     * A reusable {@link SeededRandomUtils} view over {@link #random}, created once per
+     * generator so subclasses don't allocate a fresh wrapper on every {@code generate()}
+     * call. Because it holds the same {@code random} reference, it observes any
+     * {@link #setSeed(long)} reseeding.
+     */
+    protected final SeededRandomUtils randomUtils;
+
     public AbstractDataGenerator(Random random) {
         this.random = random;
+        this.randomUtils = new SeededRandomUtils(random);
     }
 
     @Override

--- a/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
+++ b/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
@@ -16,7 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
@@ -42,8 +41,6 @@ public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
             if (maxDigits != null && maxDigits > maxPrecision) {
                 throw new IllegalArgumentException("max digits cannot be larger than max precision");
             }
-
-            SeededRandomUtils randomUtils = new SeededRandomUtils(random);
 
             // maxPrecision can be enormous (131089 for CRDB) and not helpful for testing therefore we significantly reduce.
             // the scale must be capped to the same bound so the integer part never ends up with a negative length.
@@ -81,7 +78,6 @@ public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
     public void set(Connection connection, PreparedStatement statement, int parameterIndex, BigDecimal value) throws SQLException {
         statement.setBigDecimal(parameterIndex, value);
     }
-
 
     @Override
     public BigDecimal get(ResultSet resultSet, int columnIndex) throws SQLException {

--- a/src/main/java/io/bloviate/gen/DoubleGenerator.java
+++ b/src/main/java/io/bloviate/gen/DoubleGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,7 +29,6 @@ public class DoubleGenerator extends AbstractDataGenerator<Double> {
 
     @Override
     public Double generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return randomUtils.nextDouble(startInclusive, endExclusive);
     }
 

--- a/src/main/java/io/bloviate/gen/FloatGenerator.java
+++ b/src/main/java/io/bloviate/gen/FloatGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,7 +29,6 @@ public class FloatGenerator extends AbstractDataGenerator<Float> {
 
     @Override
     public Float generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return randomUtils.nextFloat(startInclusive, endExclusive);
     }
 

--- a/src/main/java/io/bloviate/gen/IntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/IntegerGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,7 +29,6 @@ public class IntegerGenerator extends AbstractDataGenerator<Integer> {
 
     @Override
     public Integer generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return randomUtils.nextInt(startInclusive, endExclusive);
     }
 

--- a/src/main/java/io/bloviate/gen/JsonbGenerator.java
+++ b/src/main/java/io/bloviate/gen/JsonbGenerator.java
@@ -19,7 +19,6 @@ package io.bloviate.gen;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.bloviate.util.SeededRandomUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -42,7 +41,6 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         ObjectNode node = MAPPER.createObjectNode();
 
         for (int i = 0; i < fields; i++) {

--- a/src/main/java/io/bloviate/gen/LongGenerator.java
+++ b/src/main/java/io/bloviate/gen/LongGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -31,7 +29,6 @@ public class LongGenerator extends AbstractDataGenerator<Long> {
 
     @Override
     public Long generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return randomUtils.nextLong(startInclusive, endExclusive);
     }
 

--- a/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
+++ b/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Random;
@@ -31,7 +29,6 @@ public class SimpleStringGenerator extends AbstractDataGenerator<String> {
     @Override
     public String generate() {
         int maxSize = Math.min(size, 2000);
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return randomUtils.random(maxSize, letters, numbers);
     }
 

--- a/src/main/java/io/bloviate/gen/StringArrayGenerator.java
+++ b/src/main/java/io/bloviate/gen/StringArrayGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.*;
 import java.util.Random;
 
@@ -29,8 +27,6 @@ public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
     @Override
     public String[] generate() {
         String[] randomArray = new String[length];
-
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
 
         for (int i = 0; i < length; i++) {
             randomArray[i] = randomUtils.randomAlphabetic(elementLength);

--- a/src/main/java/io/bloviate/gen/VariableStringGenerator.java
+++ b/src/main/java/io/bloviate/gen/VariableStringGenerator.java
@@ -16,8 +16,6 @@
 
 package io.bloviate.gen;
 
-import io.bloviate.util.SeededRandomUtils;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Random;
@@ -36,7 +34,6 @@ public class VariableStringGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         int length = randomUtils.nextInt(Math.max(minLength, 1), maxLength + 1);
         return randomUtils.random(length, letters, numbers);
     }

--- a/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
@@ -18,7 +18,6 @@ package io.bloviate.gen.tpcc;
 
 import io.bloviate.gen.AbstractBuilder;
 import io.bloviate.gen.AbstractDataGenerator;
-import io.bloviate.util.SeededRandomUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,7 +34,6 @@ public class CreditGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return randomUtils.nextInt(1, 101) <= 10 ? BAD_CREDIT : GOOD_CREDIT;
     }
 

--- a/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
@@ -18,7 +18,6 @@ package io.bloviate.gen.tpcc;
 
 import io.bloviate.gen.AbstractBuilder;
 import io.bloviate.gen.AbstractDataGenerator;
-import io.bloviate.util.SeededRandomUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,7 +40,6 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         int num = TPCCUtils.nonUniformRandom(255, C_LOAD, 0, 999, randomUtils);
         return SYLLABLES[num / 100] + SYLLABLES[(num / 10) % 10] + SYLLABLES[num % 10];
     }

--- a/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
@@ -18,7 +18,6 @@ package io.bloviate.gen.tpcc;
 
 import io.bloviate.gen.AbstractBuilder;
 import io.bloviate.gen.AbstractDataGenerator;
-import io.bloviate.util.SeededRandomUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,7 +34,6 @@ public class DataColumnGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
 
         int dataLength = randomUtils.nextInt(26, 51);
         String data = randomUtils.randomAlphabetic(dataLength);

--- a/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
@@ -18,7 +18,6 @@ package io.bloviate.gen.tpcc;
 
 import io.bloviate.gen.AbstractBuilder;
 import io.bloviate.gen.AbstractDataGenerator;
-import io.bloviate.util.SeededRandomUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.sql.ResultSet;
@@ -35,7 +34,6 @@ public class ZipCodeGenerator extends AbstractDataGenerator<String> {
 
     @Override
     public String generate() {
-        SeededRandomUtils randomUtils = new SeededRandomUtils(random);
         return StringUtils.leftPad(Integer.toString(randomUtils.nextInt(0, 10000)), 4, '0') + SUFFIX;
     }
 


### PR DESCRIPTION
Addresses the generator DRY/efficiency findings (D7/L2) from the code review.

## What
Thirteen generators each constructed a fresh `new SeededRandomUtils(random)` inside `generate()`:

- `IntegerGenerator`, `LongGenerator`, `DoubleGenerator`, `FloatGenerator`, `BigDecimalGenerator`, `SimpleStringGenerator`, `VariableStringGenerator`, `StringArrayGenerator`, `JsonbGenerator`
- TPC-C: `CustomerLastNameGenerator`, `ZipCodeGenerator`, `CreditGenerator`, `DataColumnGenerator`

That was duplicated boilerplate and a needless per-row allocation in the hot fill loop. A single reusable instance now lives on `AbstractDataGenerator`, created once from the shared `Random`.

## Why it's safe
`SeededRandomUtils` is a thin stateless wrapper holding the `Random` reference, so the cached instance still observes `setSeed()` reseeding (the foreign-key reseeding contract in `TableFiller`). Seeded reproducibility is therefore unchanged — confirmed by the existing determinism tests (`JsonbGeneratorTest`, `TpccGeneratorsTest`, etc.).

No public API change.

## Testing
`./mvnw compile` clean; all 54 container-free tests pass. Container filler tests left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)