### PR TITLE
ci: bump checkout/setup-java/setup-node/cache to node24-runtime majors

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '25'
         distribution: 'temurin'

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           cache: 'maven'

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Configure Maven settings
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "RELEASE_PAT is configured."
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # PAT (not GITHUB_TOKEN) so the release commit can be pushed back to the
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: true
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -58,7 +58,7 @@ jobs:
           server-password: MAVEN_TOKEN
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -72,7 +72,7 @@ jobs:
           echo "GitHub actor: ${{ github.actor }}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           


### PR DESCRIPTION
## Why

Every workflow run logged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, actions/setup-java@v4, actions/setup-node@v4

These `@v4` actions bundle the deprecated **node20 action runtime**. The runner already force-runs them on node24 (so nothing was broken), but the warning persists until they're bumped. This is independent of the `setup-node` `node-version: '24'` input — that only sets the Node that runs semantic-release, not the runtime of the action wrappers themselves.

## Change

Bump to the node24-runtime majors across all six workflows:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-java | v4 | v5 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v6 |

Our usage of each is basic (checkout token/fetch-depth, setup-java distribution/server-id, setup-node node-version, cache path/key), so no config changes are needed. The required PR checks (`maven`, `commitlint`, `codeql`) exercise checkout/setup-java/setup-node directly, validating the bumps.

Not touched: `github/codeql-action@v3` and `dependabot/fetch-metadata@v2` — different actions, current majors, not part of the node20 warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)