### PR TITLE
feat: add product-name-based DatabaseSupport selection

### DIFF
--- a/src/main/java/io/bloviate/ext/DatabaseSupport.java
+++ b/src/main/java/io/bloviate/ext/DatabaseSupport.java
@@ -19,6 +19,9 @@ package io.bloviate.ext;
 import io.bloviate.db.Column;
 import io.bloviate.gen.DataGenerator;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Locale;
 import java.util.Random;
 
 /**
@@ -51,5 +54,54 @@ public interface DatabaseSupport {
      * @throws UnsupportedOperationException if the column type is not supported
      */
     DataGenerator<?> getDataGenerator(Column column, Random random);
+
+    /**
+     * Selects a {@link DatabaseSupport} for the given JDBC product name (as reported by
+     * {@link java.sql.DatabaseMetaData#getDatabaseProductName()}), so callers don't have
+     * to hardcode a specific implementation.
+     *
+     * <p>Matching is case-insensitive and substring-based: names containing
+     * {@code "cockroach"} map to {@link CockroachDBSupport}, {@code "mysql"} to
+     * {@link MySQLSupport}, and {@code "postgres"} to {@link PostgresSupport}. Anything
+     * else (including {@code null}) falls back to {@link DefaultSupport}.
+     *
+     * <p><strong>CockroachDB caveat:</strong> CockroachDB is typically reached through the
+     * PostgreSQL JDBC driver, which reports its product name as {@code "PostgreSQL"}. Such
+     * connections therefore resolve to {@link PostgresSupport}, not
+     * {@link CockroachDBSupport}. To use the CockroachDB-specific generators (jsonb, inet,
+     * arrays, bit strings, ...), pass {@code new CockroachDBSupport()} explicitly rather
+     * than relying on auto-selection.
+     *
+     * @param productName the database product name, may be null
+     * @return the matching support, or {@link DefaultSupport} if none matches
+     */
+    static DatabaseSupport forProduct(String productName) {
+        if (productName != null) {
+            String name = productName.toLowerCase(Locale.ROOT);
+            if (name.contains("cockroach")) {
+                return new CockroachDBSupport();
+            }
+            if (name.contains("mysql")) {
+                return new MySQLSupport();
+            }
+            if (name.contains("postgres")) {
+                return new PostgresSupport();
+            }
+        }
+        return new DefaultSupport();
+    }
+
+    /**
+     * Selects a {@link DatabaseSupport} by reading the product name from the connection's
+     * metadata. See {@link #forProduct(String)} for the matching rules and the CockroachDB
+     * caveat.
+     *
+     * @param connection an open database connection
+     * @return the matching support, or {@link DefaultSupport} if none matches
+     * @throws SQLException if the connection metadata cannot be read
+     */
+    static DatabaseSupport forConnection(Connection connection) throws SQLException {
+        return forProduct(connection.getMetaData().getDatabaseProductName());
+    }
 
 }

--- a/src/test/java/io/bloviate/ext/DatabaseSupportSelectionTest.java
+++ b/src/test/java/io/bloviate/ext/DatabaseSupportSelectionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class DatabaseSupportSelectionTest {
+
+    @Test
+    void selectsPostgresByProductName() {
+        assertInstanceOf(PostgresSupport.class, DatabaseSupport.forProduct("PostgreSQL"));
+    }
+
+    @Test
+    void selectsMySqlByProductName() {
+        assertInstanceOf(MySQLSupport.class, DatabaseSupport.forProduct("MySQL"));
+    }
+
+    @Test
+    void selectsCockroachByProductName() {
+        assertInstanceOf(CockroachDBSupport.class, DatabaseSupport.forProduct("CockroachDB CCL v23.1.0"));
+    }
+
+    @Test
+    void matchingIsCaseInsensitive() {
+        assertInstanceOf(MySQLSupport.class, DatabaseSupport.forProduct("mysql"));
+        assertInstanceOf(PostgresSupport.class, DatabaseSupport.forProduct("POSTGRESQL"));
+    }
+
+    @Test
+    void fallsBackToDefaultForUnknownOrNull() {
+        assertInstanceOf(DefaultSupport.class, DatabaseSupport.forProduct("H2"));
+        assertInstanceOf(DefaultSupport.class, DatabaseSupport.forProduct(null));
+        assertInstanceOf(DefaultSupport.class, DatabaseSupport.forProduct(""));
+    }
+
+    @Test
+    void cockroachReportedAsPostgresResolvesToPostgres() {
+        // documented caveat: CRDB via the pgjdbc driver reports "PostgreSQL", so auto-selection
+        // cannot distinguish it -- callers must pass CockroachDBSupport explicitly.
+        assertInstanceOf(PostgresSupport.class, DatabaseSupport.forProduct("PostgreSQL"));
+    }
+}


### PR DESCRIPTION
Implements **D3** from the code review: removes the foot-gun of callers hardcoding a `DatabaseSupport`.

## What
Two additive static factories on `DatabaseSupport`:
- `forProduct(String productName)` — maps a JDBC product name to a support. Case-insensitive, substring-based: `cockroach` → `CockroachDBSupport`, `mysql` → `MySQLSupport`, `postgres` → `PostgresSupport`, otherwise `DefaultSupport`.
- `forConnection(Connection)` — convenience that reads `getMetaData().getDatabaseProductName()` and delegates to `forProduct`.

Usage becomes:
```java
new DatabaseConfiguration(batchSize, rowCount, DatabaseSupport.forConnection(conn), tableConfigs)
```

## ⚠️ CockroachDB caveat (documented in Javadoc and tested)
CockroachDB is normally reached through the PostgreSQL JDBC driver, which reports its product name as `"PostgreSQL"`. Auto-selection therefore resolves such connections to `PostgresSupport`, **not** `CockroachDBSupport`. To use the CRDB-specific generators (jsonb, inet, arrays, bit strings), callers must still pass `new CockroachDBSupport()` explicitly. This is intentional and called out — there's no reliable product-name signal to distinguish them.

## Safety
Purely additive — no change to any existing code path. New `DatabaseSupportSelectionTest` covers each mapping, case-insensitivity, null/empty/unknown fallback, and the CRDB caveat.

## Testing
`./mvnw compile` clean; 67 container-free tests pass (+6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)