### PR TITLE
fix: return null from primitive getters for SQL NULL columns

### DIFF
--- a/src/main/java/io/bloviate/gen/BitGenerator.java
+++ b/src/main/java/io/bloviate/gen/BitGenerator.java
@@ -31,7 +31,8 @@ public class BitGenerator extends AbstractDataGenerator<Integer> {
 
     @Override
     public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getInt(columnIndex);
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Integer> {

--- a/src/main/java/io/bloviate/gen/BooleanGenerator.java
+++ b/src/main/java/io/bloviate/gen/BooleanGenerator.java
@@ -42,7 +42,8 @@ public class BooleanGenerator extends AbstractDataGenerator<Boolean> {
 
     @Override
     public Boolean get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getBoolean(columnIndex);
+        boolean value = resultSet.getBoolean(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     /**

--- a/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
+++ b/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
@@ -65,7 +65,8 @@ public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Intege
 
     @Override
     public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getInt(columnIndex);
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Integer> {

--- a/src/main/java/io/bloviate/gen/DoubleGenerator.java
+++ b/src/main/java/io/bloviate/gen/DoubleGenerator.java
@@ -39,7 +39,8 @@ public class DoubleGenerator extends AbstractDataGenerator<Double> {
 
     @Override
     public Double get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getDouble(columnIndex);
+        double value = resultSet.getDouble(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Double> {

--- a/src/main/java/io/bloviate/gen/FloatGenerator.java
+++ b/src/main/java/io/bloviate/gen/FloatGenerator.java
@@ -39,7 +39,8 @@ public class FloatGenerator extends AbstractDataGenerator<Float> {
 
     @Override
     public Float get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getFloat(columnIndex);
+        float value = resultSet.getFloat(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Float> {

--- a/src/main/java/io/bloviate/gen/IntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/IntegerGenerator.java
@@ -39,7 +39,8 @@ public class IntegerGenerator extends AbstractDataGenerator<Integer> {
 
     @Override
     public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getInt(columnIndex);
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Integer> {

--- a/src/main/java/io/bloviate/gen/LongGenerator.java
+++ b/src/main/java/io/bloviate/gen/LongGenerator.java
@@ -39,7 +39,8 @@ public class LongGenerator extends AbstractDataGenerator<Long> {
 
     @Override
     public Long get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getLong(columnIndex);
+        long value = resultSet.getLong(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Long> {

--- a/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -50,7 +50,8 @@ public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> {
 
     @Override
     public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getInt(columnIndex);
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Integer> {

--- a/src/main/java/io/bloviate/gen/ShortGenerator.java
+++ b/src/main/java/io/bloviate/gen/ShortGenerator.java
@@ -38,7 +38,8 @@ public class ShortGenerator extends AbstractDataGenerator<Short> {
 
     @Override
     public Short get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getShort(columnIndex);
+        short value = resultSet.getShort(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Short> {

--- a/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
@@ -41,7 +41,8 @@ public class StaticDoubleGenerator extends AbstractDataGenerator<Double> {
 
     @Override
     public Double get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getDouble(columnIndex);
+        double value = resultSet.getDouble(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Double> {

--- a/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
@@ -41,7 +41,8 @@ public class StaticFloatGenerator extends AbstractDataGenerator<Float> {
 
     @Override
     public Float get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getFloat(columnIndex);
+        float value = resultSet.getFloat(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Float> {

--- a/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
@@ -41,7 +41,8 @@ public class StaticIntegerGenerator extends AbstractDataGenerator<Integer> {
 
     @Override
     public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
-        return resultSet.getInt(columnIndex);
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
     }
 
     public static class Builder extends AbstractBuilder<Integer> {

--- a/src/test/java/io/bloviate/gen/ResultSetGetterTest.java
+++ b/src/test/java/io/bloviate/gen/ResultSetGetterTest.java
@@ -139,6 +139,90 @@ class ResultSetGetterTest {
         assertNull(generator.get(StubResultSet.returning("getObject", null), COLUMN));
     }
 
+    @Test
+    void integerGeneratorReadsValueAndNull() throws SQLException {
+        IntegerGenerator generator = new IntegerGenerator.Builder(RANDOM).build();
+        assertEquals(7, generator.get(StubResultSet.returning("getInt", 7), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getInt", null), COLUMN));
+    }
+
+    @Test
+    void longGeneratorReadsValueAndNull() throws SQLException {
+        LongGenerator generator = new LongGenerator.Builder(RANDOM).build();
+        assertEquals(7L, generator.get(StubResultSet.returning("getLong", 7L), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getLong", null), COLUMN));
+    }
+
+    @Test
+    void shortGeneratorReadsValueAndNull() throws SQLException {
+        ShortGenerator generator = new ShortGenerator.Builder(RANDOM).build();
+        assertEquals((short) 7, generator.get(StubResultSet.returning("getShort", (short) 7), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getShort", null), COLUMN));
+    }
+
+    @Test
+    void doubleGeneratorReadsValueAndNull() throws SQLException {
+        DoubleGenerator generator = new DoubleGenerator.Builder(RANDOM).build();
+        assertEquals(1.5d, generator.get(StubResultSet.returning("getDouble", 1.5d), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getDouble", null), COLUMN));
+    }
+
+    @Test
+    void floatGeneratorReadsValueAndNull() throws SQLException {
+        FloatGenerator generator = new FloatGenerator.Builder(RANDOM).build();
+        assertEquals(1.5f, generator.get(StubResultSet.returning("getFloat", 1.5f), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getFloat", null), COLUMN));
+    }
+
+    @Test
+    void booleanGeneratorReadsValueAndNull() throws SQLException {
+        BooleanGenerator generator = new BooleanGenerator.Builder(RANDOM).build();
+        assertEquals(true, generator.get(StubResultSet.returning("getBoolean", true), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getBoolean", null), COLUMN));
+    }
+
+    @Test
+    void bitGeneratorReadsValueAndNull() throws SQLException {
+        BitGenerator generator = new BitGenerator.Builder(RANDOM).build();
+        assertEquals(1, generator.get(StubResultSet.returning("getInt", 1), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getInt", null), COLUMN));
+    }
+
+    @Test
+    void staticIntegerGeneratorReadsValueAndNull() throws SQLException {
+        StaticIntegerGenerator generator = new StaticIntegerGenerator.Builder(RANDOM).value(5).build();
+        assertEquals(7, generator.get(StubResultSet.returning("getInt", 7), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getInt", null), COLUMN));
+    }
+
+    @Test
+    void staticDoubleGeneratorReadsValueAndNull() throws SQLException {
+        StaticDoubleGenerator generator = new StaticDoubleGenerator.Builder(RANDOM).value(5d).build();
+        assertEquals(1.5d, generator.get(StubResultSet.returning("getDouble", 1.5d), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getDouble", null), COLUMN));
+    }
+
+    @Test
+    void staticFloatGeneratorReadsValueAndNull() throws SQLException {
+        StaticFloatGenerator generator = new StaticFloatGenerator.Builder(RANDOM).value(5f).build();
+        assertEquals(1.5f, generator.get(StubResultSet.returning("getFloat", 1.5f), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getFloat", null), COLUMN));
+    }
+
+    @Test
+    void sequentialIntegerGeneratorReadsValueAndNull() throws SQLException {
+        SequentialIntegerGenerator generator = new SequentialIntegerGenerator.Builder(RANDOM).start(1).end(10).build();
+        assertEquals(7, generator.get(StubResultSet.returning("getInt", 7), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getInt", null), COLUMN));
+    }
+
+    @Test
+    void compositeKeyComponentGeneratorReadsValueAndNull() throws SQLException {
+        CompositeKeyComponentGenerator generator = new CompositeKeyComponentGenerator.Builder(RANDOM).cycle(10).build();
+        assertEquals(7, generator.get(StubResultSet.returning("getInt", 7), COLUMN));
+        assertNull(generator.get(StubResultSet.returning("getInt", null), COLUMN));
+    }
+
     private static Struct stubStruct() {
         return (Struct) Proxy.newProxyInstance(
                 ResultSetGetterTest.class.getClassLoader(),

--- a/src/test/java/io/bloviate/gen/StubResultSet.java
+++ b/src/test/java/io/bloviate/gen/StubResultSet.java
@@ -43,6 +43,11 @@ final class StubResultSet {
                 new Class<?>[]{ResultSet.class},
                 (proxy, method, args) -> {
                     if (method.getName().equals(getterName) && isSingleIntArg(args)) {
+                        // a SQL NULL on a primitive getter (getInt, getLong, ...) returns the
+                        // primitive default with wasNull() == true, not null
+                        if (value == null && method.getReturnType().isPrimitive()) {
+                            return defaultValue(method.getReturnType());
+                        }
                         return value;
                     }
                     if (method.getName().equals("wasNull")) {


### PR DESCRIPTION
Implements **C4**, the last item from the code review — completes the null-getter fixes started in #423.

## Problem
The object getters (`BigDecimal`, dates, arrays, jsonb, struct) were fixed earlier to map SQL `NULL` → `null`, but the **primitive-typed** generators were not. Their `get(ResultSet, int)` called the primitive JDBC accessor directly, so a `NULL` column read back as boxed `0` / `false`:

`IntegerGenerator`, `LongGenerator`, `ShortGenerator`, `DoubleGenerator`, `FloatGenerator`, `BooleanGenerator`, `BitGenerator`, `StaticIntegerGenerator`, `StaticDoubleGenerator`, `StaticFloatGenerator`, `SequentialIntegerGenerator`, `CompositeKeyComponentGenerator`.

## Fix
Guard each with `wasNull()`:
```java
int value = resultSet.getInt(columnIndex);
return resultSet.wasNull() ? null : value;
```

## Tests
- `StubResultSet` now correctly models a SQL `NULL` on a primitive getter: it returns the primitive default *and* reports `wasNull() == true` (previously it returned `null`, which would NPE on unboxing — so these paths couldn't be tested before).
- `ResultSetGetterTest` gains value + null coverage for all twelve generators (12 → 24 tests).

## Scope note
`get()` still has no caller in `src/main` (fill uses `generateAndSet`, flat files use `generateAsString`) — this is a public-API-consistency fix for library consumers, not a live fill bug. No behavior change to any generation path.

`./mvnw compile` clean; 79 container-free tests pass (+12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)