### PR TITLE
ci: fix Maven deploy auth in semantic-release (403 on GitHub Packages)

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -50,8 +50,12 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
           server-id: github
-          server-username: timveil
-          server-password: GITHUB_TOKEN
+          # settings.xml references ${env.MAVEN_USERNAME}/${env.MAVEN_TOKEN}. Keep
+          # these distinct from GITHUB_TOKEN: the Run semantic-release step overrides
+          # GITHUB_TOKEN with RELEASE_PAT (Contents-only, no packages:write), so the
+          # Maven deploy must auth via the built-in token through MAVEN_TOKEN instead.
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_TOKEN
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -153,10 +157,10 @@ jobs:
           # PAT drives both the @semantic-release/git push to main and the
           # @semantic-release/github release API calls.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-          # Maven deploy to GitHub Packages still uses the built-in token (packages:write).
+          # Maven deploy to GitHub Packages uses the built-in token (packages:write).
+          # settings.xml reads these via ${env.MAVEN_USERNAME}/${env.MAVEN_TOKEN}.
           MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          timveil: ${{ github.actor }}
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release
         
       - name: Log release info


### PR DESCRIPTION
## Context

Follow-up to #434. With `RELEASE_PAT` in place, the Semantic Release run now gets all the way through checkout, version bump (`2.0.0`), build, jar/sources/javadoc — then fails at the very last step:

```
[ERROR] maven-deploy-plugin:deploy: Failed to deploy artifacts:
Could not transfer artifact io.bloviate:bloviate-core:pom:2.0.0
to github (https://maven.pkg.github.com/timveil/bloviate):
status code: 403, reason phrase: Forbidden (403)
```

## Root cause

`actions/setup-java` had `server-password: GITHUB_TOKEN`, so the generated `settings.xml` reads the deploy password from `${env.GITHUB_TOKEN}`. But the **Run semantic-release** step overrides `GITHUB_TOKEN` with `RELEASE_PAT` (needed so `@semantic-release/git` can push to protected `main`). `RELEASE_PAT` is a fine-grained, Contents-only token with **no `packages:write`** → 403 on the Maven deploy. The `MAVEN_USERNAME`/`MAVEN_PASSWORD` vars meant to handle this were dead — `settings.xml` never referenced them.

## Fix

Wire the deploy to the **built-in** `GITHUB_TOKEN` (which has `packages: write`) through dedicated `MAVEN_USERNAME`/`MAVEN_TOKEN` env vars — exactly matching the proven `publish-on-release.yml`. Clean credential separation:

- `@semantic-release/git` push + GitHub release API → `RELEASE_PAT` (via `GITHUB_TOKEN`)
- `mvn clean deploy` → built-in token (via `MAVEN_TOKEN`)

## Note

The next release computes to **v2.0.0** — there's a `BREAKING CHANGE` commit (`DatabaseSupport` no longer declares the `build*Generator` methods) among the 143 commits since v1.0.3. Once this merges, the release should run clean end-to-end and cut v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)