### PR TITLE
docs: refresh code-review status and correct README examples

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,127 +1,114 @@
 # Bloviate — Code Review
 
-**Date:** 2026-06-23
+**Original review:** 2026-06-23
 **Scope:** Full `src/main` (`io.bloviate.{db,ext,gen,gen.tpcc,file,util}`) and `src/test`, plus build/CI config.
 **Focus:** Modern Java best practices (target: Java 25), DRY, correctness, and test quality.
 
 ---
 
-## Overall assessment
+## Status
 
-Solid, readable library with a clean core design: metadata → dependency graph → topological fill, with the Builder pattern and immutable `record` models used consistently. Javadoc coverage is unusually thorough. Recent work (TPCC generators, column-config, null-getter fixes) is well-tested relative to the rest. CI is mature (CodeQL, commit-lint, dependabot, semantic-release).
+Most of the prioritized findings have been addressed across five PRs. Each finding below is tagged:
+✅ **done** · 🔧 **partial** · ⬜ **open / deferred**.
 
-The themes worth attention: a handful of **real correctness bugs**, significant **DRY/abstraction debt in the generator and support layers**, an **integration-test strategy that doesn't unit-test the hardest logic**, and some **stale/dead code and docs**.
+| PR | Theme |
+|----|-------|
+| #424 | C1/C2/C3 correctness fixes, dead-code + stale-doc cleanup, FK-chain & fill-ordering unit tests |
+| #425 | Cache `SeededRandomUtils` instead of per-call allocation (D7) |
+| #426 | Replace the `DatabaseSupport` type switch with a `JDBCType` registry (D1, breaking) |
+| #427 | Product-name-based `DatabaseSupport` selection (D3) |
+| #428 | Null-returning primitive `get()` getters (C4) |
 
-> **Verification note:** `DataGenerator.get(ResultSet, int)` has **no caller in `src/main`** — it is exercised only by tests. The live fill path uses `generate()` / `generateAndSet()` / `setSeed()`; the flat-file path uses `generateAsString()`. So the whole "null getters" family of issues (C4) is a public-API-contract/consistency concern, not a live production bug.
+**Still open** (intentionally deferred or lower-priority): C5, C6, C7; D2, D4, D6, D8; the modern-Java polish items; and the remaining test-infrastructure improvements. Details inline.
 
 ---
 
-## 1. Correctness bugs (highest value)
+## 1. Correctness bugs
 
-### C1 — `Table.filteredColumns()` can NPE on unboxing
-`Table.java:81` does `!column.autoIncrement()`, but `DatabaseUtils.mapColumn` (`DatabaseUtils.java:273-279`) leaves `autoIncrement` **null** when `IS_AUTOINCREMENT` is empty/unknown (JDBC allows `""`). A null there throws `NullPointerException` during insert-string construction.
-**Fix:** `Boolean.TRUE.equals(column.autoIncrement())`.
+### ✅ C1 — `Table.filteredColumns()` NPE on unboxing — *fixed in #424*
+`Table.java` unboxed a nullable `autoIncrement` Boolean. Now guarded with `Boolean.TRUE.equals(...)`.
 
-### C2 — `BigDecimalGenerator` precision/scale can throw or exceed column precision
-`BigDecimalGenerator.java:40-75`. Precision is clamped to 25 (`minMaxPrecision`) but `maxDigits` (scale) is used un-clamped:
-- For NUMERIC(30,28): `adjustedPrecision = 25 - 28 = -3`, and `randomNumeric(1, -2)` trips `SeededRandomUtils`' validation → `IllegalArgumentException` at generate time.
-- For NUMERIC(30,30): the equal-branch (`:49-53`) emits 30 fractional digits, ignoring the clamp.
-- The field-doc comments (`:31-35`) describe the two fields in swapped terms.
+### ✅ C2 — `BigDecimalGenerator` precision/scale — *fixed in #424*
+Scale was used un-capped while precision was clamped to 25, throwing on e.g. `NUMERIC(30,28)`. Scale is now capped to the reduced precision; covered by `BigDecimalGeneratorTest`.
 
