### PR TITLE
refactor: replace DatabaseSupport type switch with a JDBCType registry

### DIFF
--- a/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
+++ b/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
@@ -19,331 +19,108 @@ package io.bloviate.ext;
 import io.bloviate.db.Column;
 import io.bloviate.gen.*;
 
+import java.sql.JDBCType;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Random;
 
+/**
+ * Base {@link DatabaseSupport} that maps columns to generators through a
+ * {@link JDBCType}-keyed registry of {@link GeneratorFactory} entries.
+ *
+ * <p>The constructor seeds the registry with cross-database defaults and then invokes
+ * {@link #configure(Map)}, which database-specific subclasses override to add or replace
+ * entries (for example, to handle driver-specific type names). Types absent from the
+ * registry are unsupported and cause {@link #getDataGenerator(Column, Random)} to throw.
+ *
+ * @see GeneratorFactory
+ */
 public abstract class AbstractDatabaseSupport implements DatabaseSupport {
+
+    private final Map<JDBCType, GeneratorFactory> registry;
+
+    protected AbstractDatabaseSupport() {
+        Map<JDBCType, GeneratorFactory> defaults = new EnumMap<>(JDBCType.class);
+        registerDefaults(defaults);
+        configure(defaults);
+        this.registry = defaults;
+    }
 
     @Override
     public final DataGenerator<?> getDataGenerator(Column column, Random random) {
-        switch (column.jdbcType()) {
-            case BIT -> {
-                return buildBitGenerator(column, random);
-            }
-            case TINYINT -> {
-                return buildTinyIntGenerator(column, random);
-            }
-            case SMALLINT -> {
-                return buildSmallIntGenerator(column, random);
-            }
-            case INTEGER -> {
-                return buildIntegerGenerator(column, random);
-            }
-            case BIGINT -> {
-                return buildBigIntGenerator(column, random);
-            }
-            case FLOAT -> {
-                return buildFloatGenerator(column, random);
-            }
-            case REAL -> {
-                return buildRealGenerator(column, random);
-            }
-            case DOUBLE -> {
-                return buildDoubleGenerator(column, random);
-            }
-            case NUMERIC -> {
-                return buildNumericGenerator(column, random);
-            }
-            case DECIMAL -> {
-                return buildDecimalGenerator(column, random);
-            }
-            case CHAR -> {
-                return buildCharGenerator(column, random);
-            }
-            case VARCHAR -> {
-                return buildVarcharGenerator(column, random);
-            }
-            case LONGVARCHAR -> {
-                return buildLongVarcharGenerator(column, random);
-            }
-            case DATE -> {
-                return buildDateGenerator(column, random);
-            }
-            case TIME -> {
-                return buildTimeGenerator(column, random);
-            }
-            case TIMESTAMP -> {
-                return buildTimestampGenerator(column, random);
-            }
-            case BINARY -> {
-                return buildBinaryGenerator(column, random);
-            }
-            case VARBINARY -> {
-                return buildVarbinaryGenerator(column, random);
-            }
-            case LONGVARBINARY -> {
-                return buildLongVarbinaryGenerator(column, random);
-            }
-            case NULL -> {
-                return buildNullGenerator(column, random);
-            }
-            case OTHER -> {
-                return buildOtherGenerator(column, random);
-            }
-            case JAVA_OBJECT -> {
-                return buildJavaObjectGenerator(column, random);
-            }
-            case DISTINCT -> {
-                return buildDistinctGenerator(column, random);
-            }
-            case STRUCT -> {
-                return buildStructGenerator(column, random);
-            }
-            case ARRAY -> {
-                return buildArrayGenerator(column, random);
-            }
-            case BLOB -> {
-                return buildBlobGenerator(column, random);
-            }
-            case CLOB -> {
-                return buildClobGenerator(column, random);
-            }
-            case REF -> {
-                return buildRefGenerator(column, random);
-            }
-            case DATALINK -> {
-                return buildDataLinkGenerator(column, random);
-            }
-            case BOOLEAN -> {
-                return buildBooleanGenerator(column, random);
-            }
-            case ROWID -> {
-                return buildRowIdGenerator(column, random);
-            }
-            case NCHAR -> {
-                return buildNCharGenerator(column, random);
-            }
-            case NVARCHAR -> {
-                return buildNVarcharGenerator(column, random);
-            }
-            case LONGNVARCHAR -> {
-                return buildLongNVarcharGenerator(column, random);
-            }
-            case NCLOB -> {
-                return buildNClobGenerator(column, random);
-            }
-            case SQLXML -> {
-                return buildSqlXmlGenerator(column, random);
-            }
-            case REF_CURSOR -> {
-                return buildRefCursorGenerator(column, random);
-            }
-            case TIME_WITH_TIMEZONE -> {
-                return buildTimeWithTimezoneGenerator(column, random);
-            }
-            case TIMESTAMP_WITH_TIMEZONE -> {
-                return buildTimestampWithTimezoneGenerator(column, random);
-            }
+        GeneratorFactory factory = registry.get(column.jdbcType());
+        if (factory == null) {
+            throw new UnsupportedOperationException("JDBCType [" + column.jdbcType() + "] not supported");
         }
-
-        throw new UnsupportedOperationException("JDBCType [" + column.jdbcType() + "] not supported");
+        return factory.create(column, random);
     }
 
-    @Override
-    public DataGenerator<?> buildTinyIntGenerator(Column column, Random random) {
-        return new ShortGenerator.Builder(random).start(0).end(255).build();
+    /**
+     * Hook for subclasses to add or replace generator factories for specific JDBC types.
+     * The supplied registry already holds the cross-database defaults; subclasses with no
+     * customizations need not override this method. Implementations must not retain a
+     * reference to the map beyond the call.
+     *
+     * @param registry the mutable registry to customize, keyed by {@link JDBCType}
+     */
+    protected void configure(Map<JDBCType, GeneratorFactory> registry) {
+        // no customizations by default
     }
 
-    @Override
-    public DataGenerator<?> buildSmallIntGenerator(Column column, Random random) {
-        return new ShortGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildIntegerGenerator(Column column, Random random) {
-        return new IntegerGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildBigIntGenerator(Column column, Random random) {
-        return new LongGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildFloatGenerator(Column column, Random random) {
-        return new FloatGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildRealGenerator(Column column, Random random) {
-        return new FloatGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildDoubleGenerator(Column column, Random random) {
-        return new DoubleGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildDecimalGenerator(Column column, Random random) {
-        return new BigDecimalGenerator.Builder(random).precision(column.maxSize()).digits(column.maxDigits()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildCharGenerator(Column column, Random random) {
-        return new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildNCharGenerator(Column column, Random random) {
-        return new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildVarcharGenerator(Column column, Random random) {
-        return new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildNVarcharGenerator(Column column, Random random) {
-        return new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildLongVarcharGenerator(Column column, Random random) {
-        return new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildLongNVarcharGenerator(Column column, Random random) {
-        return new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildDateGenerator(Column column, Random random) {
-        return new SqlDateGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildTimeGenerator(Column column, Random random) {
-        return new SqlTimeGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildTimeWithTimezoneGenerator(Column column, Random random) {
-        return new SqlTimeGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildTimestampGenerator(Column column, Random random) {
-        return new SqlTimestampGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildTimestampWithTimezoneGenerator(Column column, Random random) {
-        return new SqlTimestampGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildBinaryGenerator(Column column, Random random) {
-        return new ByteGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildVarbinaryGenerator(Column column, Random random) {
-        return new ByteGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildLongVarbinaryGenerator(Column column, Random random) {
-        return new ByteGenerator.Builder(random).size(column.maxSize()).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildBlobGenerator(Column column, Random random) {
-        return new SqlBlobGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildClobGenerator(Column column, Random random) {
-        return new SqlClobGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildNClobGenerator(Column column, Random random) {
-        return new SqlClobGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildStructGenerator(Column column, Random random) {
-        return new SqlStructGenerator.Builder(random).build();
-    }
-
-    @Override
-    public DataGenerator<?> buildArrayGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
-
-    @Override
-    public DataGenerator<?> buildBitGenerator(Column column, Random random) {
-        if (1 == column.maxSize()) {
-            return new BitGenerator.Builder(random).build();
-        } else {
+    private void registerDefaults(Map<JDBCType, GeneratorFactory> map) {
+        map.put(JDBCType.BIT, (column, random) -> {
+            if (1 == column.maxSize()) {
+                return new BitGenerator.Builder(random).build();
+            }
             return new BitStringGenerator.Builder(random).size(column.maxSize()).build();
-        }
-    }
+        });
 
-    @Override
-    public DataGenerator<?> buildBooleanGenerator(Column column, Random random) {
-        return new BooleanGenerator.Builder(random).build();
-    }
+        map.put(JDBCType.TINYINT, (column, random) -> new ShortGenerator.Builder(random).start(0).end(255).build());
+        map.put(JDBCType.SMALLINT, (column, random) -> new ShortGenerator.Builder(random).build());
+        map.put(JDBCType.INTEGER, (column, random) -> new IntegerGenerator.Builder(random).build());
+        map.put(JDBCType.BIGINT, (column, random) -> new LongGenerator.Builder(random).build());
 
-    @Override
-    public DataGenerator<?> buildOtherGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        map.put(JDBCType.FLOAT, (column, random) -> new FloatGenerator.Builder(random).build());
+        map.put(JDBCType.REAL, (column, random) -> new FloatGenerator.Builder(random).build());
+        map.put(JDBCType.DOUBLE, (column, random) -> new DoubleGenerator.Builder(random).build());
 
-    @Override
-    public DataGenerator<?> buildNumericGenerator(Column column, Random random) {
-        return new BigDecimalGenerator.Builder(random).precision(column.maxSize()).digits(column.maxDigits()).build();
-    }
+        GeneratorFactory bigDecimal = (column, random) ->
+                new BigDecimalGenerator.Builder(random).precision(column.maxSize()).digits(column.maxDigits()).build();
+        map.put(JDBCType.NUMERIC, bigDecimal);
+        map.put(JDBCType.DECIMAL, bigDecimal);
 
-    @Override
-    public DataGenerator<?> buildJavaObjectGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        GeneratorFactory string = (column, random) ->
+                new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
+        map.put(JDBCType.CHAR, string);
+        map.put(JDBCType.NCHAR, string);
+        map.put(JDBCType.VARCHAR, string);
+        map.put(JDBCType.NVARCHAR, string);
+        map.put(JDBCType.LONGVARCHAR, string);
+        map.put(JDBCType.LONGNVARCHAR, string);
 
-    @Override
-    public DataGenerator<?> buildDistinctGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        map.put(JDBCType.DATE, (column, random) -> new SqlDateGenerator.Builder(random).build());
 
-    @Override
-    public DataGenerator<?> buildNullGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        GeneratorFactory time = (column, random) -> new SqlTimeGenerator.Builder(random).build();
+        map.put(JDBCType.TIME, time);
+        map.put(JDBCType.TIME_WITH_TIMEZONE, time);
 
-    @Override
-    public DataGenerator<?> buildRefGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        GeneratorFactory timestamp = (column, random) -> new SqlTimestampGenerator.Builder(random).build();
+        map.put(JDBCType.TIMESTAMP, timestamp);
+        map.put(JDBCType.TIMESTAMP_WITH_TIMEZONE, timestamp);
 
-    @Override
-    public DataGenerator<?> buildDataLinkGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        GeneratorFactory bytes = (column, random) ->
+                new ByteGenerator.Builder(random).size(column.maxSize()).build();
+        map.put(JDBCType.BINARY, bytes);
+        map.put(JDBCType.VARBINARY, bytes);
+        map.put(JDBCType.LONGVARBINARY, bytes);
 
-    @Override
-    public DataGenerator<?> buildRowIdGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        map.put(JDBCType.BLOB, (column, random) -> new SqlBlobGenerator.Builder(random).build());
 
-    @Override
-    public DataGenerator<?> buildSqlXmlGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
-    }
+        GeneratorFactory clob = (column, random) -> new SqlClobGenerator.Builder(random).build();
+        map.put(JDBCType.CLOB, clob);
+        map.put(JDBCType.NCLOB, clob);
 
-    @Override
-    public DataGenerator<?> buildRefCursorGenerator(Column column, Random random) {
-        throw new UnsupportedOperationException("generator not supported");
+        map.put(JDBCType.STRUCT, (column, random) -> new SqlStructGenerator.Builder(random).build());
+        map.put(JDBCType.BOOLEAN, (column, random) -> new BooleanGenerator.Builder(random).build());
     }
 }

--- a/src/main/java/io/bloviate/ext/CockroachDBSupport.java
+++ b/src/main/java/io/bloviate/ext/CockroachDBSupport.java
@@ -16,10 +16,10 @@
 
 package io.bloviate.ext;
 
-import io.bloviate.db.Column;
 import io.bloviate.gen.*;
 
-import java.util.Random;
+import java.sql.JDBCType;
+import java.util.Map;
 
 /**
  * CockroachDB-specific implementation of database support.
@@ -34,41 +34,36 @@ import java.util.Random;
 public class CockroachDBSupport extends AbstractDatabaseSupport {
 
     @Override
-    public DataGenerator<?> buildBitGenerator(Column column, Random random) {
-        // CockroachDB BIT and BIT(n) are bit strings, not integers/booleans, so
-        // always generate a bit string -- including the single-bit case (the
-        // generic implementation would emit an integer for BIT(1), which
-        // CockroachDB rejects).
-        return new BitStringGenerator.Builder(random).size(column.maxSize()).build();
-    }
+    protected void configure(Map<JDBCType, GeneratorFactory> registry) {
+        // CockroachDB BIT and BIT(n) are bit strings, not integers/booleans, so always
+        // generate a bit string -- including the single-bit case (the generic default
+        // would emit an integer for BIT(1), which CockroachDB rejects).
+        registry.put(JDBCType.BIT, (column, random) ->
+                new BitStringGenerator.Builder(random).size(column.maxSize()).build());
 
-    @Override
-    public DataGenerator<?> buildArrayGenerator(Column column, Random random) {
-        if ("_text".equalsIgnoreCase(column.typeName())) {
-            return new StringArrayGenerator.Builder(random).build();
-        } else if ("_int8".equalsIgnoreCase(column.typeName()) || "_int4".equalsIgnoreCase(column.typeName())) {
-            return new IntegerArrayGenerator.Builder(random).build();
-        } else {
+        // ARRAY and OTHER are dispatched on the driver-reported type name.
+        registry.put(JDBCType.ARRAY, (column, random) -> {
+            if ("_text".equalsIgnoreCase(column.typeName())) {
+                return new StringArrayGenerator.Builder(random).build();
+            } else if ("_int8".equalsIgnoreCase(column.typeName()) || "_int4".equalsIgnoreCase(column.typeName())) {
+                return new IntegerArrayGenerator.Builder(random).build();
+            }
             throw new UnsupportedOperationException("Data Type [" + column.typeName() + "] for ARRAY not supported");
-        }
-    }
+        });
 
-    @Override
-    public DataGenerator<?> buildOtherGenerator(Column column, Random random) {
-        if ("uuid".equalsIgnoreCase(column.typeName())) {
-            return new UUIDGenerator.Builder(random).build();
-        } else if ("varbit".equalsIgnoreCase(column.typeName())) {
-            return new BitStringGenerator.Builder(random).size(column.maxSize()).build();
-        } else if ("inet".equalsIgnoreCase(column.typeName())) {
-            return new InetGenerator.Builder(random).build();
-        } else if ("interval".equalsIgnoreCase(column.typeName())) {
-            return new IntervalGenerator.Builder(random).build();
-        } else if ("jsonb".equalsIgnoreCase(column.typeName())) {
-            return new JsonbGenerator.Builder(random).build();
-        } else {
+        registry.put(JDBCType.OTHER, (column, random) -> {
+            if ("uuid".equalsIgnoreCase(column.typeName())) {
+                return new UUIDGenerator.Builder(random).build();
+            } else if ("varbit".equalsIgnoreCase(column.typeName())) {
+                return new BitStringGenerator.Builder(random).size(column.maxSize()).build();
+            } else if ("inet".equalsIgnoreCase(column.typeName())) {
+                return new InetGenerator.Builder(random).build();
+            } else if ("interval".equalsIgnoreCase(column.typeName())) {
+                return new IntervalGenerator.Builder(random).build();
+            } else if ("jsonb".equalsIgnoreCase(column.typeName())) {
+                return new JsonbGenerator.Builder(random).build();
+            }
             throw new UnsupportedOperationException("Data Type [" + column.typeName() + "] for OTHER not supported");
-        }
+        });
     }
-
-
 }

--- a/src/main/java/io/bloviate/ext/DatabaseSupport.java
+++ b/src/main/java/io/bloviate/ext/DatabaseSupport.java
@@ -24,127 +24,32 @@ import java.util.Random;
 /**
  * Database-specific support interface for data generation and SQL handling.
  * 
- * <p>This interface defines the contract for database-specific implementations
- * that handle the creation of appropriate {@link DataGenerator} instances for
- * different JDBC data types. Each database may have unique type mappings,
- * constraints, and behavioral differences that require specialized handling.
- * 
- * <p>Implementations should provide database-specific logic for:
- * <ul>
- *   <li>Mapping JDBC types to appropriate data generators</li>
- *   <li>Handling database-specific data type variations</li>
- *   <li>Applying database-specific constraints and limits</li>
- *   <li>Managing database-specific SQL generation requirements</li>
- * </ul>
- * 
+ * <p>This interface defines the single contract for database-specific implementations:
+ * mapping a {@link Column} to an appropriate {@link DataGenerator}. The cross-database
+ * defaults and the per-{@link java.sql.JDBCType} registry live in
+ * {@link AbstractDatabaseSupport}; database-specific subclasses customize generation by
+ * registering or replacing factories rather than implementing this interface directly.
+ *
  * <p>Common implementations include {@link PostgresSupport}, {@link MySQLSupport},
  * {@link CockroachDBSupport}, and {@link DefaultSupport} for generic databases.
- * 
+ *
  * @author Tim Veil
  * @see DataGenerator
  * @see Column
  * @see AbstractDatabaseSupport
+ * @see GeneratorFactory
  */
 public interface DatabaseSupport {
 
     /**
-     * Creates an appropriate data generator for the given column.
-     * 
-     * <p>This is the main entry point for obtaining a data generator
-     * that matches the column's JDBC type and database-specific requirements.
-     * Implementations should delegate to the appropriate build method based
-     * on the column's {@link java.sql.JDBCType}.
-     * 
+     * Creates an appropriate data generator for the given column based on its
+     * {@link java.sql.JDBCType} (and, where relevant, its database-specific type name).
+     *
      * @param column the column metadata including type and constraints
      * @param random the random number generator for seeded data generation
      * @return a data generator appropriate for the column type
-     * @throws IllegalArgumentException if the column type is not supported
+     * @throws UnsupportedOperationException if the column type is not supported
      */
     DataGenerator<?> getDataGenerator(Column column, Random random);
-
-    /**
-     * Creates a data generator for TINYINT columns.
-     * @param column the column metadata
-     * @param random the random number generator
-     * @return a data generator for TINYINT values
-     */
-    DataGenerator<?> buildTinyIntGenerator(Column column, Random random);
-
-    DataGenerator<?> buildSmallIntGenerator(Column column, Random random);
-
-    DataGenerator<?> buildIntegerGenerator(Column column, Random random);
-
-    DataGenerator<?> buildBigIntGenerator(Column column, Random random);
-
-    DataGenerator<?> buildFloatGenerator(Column column, Random random);
-
-    DataGenerator<?> buildRealGenerator(Column column, Random random);
-
-    DataGenerator<?> buildDoubleGenerator(Column column, Random random);
-
-    DataGenerator<?> buildDecimalGenerator(Column column, Random random);
-
-    DataGenerator<?> buildCharGenerator(Column column, Random random);
-
-    DataGenerator<?> buildNCharGenerator(Column column, Random random);
-
-    DataGenerator<?> buildVarcharGenerator(Column column, Random random);
-
-    DataGenerator<?> buildNVarcharGenerator(Column column, Random random);
-
-    DataGenerator<?> buildLongVarcharGenerator(Column column, Random random);
-
-    DataGenerator<?> buildLongNVarcharGenerator(Column column, Random random);
-
-    DataGenerator<?> buildDateGenerator(Column column, Random random);
-
-    DataGenerator<?> buildTimeGenerator(Column column, Random random);
-
-    DataGenerator<?> buildTimeWithTimezoneGenerator(Column column, Random random);
-
-    DataGenerator<?> buildTimestampGenerator(Column column, Random random);
-
-    DataGenerator<?> buildTimestampWithTimezoneGenerator(Column column, Random random);
-
-    DataGenerator<?> buildBinaryGenerator(Column column, Random random);
-
-    DataGenerator<?> buildVarbinaryGenerator(Column column, Random random);
-
-    DataGenerator<?> buildLongVarbinaryGenerator(Column column, Random random);
-
-    DataGenerator<?> buildBlobGenerator(Column column, Random random);
-
-    DataGenerator<?> buildClobGenerator(Column column, Random random);
-
-    DataGenerator<?> buildNClobGenerator(Column column, Random random);
-
-    DataGenerator<?> buildStructGenerator(Column column, Random random);
-
-    DataGenerator<?> buildArrayGenerator(Column column, Random random);
-
-    DataGenerator<?> buildBitGenerator(Column column, Random random);
-
-    DataGenerator<?> buildBooleanGenerator(Column column, Random random);
-
-    DataGenerator<?> buildOtherGenerator(Column column, Random random);
-
-    DataGenerator<?> buildNumericGenerator(Column column, Random random);
-
-    DataGenerator<?> buildJavaObjectGenerator(Column column, Random random);
-
-    DataGenerator<?> buildDistinctGenerator(Column column, Random random);
-
-    DataGenerator<?> buildNullGenerator(Column column, Random random);
-
-    DataGenerator<?> buildRefGenerator(Column column, Random random);
-
-    DataGenerator<?> buildDataLinkGenerator(Column column, Random random);
-
-    DataGenerator<?> buildRowIdGenerator(Column column, Random random);
-
-    DataGenerator<?> buildSqlXmlGenerator(Column column, Random random);
-
-    DataGenerator<?> buildRefCursorGenerator(Column column, Random random);
-
 
 }

--- a/src/main/java/io/bloviate/ext/GeneratorFactory.java
+++ b/src/main/java/io/bloviate/ext/GeneratorFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import io.bloviate.db.Column;
+import io.bloviate.gen.DataGenerator;
+
+import java.util.Random;
+
+/**
+ * Builds the {@link DataGenerator} used for a column of a particular JDBC type.
+ *
+ * <p>{@link AbstractDatabaseSupport} keeps a registry of these keyed by
+ * {@link java.sql.JDBCType}; database-specific subclasses add or replace entries to
+ * customize generation (for example, to handle driver-specific type names exposed via
+ * {@link Column#typeName()}).
+ *
+ * @see AbstractDatabaseSupport
+ * @since 1.0.0
+ */
+@FunctionalInterface
+public interface GeneratorFactory {
+
+    /**
+     * Creates a generator for the given column.
+     *
+     * @param column the column metadata, including type, size, and database-specific type name
+     * @param random the seeded random source supplied by the fill engine
+     * @return the generator to use for the column
+     */
+    DataGenerator<?> create(Column column, Random random);
+}

--- a/src/test/java/io/bloviate/ext/DatabaseSupportTest.java
+++ b/src/test/java/io/bloviate/ext/DatabaseSupportTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import io.bloviate.db.Column;
+import io.bloviate.gen.*;
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DatabaseSupportTest {
+
+    private static final Random RANDOM = new Random(1);
+
+    private static Column column(JDBCType type, Integer maxSize, String typeName) {
+        return new Column("c", "t", null, null, type, maxSize, null, typeName, false, true, null, 1);
+    }
+
+    private static Object generatorFor(DatabaseSupport support, JDBCType type, Integer maxSize, String typeName) {
+        return support.getDataGenerator(column(type, maxSize, typeName), RANDOM);
+    }
+
+    @Test
+    void defaultSupportMapsCommonTypes() {
+        DatabaseSupport support = new DefaultSupport();
+
+        assertInstanceOf(IntegerGenerator.class, generatorFor(support, JDBCType.INTEGER, 10, "int4"));
+        assertInstanceOf(LongGenerator.class, generatorFor(support, JDBCType.BIGINT, 19, "int8"));
+        assertInstanceOf(SimpleStringGenerator.class, generatorFor(support, JDBCType.VARCHAR, 32, "varchar"));
+        assertInstanceOf(BooleanGenerator.class, generatorFor(support, JDBCType.BOOLEAN, null, "bool"));
+        assertInstanceOf(BigDecimalGenerator.class, generatorFor(support, JDBCType.NUMERIC, 10, "numeric"));
+    }
+
+    @Test
+    void defaultSupportDistinguishesSingleBitFromBitString() {
+        DatabaseSupport support = new DefaultSupport();
+
+        assertInstanceOf(BitGenerator.class, generatorFor(support, JDBCType.BIT, 1, "bit"));
+        assertInstanceOf(BitStringGenerator.class, generatorFor(support, JDBCType.BIT, 8, "bit"));
+    }
+
+    @Test
+    void defaultSupportThrowsForUnregisteredType() {
+        DatabaseSupport support = new DefaultSupport();
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> generatorFor(support, JDBCType.ARRAY, null, "_int4"));
+    }
+
+    @Test
+    void postgresAndMySqlBehaveLikeDefault() {
+        assertInstanceOf(IntegerGenerator.class, generatorFor(new PostgresSupport(), JDBCType.INTEGER, 10, "int4"));
+        assertInstanceOf(IntegerGenerator.class, generatorFor(new MySQLSupport(), JDBCType.INTEGER, 10, "int4"));
+    }
+
+    @Test
+    void cockroachOverridesBitToBitString() {
+        DatabaseSupport support = new CockroachDBSupport();
+
+        // CRDB treats BIT(1) as a bit string, unlike the default which would use BitGenerator
+        assertInstanceOf(BitStringGenerator.class, generatorFor(support, JDBCType.BIT, 1, "bit"));
+    }
+
+    @Test
+    void cockroachDispatchesArrayAndOtherByTypeName() {
+        DatabaseSupport support = new CockroachDBSupport();
+
+        assertInstanceOf(StringArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_text"));
+        assertInstanceOf(IntegerArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_int8"));
+        assertInstanceOf(UUIDGenerator.class, generatorFor(support, JDBCType.OTHER, null, "uuid"));
+        assertInstanceOf(InetGenerator.class, generatorFor(support, JDBCType.OTHER, null, "inet"));
+        assertInstanceOf(JsonbGenerator.class, generatorFor(support, JDBCType.OTHER, null, "jsonb"));
+    }
+
+    @Test
+    void cockroachStillProvidesDefaultsAndRejectsUnknownTypeNames() {
+        DatabaseSupport support = new CockroachDBSupport();
+
+        // inherited default still works
+        assertInstanceOf(IntegerGenerator.class, generatorFor(support, JDBCType.INTEGER, 10, "int4"));
+        // unknown ARRAY/OTHER type names are rejected
+        assertThrows(UnsupportedOperationException.class,
+                () -> generatorFor(support, JDBCType.OTHER, null, "geometry"));
+    }
+}


### PR DESCRIPTION
Implements **D1** from the code review: replace the fat `DatabaseSupport` interface (40 `build*Generator` methods) and the 120-line dispatch `switch` with a `JDBCType`-keyed registry of `GeneratorFactory` entries.

## Changes
- **`DatabaseSupport`** slimmed to its single contract, `getDataGenerator(Column, Random)`.
- **New `GeneratorFactory`** functional interface (`(Column, Random) -> DataGenerator<?>`).
- **`AbstractDatabaseSupport`** seeds an `EnumMap<JDBCType, GeneratorFactory>` with cross-database defaults, then calls a `configure(Map)` hook subclasses override. Unmapped types throw `UnsupportedOperationException` — this **removes the ~12 `UnsupportedOperationException` stub methods** entirely.
- **`CockroachDBSupport`** registers its `BIT` / `ARRAY` / `OTHER` factories via the hook instead of overriding `build*` methods. Behavior unchanged.
- **`DatabaseSupportTest`** (new) — first container-free coverage of the support layer: default dispatch, single-bit vs bit-string, Postgres/MySQL == default, CRDB overrides, and unsupported-type handling.

## ⚠️ Breaking change
`DatabaseSupport` no longer declares the `build*Generator` methods. Any external subclass that overrode them must move that logic into `configure(Map)`. All in-tree subclasses are updated. The commit body carries a `BREAKING CHANGE:` footer — but I used a plain `refactor:` **title** so this does not auto-trigger a major release; **promote it to `refactor!:` at merge if you want semantic-release to bump the major version.**

## Testing
`./mvnw compile` clean; 61 container-free tests pass (was 54, +7 new). Behavior is identical, so the existing Postgres/MySQL/CockroachDB filler tests (run in CI) are the integration check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)