### PR TITLE
ci: fix semantic-release push to protected main via PAT

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -25,7 +25,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (not GITHUB_TOKEN) so the release commit can be pushed back to the
+          # protected main branch; persisted credentials are reused by the git push.
+          token: ${{ secrets.RELEASE_PAT }}
+          persist-credentials: true
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -44,12 +47,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       
+      - name: Verify release token
+        run: |
+          if [ -z "${{ secrets.RELEASE_PAT }}" ]; then
+            echo "::error::RELEASE_PAT secret is not set. semantic-release needs a PAT that is" \
+                 "allowed to push to the protected main branch (see the workflow comments)."
+            exit 1
+          fi
+          echo "RELEASE_PAT is configured."
+
       - name: Verify Maven settings
         run: |
           echo "Maven settings.xml content:"
           cat ~/.m2/settings.xml || echo "No settings.xml found"
           echo "GitHub actor: ${{ github.actor }}"
-          echo "Token exists: ${{ secrets.GITHUB_TOKEN != '' }}"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -134,7 +145,10 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT drives both the @semantic-release/git push to main and the
+          # @semantic-release/github release API calls.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          # Maven deploy to GitHub Packages still uses the built-in token (packages:write).
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           timveil: ${{ github.actor }}


### PR DESCRIPTION
## Problem
The **Semantic Release** workflow has failed on every push to `main` (runs for #424–#428 all red). From the logs:

```
@semantic-release/git → git push --tags https://github.com/timveil/bloviate HEAD:main
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 3 of 3 required status checks are expected.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

`@semantic-release/git` pushes the version-bump + `CHANGELOG.md` commit back to `main`, but `main` is protected with required status checks, so the push from the default `GITHUB_TOKEN` is rejected. It dies in **prepare**, before `mvn deploy` and the GitHub release — so no release is ever produced.

## Fix (PAT route — preserves commit-back)
Authenticate the release with a personal access token (`RELEASE_PAT`) instead of `GITHUB_TOKEN`:
- `actions/checkout` uses `RELEASE_PAT` (persisted), so the subsequent `git push` reuses it.
- the `semantic-release` step sets `GITHUB_TOKEN=RELEASE_PAT`, driving both the `@semantic-release/git` push to `main` and the `@semantic-release/github` release API.
- Maven deploy to GitHub Packages keeps using the built-in `GITHUB_TOKEN` (`packages:write`).
- a guard fails the job early with a clear message if `RELEASE_PAT` is unset.

All plugins are retained, so `pom.xml` + `CHANGELOG.md` commit-back is preserved. The release commit carries `[skip ci]` so it doesn't retrigger the pipeline.

## ⚠️ Required repo setup (cannot be done from the workflow)
1. **Create a PAT** owned by an account allowed to bypass `main`'s protection — classic PAT with `repo` scope, or a fine-grained PAT with **Contents: read/write** on this repo.
2. **Add it as a repo secret** named `RELEASE_PAT`.
3. **Branch protection:** ensure that identity can bypass `main`'s required status checks (add it to the ruleset bypass list, or allow admins to bypass). Without this, even a PAT push is rejected by the same `GH006`.

> Alternative considered: dropping `@semantic-release/git`/`changelog` (no commit-back, release notes only on the GitHub Release) — avoids needing a PAT entirely. This PR takes the PAT route per request to keep commit-back.

## Validation
Workflow YAML and the embedded `.releaserc.json` both parse cleanly; plugins intact (`commit-analyzer, release-notes-generator, changelog, exec, git, github`). The release itself only runs on push to `main`, so end-to-end proof comes post-merge (and after the secret is configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)