-**Fix:** apply the clamp consistently to both precision and scale; clamp scale to `minMaxPrecision`.
+### ✅ C3 — `SeededRandomUtils.nextLong` precision — *fixed in #424*
+No longer routes longs through `double`; uses `RandomGenerator.nextLong(origin, bound)` directly.
 
-### C3 — `SeededRandomUtils.nextLong` loses precision
-`SeededRandomUtils.java:91` routes longs through `(long) nextDouble(...)`. With wide ranges (LongGenerator defaults to `Long.MAX_VALUE`, and all date/time generators funnel through this) the top of the range is unreachable and values are quantized to ~52 bits.
-**Fix:** use `RandomGenerator.nextLong(origin, bound)` directly.
+### ✅ C4 — primitive getters returned `0`/`false` for SQL NULL — *fixed in #428*
+All twelve primitive-typed `get(ResultSet,int)` methods now guard with `wasNull()`. `ResultSetGetterTest` covers value + null for each. Note: `get()` still has no caller in `src/main` — this was an API-consistency fix, not a live fill bug.
 
-### C4 — Nullable primitive columns read back as `0`/`false` (API inconsistency)
-The `get(ResultSet,int)` overrides in `IntegerGenerator:45`, `LongGenerator:45`, `ShortGenerator:41`, `DoubleGenerator:45`, `FloatGenerator:45`, `BooleanGenerator:45`, `BitGenerator:34`, and the `Static*`/`Sequential*`/`CompositeKeyComponentGenerator` call the primitive JDBC accessor with no `wasNull()` guard, so SQL NULL becomes boxed `0`. The recent branch fixed the *object* getters (`BigDecimal`, dates) but not these.
-**Caveat:** `get()` is never called in `src/main` (see verification note) — this is a contract/consistency issue for library consumers, not a live fill bug. Lower urgency than its branch name implies.
+### ⬜ C5 — `SqlBlobGenerator`/`SqlClobGenerator.generate()` return `null`
+Still `//todo` stubs; a non-nullable BLOB/CLOB column fails at insert with no useful diagnostic. Implement, or document the null contract as `SqlStructGenerator` does.
 
-### C5 — `SqlBlobGenerator`/`SqlClobGenerator.generate()` return `null`
-`SqlBlobGenerator.java:23`, `SqlClobGenerator.java:23` are `//todo` stubs. A non-nullable BLOB/CLOB column fails at insert with no useful diagnostic.
-**Fix:** implement, or at minimum document the null contract as was done for `SqlStructGenerator`.
+### ⬜ C6 — range off-by-ones in composite generators
+`IntervalGenerator` (month never 12) and `InetGenerator` (octets `1..255`, never 0) remain. Cosmetic for dummy data.
 
-### C6 — Range off-by-ones in composite generators
-`IntervalGenerator.java:63-68` (month `end(12)` → never 12), `InetGenerator.java:57` (octets `1..255`, never 0). Cosmetic for dummy data but inconsistent with documented intent.
-
-### C7 — Silent `IOException` swallowing in `FlatFileGenerator`
-`FlatFileGenerator.java:115-117`, `:125-127`: write failures are logged and the method returns normally, so callers believe the file was written.
-**Fix:** rethrow as unchecked.
+### ⬜ C7 — silent `IOException` swallowing in `FlatFileGenerator`
+`generate()` / `yaml()` still log and return normally on write failure; callers can't tell the file wasn't written. Rethrow as unchecked.
 
 ---
 
 ## 2. Design / DRY / abstraction
 
-### D1 — `DatabaseSupport` is a 40-method fat interface that no one implements directly
-All impls extend `AbstractDatabaseSupport`, ~12 `build*` methods are `throw UnsupportedOperationException` stubs, and `getDataGenerator` is `final` over a 120-line switch (`AbstractDatabaseSupport.java:27-149`).
-**Suggestion:** a `Map<JDBCType, BiFunction<Column,Random,DataGenerator<?>>>` registry that subclasses mutate would delete the interface, the switch, and most stubs — and make adding a type a one-liner.
+### ✅ D1 — `DatabaseSupport` fat interface + giant switch — *fixed in #426*
+Interface slimmed to `getDataGenerator(...)`; `AbstractDatabaseSupport` dispatches via an `EnumMap<JDBCType, GeneratorFactory>` seeded with defaults + a `configure(Map)` hook. The ~12 `UnsupportedOperationException` stubs are gone. **Breaking change** to the extension API. `DatabaseSupportTest` added.
 
-### D2 — `PostgresSupport`, `MySQLSupport`, `DefaultSupport` are empty marker subclasses
-Only CockroachDB overrides anything. Javadoc claims "PostgreSQL-specific generation" that doesn't exist.
-**Suggestion:** add the real behavior or collapse them and document the truth.
+### ⬜ D2 — empty marker subclasses (`PostgresSupport`, `MySQLSupport`, `DefaultSupport`)
+Still behaviorally identical to `DefaultSupport`. They now at least serve as auto-selection targets (D3), but carry no DB-specific generation. Add real behavior or document the no-op honestly.
 
-### D3 — No product→support selection
-Callers hardcode `new PostgresSupport()`. A factory keyed on `DatabaseMetaData.getDatabaseProductName()` (or `ServiceLoader`) is the natural library affordance and removes a foot-gun (wrong support for a DB).
+### ✅ D3 — no product→support selection — *fixed in #427*
+Added `DatabaseSupport.forProduct(String)` and `forConnection(Connection)`. CockroachDB-reports-as-PostgreSQL caveat is documented and tested.
 
-### D4 — CockroachDB type dispatch is fragile string-matching
-`CockroachDBSupport.java:47-70` matches driver catalog names (`"_int8"`, `"varbit"`, `"jsonb"`…) with hardcoded literals and `UnsupportedOperationException` fall-through.
-**Suggestion:** extract to a constant name→generator map; current form is brittle across driver versions.
+### ⬜ D4 — CockroachDB type dispatch is fragile string-matching
+Still matches driver catalog names (`"_int8"`, `"varbit"`, `"jsonb"`, …) with hardcoded literals (now inside registry entries rather than overridden methods). Consider a shared constant name→generator map.
 
-### D5 — Generator boilerplate is the single biggest DRY target
-~20 generators repeat the identical `Builder(Random)` / `build()` / private `X(Builder)` / `set→setX` / `get→getX` quartet, and `start/end` range fields recur across Integer/Long/Double/Float/Short and all date/time builders.
-**Suggestion:** a shared `RangeBuilder` base and a functional JDBC-accessor pair would remove hundreds of lines.
+### 🔧 D5 — generator builder boilerplate
+The per-call `SeededRandomUtils` allocation was removed (D7, #425), but the repeated `Builder`/`build()`/private-ctor and `start`/`end` range scaffolding remains. A generic `RangeBuilder` would change the public `start`/`end` signatures (type-divergent across int/long/double/float), so it was deferred as an API-affecting change.
 
-### D6 — `FileDefinition` hierarchy is redundant
-`CsvFile`/`TabDelimitedFile`/`PipeDelimitedFile` each only call `super(FileType.X)`; `FileType` already carries the delimiter. Delimiters are defined twice (dead `FileType.getDelimiter()` at `FileType.java:61`, and `FlatFileGenerator.getCsvFormat()`), risking drift.
-**Suggestion:** collapse to just the `FileType` enum on the builder.
+### ⬜ D6 — `FileDefinition` hierarchy is redundant
+`CsvFile`/`TabDelimitedFile`/`PipeDelimitedFile` could collapse into `FileType`. Deferred — removing the public classes is API-breaking.
 
-### D7 — Per-row allocation in hot loops
-`new SeededRandomUtils(random)` is allocated on every `generate()` call across ~10 generators (e.g. `IntegerGenerator:34`). It's a stateless wrapper.
-**Fix:** hoist to a field or make the helpers static.
+### ✅ D7 — per-row `SeededRandomUtils` allocation — *fixed in #425*
+A single reusable instance now lives on `AbstractDataGenerator`; 13 generators updated.
 
-### D8 — `SeededRandomUtils` forbids negative ranges
-`startInclusive >= 0` (lines 52/63/74/85). Signed columns never get negative values, and `IntegerGenerator.start(-5)` throws at runtime. The four range methods also duplicate the same two `Validate` lines.
-**Suggestion:** document or lift the constraint; extract a `validateRange` helper.
+### ⬜ D8 — `SeededRandomUtils` forbids negative ranges; duplicated validation
+`startInclusive >= 0` still blocks negative values, and the four range methods still repeat the same two `Validate` checks. Extract a `validateRange` helper and decide whether to allow negatives.
 
 ---
 
 ## 3. Modern Java (target: 25)
 
-- `AbstractDatabaseSupport.getDataGenerator` is an arrow-`switch` *statement* with no `default`, relying on fall-through to a throw (`:28-148`). Convert to a `switch` *expression* so the compiler enforces totality.
-- Prefer `Path.of(...)` over `Paths.get(...)` (`FlatFileGenerator.java:102,124`).
-- `DataGenerator` has a closed implementor set and a Jackson `@JsonTypeInfo` — a `sealed` hierarchy would be a natural fit and document the closure.
-- `AbstractDataGenerator.logger` (`:51`) is a non-static package-private field, mostly unused — make `private static final` per class or drop it.
-- TINYINT → `[0,255]` (`AbstractDatabaseSupport.java:152`) assumes unsigned; standard JDBC TINYINT is signed `byte`. Risks out-of-range inserts on signed columns.
+- ✅ The `AbstractDatabaseSupport` dispatch `switch` is gone (replaced by the registry, #426).
+- ⬜ Prefer `Path.of(...)` over `Paths.get(...)` in `FlatFileGenerator`.
+- ⬜ `DataGenerator` could be a `sealed` hierarchy (closed implementor set + Jackson `@JsonTypeInfo`).
+- ⬜ `AbstractDataGenerator.logger` is a non-static package-private field, mostly unused.
+- ⬜ TINYINT → `[0,255]` assumes unsigned; standard JDBC TINYINT is signed `byte`.
 
 ---
 
 ## 4. Tests
 
-- **Biggest gap:** the hardest logic — graph/topological ordering (`DatabaseFiller`), FK seed-map reseeding (`TableFiller.java:144`), recursive `getAssociatedPrimaryKeyColumn` — has **no container-free unit tests**; it's exercised only as a side effect of full fills, and even then FK *value equality* (the point of reseeding) is never asserted (`PostgresFillerTest.java:110-111` relies on "the fill would have thrown"). Add fast unit tests with stub `Database`/`Table` graphs (cycles, multi-level chains, self-references).
-- **A fresh container per `@Test`** (`Base*Test` call `new XContainer().start()` in `fillDatabase`; CRDB runs 8) — slow and a flakiness vector. Use `@Container` singleton / `withReuse(true)`.
-- **`FlatFileTest` asserts nothing** (`:28-69`) — pure smoke test, writes into `target/` instead of `@TempDir`, has a commented-out 1M-row line. Give it real content/row/delimiter assertions.
-- Heavy duplication across the three `Base*Test` and three `*FillerTest` classes — prime `@ParameterizedTest` over `(support, initScript)` candidates.
-- Several generator tests use unseeded `new Random()` for what are meant to be regression assertions — fix a seed for reproducibility.
-- `StubResultSet` is sound (proxy-based, `wasNull()` correctly wired). `ResultSetGetterTest.stubStruct()` duplicates the idiom and could reuse it.
+- ✅ Core logic now has fast, container-free coverage: `AssociatedPrimaryKeyColumnTest` (FK-chain resolution) and `DatabaseFillerOrderTest` (topological fill order) in #424; `DatabaseSupportTest` (registry dispatch) in #426; `DatabaseSupportSelectionTest` (product selection) in #427; expanded `ResultSetGetterTest` in #428. To make ordering testable, `buildReversedDependencyGraph()`/`fillOrder()` were extracted from `DatabaseFiller.fill()`.
+- ⬜ Each DB integration test still spins up a fresh container per `@Test` — adopt a shared/`@Container` singleton (or `withReuse(true)`).
+- ⬜ `FlatFileTest` still asserts nothing and writes into `target/` — give it real assertions over a `@TempDir`.
+- ⬜ Heavy duplication across the three `Base*Test` and `*FillerTest` classes — candidates for `@ParameterizedTest`.
+- ⬜ Some generator tests use unseeded `new Random()` for regression assertions — fix a seed.
 
 ---
 
 ## 5. Dead code & docs
 
-- **`ScriptRunner` (308 lines) is entirely unused** — copy-pasted MyBatis code, uses platform-default charset (`:52-53`), and has a known delimiter-mis-parse bug. Delete it.
-- `DatabaseUtils.getExportedKeys` (`:174`) — private, never called.
-- `FlatFileGenerator.compress` field + builder method (`:86,138,170,184`) — never consulted; implement or remove.
-- `FileType.getDelimiter()` (`:61`), `StringArrayGenerator.Builder.elementGenerator` (`:75`) — dead.
-- **Version docs are stale:** `pom.xml` targets `release 25`, but `README.md` badge and `CLAUDE.md` both say "Java 16."
-- `getColumn` throws raw `RuntimeException` (`DatabaseUtils.java:226`) — use a typed exception.
+- ✅ Deleted `ScriptRunner` (and dropped the unused `commons-compress` dep), the no-op `FlatFileGenerator.compress` feature, the unused `FileType` delimiter, `DatabaseUtils.getExportedKeys`, and the dead `StringArrayGenerator.Builder.elementGenerator` field. *(#424)*
+- ✅ `getColumn` now throws `IllegalStateException` instead of a raw `RuntimeException`. *(#424)*
+- ✅ README badge/requirements and `CLAUDE.md` updated from Java 16 to Java 25. *(#424)*
+- ⬜ `SqlBlobGenerator`/`SqlClobGenerator` stubs remain undocumented (see C5).
 
 ---
 
-## Prioritized recommendations
+## Remaining recommendations (in rough priority order)
 
-1. **Fix the real bugs:** C1 (NPE), C2 (BigDecimal), C3 (nextLong) — can corrupt or abort fills. *(small, high value)*
-2. **Delete dead code & fix docs:** ScriptRunner, `getExportedKeys`, `compress`, the Java-version mismatch. *(trivial, removes noise)*
-3. **Unit-test the core graph/FK/recursion logic** independent of containers; assert FK value equality. *(biggest coverage win)*
-4. **Refactor the support layer** to a `JDBCType→factory` registry (D1) and add product-name-based selection (D3). *(removes the most structural debt)*
-5. **Collapse generator builder boilerplate** (D5) and the `FileDefinition` hierarchy (D6) once tests protect you.
+1. **C7** — stop swallowing write failures in `FlatFileGenerator` (small, real correctness).
+2. **C5** — implement or clearly document the BLOB/CLOB stubs.
+3. **Test infra** — shared container lifecycle + real `FlatFileTest` assertions + `@ParameterizedTest` de-duplication.
+4. **D6 / D5** — `FileDefinition`→`FileType` collapse and a numeric `RangeBuilder` (both API-breaking; bundle into a deliberate breaking release).
+5. **Polish** — D2 (honest support subclasses), D4 (CRDB name→generator map), D8 (negative ranges + validation helper), and the modern-Java items.

--- a/README.md
+++ b/README.md
@@ -114,22 +114,36 @@ new FlatFileGenerator.Builder("output/users")
 | CockroachDB | `CockroachDBSupport` | ✅ Full Support |
 | Generic JDBC | `DefaultSupport` | ⚠️ Basic Support |
 
+You can let Bloviate pick the support implementation from the connection's
+metadata instead of hardcoding it:
+
+```java
+DatabaseSupport support = DatabaseSupport.forConnection(connection);
+```
+
+> **Note:** CockroachDB is reached through the PostgreSQL JDBC driver and
+> reports its product name as `PostgreSQL`, so auto-selection resolves it to
+> `PostgresSupport`. To use the CockroachDB-specific generators, pass
+> `new CockroachDBSupport()` explicitly.
+
 ## 📖 Usage Examples
 
 ### Advanced Database Configuration
 
 ```java
 import io.bloviate.db.*;
+import java.util.Set;
 
-// Custom table configuration
-Map<String, TableConfiguration> tableConfigs = new HashMap<>();
-tableConfigs.put("users", new TableConfiguration(50)); // 50 records for users table
+// Per-table overrides (each TableConfiguration names its table; 50 rows for "users")
+Set<TableConfiguration> tableConfigs = Set.of(
+    new TableConfiguration("users", 50)
+);
 
 DatabaseConfiguration config = new DatabaseConfiguration(
     10,                    // batch size
     100,                   // default records per table
     new PostgresSupport(), // database support
-    tableConfigs          // table-specific overrides
+    tableConfigs           // table-specific overrides
 );
 
 DatabaseFiller filler = new DatabaseFiller.Builder(connection, config)
@@ -164,13 +178,14 @@ new FlatFileGenerator.Builder("data/output")
 Bloviate includes generators for all common database types:
 
 ```java
-// Numeric generators
-new IntegerGenerator.Builder(random).min(1).max(1000).build()
-new DoubleGenerator.Builder(random).min(0.0).max(100.0).build()
-new BigDecimalGenerator.Builder(random).precision(10).scale(2).build()
+// Numeric generators (ranges are [start, end))
+new IntegerGenerator.Builder(random).start(1).end(1000).build()
+new DoubleGenerator.Builder(random).start(0.0).end(100.0).build()
+new BigDecimalGenerator.Builder(random).precision(10).digits(2).build()
 
 // String generators
-new SimpleStringGenerator.Builder(random).minLength(5).maxLength(50).build()
+new SimpleStringGenerator.Builder(random).size(20).build()
+new VariableStringGenerator.Builder(random).minLength(5).maxLength(50).build()
 new UUIDGenerator.Builder(random).build()
 
 // Date/Time generators
@@ -197,7 +212,6 @@ new InetGenerator.Builder(random).build()
 
 - **Output Format**: CSV, TSV, or pipe-delimited
 - **Row Count**: Number of rows to generate
-- **Compression**: Optional file compression
 - **Custom Column Definitions**: Full control over data generation
 
 ## 🛠️ Development


### PR DESCRIPTION
Two documentation updates.

## CODE_REVIEW.md
Refreshed to track what actually landed. Each finding is now tagged ✅ done / 🔧 partial / ⬜ open, with a summary table of the follow-up PRs (#424–#428) and an updated remaining-recommendations list.

## README.md
Fixed code examples that referenced APIs that don't exist (would not compile):
- `IntegerGenerator`/`DoubleGenerator` `.min().max()` → `.start().end()`
- `BigDecimalGenerator` `.scale()` → `.digits()`
- `SimpleStringGenerator` `.minLength().maxLength()` → `.size()`, plus a `VariableStringGenerator` example for variable-length strings
- Advanced-config example: `Map<String, TableConfiguration>` + `new TableConfiguration(50)` → `Set<TableConfiguration>` with `new TableConfiguration("users", 50)` (matches the actual `DatabaseConfiguration` / `TableConfiguration` signatures)
- Removed the "Compression" file option (that feature was deleted in #424)
- Documented the new `DatabaseSupport.forConnection(...)` auto-selection (from #427), including the CockroachDB-reports-as-PostgreSQL caveat

(The Java 16→25 badge/requirement was already corrected in #424.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)