### PR TITLE
feat(tpcc): close data-generation fidelity gaps 1 and 3 vs the spec

### DIFF
--- a/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
+++ b/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates a {@link BigDecimal} drawn uniformly from the half-open range
+ * {@code [startInclusive, endExclusive)} and rounded (HALF_UP) to a fixed
+ * {@code scale}. Useful for columns that require values within a specific
+ * numeric range and decimal scale rather than merely within the column's
+ * declared width (e.g. a tax rate constrained to {@code [0.0000, 0.2000]}).
+ */
+public class ScaledBigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
+
+    private final double startInclusive;
+    private final double endExclusive;
+    private final int scale;
+
+    @Override
+    public BigDecimal generate() {
+        double value = randomUtils.nextDouble(startInclusive, endExclusive);
+        return BigDecimal.valueOf(value).setScale(scale, RoundingMode.HALF_UP);
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, BigDecimal value) throws SQLException {
+        statement.setBigDecimal(parameterIndex, value);
+    }
+
+    @Override
+    public BigDecimal get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getBigDecimal(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<BigDecimal> {
+
+        private double startInclusive = 0;
+        private double endExclusive = 1;
+        private int scale = 2;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder start(double start) {
+            this.startInclusive = start;
+            return this;
+        }
+
+        public Builder end(double end) {
+            this.endExclusive = end;
+            return this;
+        }
+
+        public Builder scale(int scale) {
+            this.scale = scale;
+            return this;
+        }
+
+        @Override
+        public ScaledBigDecimalGenerator build() {
+            return new ScaledBigDecimalGenerator(this);
+        }
+    }
+
+    private ScaledBigDecimalGenerator(Builder builder) {
+        super(builder.random);
+        this.startInclusive = builder.startInclusive;
+        this.endExclusive = builder.endExclusive;
+        this.scale = builder.scale;
+    }
+}

--- a/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
+++ b/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Always generates the same configured {@link BigDecimal} value. The random source is ignored.
+ */
+public class StaticBigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
+
+    private final BigDecimal value;
+
+    @Override
+    public BigDecimal generate() {
+        return value;
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, BigDecimal value) throws SQLException {
+        statement.setBigDecimal(parameterIndex, value);
+    }
+
+    @Override
+    public BigDecimal get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getBigDecimal(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<BigDecimal> {
+
+        private BigDecimal value = BigDecimal.ZERO;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder value(BigDecimal value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder value(String value) {
+            this.value = new BigDecimal(value);
+            return this;
+        }
+
+        @Override
+        public StaticBigDecimalGenerator build() {
+            return new StaticBigDecimalGenerator(this);
+        }
+    }
+
+    private StaticBigDecimalGenerator(Builder builder) {
+        super(builder.random);
+        this.value = builder.value;
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -20,8 +20,13 @@ import io.bloviate.db.ColumnConfiguration;
 import io.bloviate.db.ColumnGeneratorFactory;
 import io.bloviate.db.TableConfiguration;
 import io.bloviate.gen.CompositeKeyComponentGenerator;
+import io.bloviate.gen.IntegerGenerator;
+import io.bloviate.gen.ScaledBigDecimalGenerator;
+import io.bloviate.gen.StaticBigDecimalGenerator;
+import io.bloviate.gen.StaticFloatGenerator;
 import io.bloviate.gen.StaticIntegerGenerator;
 import io.bloviate.gen.StaticStringGenerator;
+import io.bloviate.gen.VariableStringGenerator;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -35,12 +40,23 @@ import java.util.Set;
  * cartesian product using {@link CompositeKeyComponentGenerator}, so each table
  * receives exactly its cartesian cardinality of rows with unique keys and valid
  * references. Realistic values (last names, zip codes, credit, i_data/s_data) use
- * the TPC-C generators in this package; remaining columns fall back to the
- * database's auto-detected generators.
+ * the TPC-C generators in this package; the remaining non-key columns are
+ * configured with bounded generators matching the value ranges and seed values
+ * from the TPC-C specification (clause 4.3.3.1).
  *
- * <p>Simplifications relative to a strict benchmark load: orders-per-district
- * equals customers-per-district (one order per customer), {@code new_order}
- * mirrors every order, and each order has a fixed number of lines.
+ * <p>Two parts of the spec are still simplified relative to a strict benchmark
+ * load:
+ * <ul>
+ *   <li>orders-per-district equals customers-per-district (one order per
+ *       customer) and {@code o_c_id} is the identity rather than a per-district
+ *       permutation of customer ids;</li>
+ *   <li>each order has a fixed number of lines ({@code o_ol_cnt} is constant)
+ *       rather than a random {@code [5, 15]}, and {@code o_carrier_id} is always
+ *       populated rather than NULL for the most recent (undelivered) orders.</li>
+ * </ul>
+ * In line with the spec, however, {@code new_order} holds only the most recent
+ * {@code newOrdersPerDistrict} orders per district (the highest {@code o_id}s)
+ * rather than mirroring every order.
  */
 public final class TPCCConfiguration {
 
@@ -48,6 +64,7 @@ public final class TPCCConfiguration {
     public static final int DEFAULT_DISTRICTS_PER_WAREHOUSE = 10;
     public static final int DEFAULT_CUSTOMERS_PER_DISTRICT = 3_000;
     public static final int DEFAULT_LINES_PER_ORDER = 10;
+    public static final int DEFAULT_NEW_ORDERS_PER_DISTRICT = 900;
 
     private TPCCConfiguration() {
     }
@@ -64,6 +81,8 @@ public final class TPCCConfiguration {
 
     /**
      * Builds a TPC-C configuration with explicit cardinalities (useful for tests).
+     * The number of {@code new_order} rows per district defaults to
+     * {@link #DEFAULT_NEW_ORDERS_PER_DISTRICT}, clamped to the orders-per-district.
      *
      * @param warehouses           number of warehouses (W)
      * @param items                number of items (I)
@@ -73,6 +92,24 @@ public final class TPCCConfiguration {
      * @return the set of table configurations
      */
     public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int linesPerOrder) {
+        return build(warehouses, items, districtsPerWarehouse, customersPerDistrict, linesPerOrder,
+                Math.min(customersPerDistrict, DEFAULT_NEW_ORDERS_PER_DISTRICT));
+    }
+
+    /**
+     * Builds a TPC-C configuration with explicit cardinalities, including the
+     * number of {@code new_order} rows per district.
+     *
+     * @param warehouses             number of warehouses (W)
+     * @param items                  number of items (I)
+     * @param districtsPerWarehouse  districts per warehouse (D)
+     * @param customersPerDistrict   customers per district (C); also used as orders per district
+     * @param linesPerOrder          order lines per order (L)
+     * @param newOrdersPerDistrict   most-recent orders per district mirrored into {@code new_order};
+     *                               clamped to {@code [0, customersPerDistrict]}
+     * @return the set of table configurations
+     */
+    public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int linesPerOrder, int newOrdersPerDistrict) {
 
         final int w = warehouses;
         final int i = items;
@@ -80,32 +117,45 @@ public final class TPCCConfiguration {
         final int c = customersPerDistrict;
         final int o = customersPerDistrict; // one order per customer
         final int l = linesPerOrder;
+        final int no = Math.max(0, Math.min(newOrdersPerDistrict, o)); // new_order is a subset of orders
 
         final long stockRows = (long) w * i;
         final long districtRows = (long) w * d;
         final long customerRows = (long) w * d * c;
         final long orderRows = (long) w * d * o;
         final long orderLineRows = (long) w * d * o * l;
+        final long newOrderRows = (long) w * d * no;
 
         Set<TableConfiguration> tables = new HashSet<>();
 
         tables.add(new TableConfiguration("warehouse", w, set(
                 key("w_id", 1, 1, w),
-                col("w_zip", zip()))));
+                col("w_zip", zip()),
+                col("w_tax", taxRate()),
+                col("w_ytd", staticDecimal("300000.00")))));
 
         tables.add(new TableConfiguration("item", i, set(
                 key("i_id", 1, 1, i),
-                col("i_data", data()))));
+                col("i_data", data()),
+                col("i_im_id", intRange(1, 10_000)),
+                col("i_price", scaledDecimal(1.0, 100.0, 2)))));
 
         tables.add(new TableConfiguration("stock", stockRows, set(
                 key("s_w_id", 1, i, w),
                 key("s_i_id", 1, 1, i),
-                col("s_data", data()))));
+                col("s_data", data()),
+                col("s_quantity", intRange(10, 100)),
+                col("s_ytd", staticDecimal("0.00")),
+                col("s_order_cnt", staticInt(0)),
+                col("s_remote_cnt", staticInt(0)))));
 
         tables.add(new TableConfiguration("district", districtRows, set(
                 key("d_w_id", 1, d, w),
                 key("d_id", 1, 1, d),
-                col("d_zip", zip()))));
+                col("d_zip", zip()),
+                col("d_tax", taxRate()),
+                col("d_ytd", staticDecimal("30000.00")),
+                col("d_next_o_id", staticInt(o + 1)))));
 
         tables.add(new TableConfiguration("customer", customerRows, set(
                 key("c_w_id", 1, (long) d * c, w),
@@ -114,27 +164,38 @@ public final class TPCCConfiguration {
                 col("c_zip", zip()),
                 col("c_last", lastName()),
                 col("c_credit", credit()),
-                col("c_middle", staticString("OE")))));
+                col("c_middle", staticString("OE")),
+                col("c_discount", scaledDecimal(0.0, 0.5, 4)),
+                col("c_credit_lim", staticDecimal("50000.00")),
+                col("c_balance", staticDecimal("-10.00")),
+                col("c_ytd_payment", staticFloat(10.0f)),
+                col("c_payment_cnt", staticInt(1)),
+                col("c_delivery_cnt", staticInt(0)),
+                col("c_phone", numericString(16)),
+                col("c_data", variableString(300, 500)))));
 
         tables.add(new TableConfiguration("history", customerRows, set(
                 key("h_c_w_id", 1, (long) d * c, w),
                 key("h_c_d_id", 1, c, d),
                 key("h_c_id", 1, 1, c),
                 key("h_w_id", 1, (long) d * c, w),
-                key("h_d_id", 1, c, d))));
+                key("h_d_id", 1, c, d),
+                col("h_amount", staticDecimal("10.00")),
+                col("h_data", variableString(12, 24)))));
 
         tables.add(new TableConfiguration("open_order", orderRows, set(
                 key("o_w_id", 1, (long) d * o, w),
                 key("o_d_id", 1, o, d),
                 key("o_id", 1, 1, o),
                 key("o_c_id", 1, 1, c),
+                col("o_carrier_id", intRange(1, 10)),
                 col("o_ol_cnt", staticInt(l)),
                 col("o_all_local", staticInt(1)))));
 
-        tables.add(new TableConfiguration("new_order", orderRows, set(
-                key("no_w_id", 1, (long) d * o, w),
-                key("no_d_id", 1, o, d),
-                key("no_o_id", 1, 1, o))));
+        tables.add(new TableConfiguration("new_order", newOrderRows, set(
+                key("no_w_id", 1, (long) d * no, w),
+                key("no_d_id", 1, no, d),
+                key("no_o_id", o - no + 1, 1, no))));
 
         tables.add(new TableConfiguration("order_line", orderLineRows, set(
                 key("ol_w_id", 1, (long) d * o * l, w),
@@ -142,7 +203,9 @@ public final class TPCCConfiguration {
                 key("ol_o_id", 1, l, o),
                 key("ol_number", 1, 1, l),
                 key("ol_supply_w_id", 1, (long) d * o * l, w),
-                key("ol_i_id", 1, 1, i))));
+                key("ol_i_id", 1, 1, i),
+                col("ol_quantity", staticInt(5)),
+                col("ol_amount", scaledDecimal(0.01, 9999.99, 2)))));
 
         return tables;
     }
@@ -181,6 +244,43 @@ public final class TPCCConfiguration {
 
     private static ColumnGeneratorFactory staticInt(int value) {
         return random -> new StaticIntegerGenerator.Builder(random).value(value).build();
+    }
+
+    private static ColumnGeneratorFactory staticFloat(float value) {
+        return random -> new StaticFloatGenerator.Builder(random).value(value).build();
+    }
+
+    private static ColumnGeneratorFactory staticDecimal(String value) {
+        return random -> new StaticBigDecimalGenerator.Builder(random).value(value).build();
+    }
+
+    /**
+     * A random decimal drawn uniformly from {@code [start, end)} rounded to {@code scale} places.
+     */
+    private static ColumnGeneratorFactory scaledDecimal(double start, double end, int scale) {
+        return random -> new ScaledBigDecimalGenerator.Builder(random).start(start).end(end).scale(scale).build();
+    }
+
+    /**
+     * Tax rate per the spec: a decimal in {@code [0.0000, 0.2000]} with scale 4.
+     */
+    private static ColumnGeneratorFactory taxRate() {
+        return scaledDecimal(0.0, 0.2, 4);
+    }
+
+    /**
+     * A random integer in the inclusive range {@code [startInclusive, endInclusive]}.
+     */
+    private static ColumnGeneratorFactory intRange(int startInclusive, int endInclusive) {
+        return random -> new IntegerGenerator.Builder(random).start(startInclusive).end(endInclusive + 1).build();
+    }
+
+    private static ColumnGeneratorFactory variableString(int minLength, int maxLength) {
+        return random -> new VariableStringGenerator.Builder(random).minLength(minLength).maxLength(maxLength).letters(true).numbers(true).build();
+    }
+
+    private static ColumnGeneratorFactory numericString(int length) {
+        return random -> new VariableStringGenerator.Builder(random).minLength(length).maxLength(length).letters(false).numbers(true).build();
     }
 
     private static Set<ColumnConfiguration> set(ColumnConfiguration... configurations) {

--- a/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -63,4 +63,45 @@ public class BaseDatabaseTestCase {
             assertEquals(expected, resultSet.getLong(1), query);
         }
     }
+
+    /**
+     * Asserts that a TPC-C dataset produced by {@code TPCCConfiguration} matches the spec's
+     * value ranges and seed values (issue #421, gaps 1 and 3). The SQL is portable across
+     * PostgreSQL, MySQL and CockroachDB.
+     *
+     * @param connection      an open connection to the filled database
+     * @param customers       customers (and orders) per district
+     * @param linesPerOrder   order lines per order
+     * @param newOrders       most-recent orders per district mirrored into {@code new_order}
+     */
+    protected static void assertTpccColumnFidelity(Connection connection, int customers, int linesPerOrder, int newOrders) throws SQLException {
+        // realistic value generators were applied (unchanged from the original TPC-C support)
+        assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
+        assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
+        assertCount(connection, "select count(*) from customer where c_middle <> 'OE'", 0);
+        assertCount(connection, "select count(*) from open_order where o_ol_cnt <> " + linesPerOrder, 0);
+
+        // gap 1: new_order holds only the most-recent orders per district (highest o_id values)
+        assertCount(connection, "select count(*) from new_order where no_o_id < " + (customers - newOrders + 1), 0);
+
+        // gap 3: spec value ranges for non-key columns
+        assertCount(connection, "select count(*) from warehouse where w_tax < 0 or w_tax > 0.2", 0);
+        assertCount(connection, "select count(*) from district where d_tax < 0 or d_tax > 0.2", 0);
+        assertCount(connection, "select count(*) from customer where c_discount < 0 or c_discount > 0.5", 0);
+        assertCount(connection, "select count(*) from item where i_price < 1 or i_price > 100", 0);
+        assertCount(connection, "select count(*) from stock where s_quantity < 10 or s_quantity > 100", 0);
+        assertCount(connection, "select count(*) from open_order where o_carrier_id < 1 or o_carrier_id > 10", 0);
+        assertCount(connection, "select count(*) from order_line where ol_amount < 0 or ol_amount > 9999.99", 0);
+
+        // gap 3: spec seed values
+        assertCount(connection, "select count(*) from warehouse where w_ytd <> 300000.00", 0);
+        assertCount(connection, "select count(*) from district where d_ytd <> 30000.00", 0);
+        assertCount(connection, "select count(*) from district where d_next_o_id <> " + (customers + 1), 0);
+        assertCount(connection, "select count(*) from stock where s_ytd <> 0 or s_order_cnt <> 0 or s_remote_cnt <> 0", 0);
+        assertCount(connection, "select count(*) from customer where c_credit_lim <> 50000.00", 0);
+        assertCount(connection, "select count(*) from customer where c_balance <> -10.00", 0);
+        assertCount(connection, "select count(*) from customer where c_payment_cnt <> 1 or c_delivery_cnt <> 0", 0);
+        assertCount(connection, "select count(*) from history where h_amount <> 10.00", 0);
+        assertCount(connection, "select count(*) from order_line where ol_quantity <> 5", 0);
+    }
 }

--- a/src/test/java/io/bloviate/db/CockroachDBFillerTest.java
+++ b/src/test/java/io/bloviate/db/CockroachDBFillerTest.java
@@ -59,9 +59,10 @@ class CockroachDBFillerTest extends BaseCockroachTest {
         int d = 2;
         int c = 3;
         int l = 2;
+        int newOrders = 2;
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(
-                128, 10, new CockroachDBSupport(), TPCCConfiguration.build(w, i, d, c, l));
+                128, 10, new CockroachDBSupport(), TPCCConfiguration.build(w, i, d, c, l, newOrders));
 
         fillDatabase("create_tpcc.cockroachdb.sql", configuration, connection -> {
             assertRowCount(connection, "warehouse", w);
@@ -71,11 +72,10 @@ class CockroachDBFillerTest extends BaseCockroachTest {
             assertRowCount(connection, "customer", (long) w * d * c);
             assertRowCount(connection, "history", (long) w * d * c);
             assertRowCount(connection, "open_order", (long) w * d * c);
-            assertRowCount(connection, "new_order", (long) w * d * c);
+            assertRowCount(connection, "new_order", (long) w * d * newOrders);
             assertRowCount(connection, "order_line", (long) w * d * c * l);
 
-            assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
-            assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
+            assertTpccColumnFidelity(connection, c, l, newOrders);
         });
     }
 

--- a/src/test/java/io/bloviate/db/MySqlFillerTest.java
+++ b/src/test/java/io/bloviate/db/MySqlFillerTest.java
@@ -58,9 +58,10 @@ class MySqlFillerTest extends BaseMySqlTest {
         int d = 2;
         int c = 3;
         int l = 2;
+        int newOrders = 2;
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(
-                128, 10, new MySQLSupport(), TPCCConfiguration.build(w, i, d, c, l));
+                128, 10, new MySQLSupport(), TPCCConfiguration.build(w, i, d, c, l, newOrders));
 
         fillDatabase("create_tpcc.mysql.sql", configuration, connection -> {
             assertRowCount(connection, "warehouse", w);
@@ -70,11 +71,10 @@ class MySqlFillerTest extends BaseMySqlTest {
             assertRowCount(connection, "customer", (long) w * d * c);
             assertRowCount(connection, "history", (long) w * d * c);
             assertRowCount(connection, "open_order", (long) w * d * c);
-            assertRowCount(connection, "new_order", (long) w * d * c);
+            assertRowCount(connection, "new_order", (long) w * d * newOrders);
             assertRowCount(connection, "order_line", (long) w * d * c * l);
 
-            assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
-            assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
+            assertTpccColumnFidelity(connection, c, l, newOrders);
         });
     }
 }

--- a/src/test/java/io/bloviate/db/PostgresFillerTest.java
+++ b/src/test/java/io/bloviate/db/PostgresFillerTest.java
@@ -97,14 +97,15 @@ class PostgresFillerTest extends BasePostgresTest {
     @Test
     void fillTPCCWithColumnConfigs() throws SQLException {
 
-        int w = 2;   // warehouses
-        int i = 10;  // items
-        int d = 2;   // districts per warehouse
-        int c = 3;   // customers (and orders) per district
-        int l = 2;   // lines per order
+        int w = 2;          // warehouses
+        int i = 10;         // items
+        int d = 2;          // districts per warehouse
+        int c = 3;          // customers (and orders) per district
+        int l = 2;          // lines per order
+        int newOrders = 2;  // most-recent orders per district mirrored into new_order
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(
-                128, 10, new PostgresSupport(), TPCCConfiguration.build(w, i, d, c, l));
+                128, 10, new PostgresSupport(), TPCCConfiguration.build(w, i, d, c, l, newOrders));
 
         fillDatabase("create_tpcc.postgres.sql", configuration, connection -> {
             // cardinalities of the dense cartesian-product fill; if any composite key
@@ -116,14 +117,10 @@ class PostgresFillerTest extends BasePostgresTest {
             assertRowCount(connection, "customer", (long) w * d * c);
             assertRowCount(connection, "history", (long) w * d * c);
             assertRowCount(connection, "open_order", (long) w * d * c);
-            assertRowCount(connection, "new_order", (long) w * d * c);
+            assertRowCount(connection, "new_order", (long) w * d * newOrders);
             assertRowCount(connection, "order_line", (long) w * d * c * l);
 
-            // realistic value generators were applied
-            assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
-            assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
-            assertCount(connection, "select count(*) from customer where c_middle <> 'OE'", 0);
-            assertCount(connection, "select count(*) from open_order where o_ol_cnt <> " + l, 0);
+            assertTpccColumnFidelity(connection, c, l, newOrders);
         });
     }
 }

--- a/src/test/java/io/bloviate/gen/ScaledBigDecimalGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/ScaledBigDecimalGeneratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScaledBigDecimalGeneratorTest {
+
+    @Test
+    void staysWithinRangeAndScale() {
+        ScaledBigDecimalGenerator generator = new ScaledBigDecimalGenerator.Builder(new Random(42))
+                .start(0.0).end(0.2).scale(4).build();
+
+        BigDecimal low = new BigDecimal("0.0000");
+        BigDecimal high = new BigDecimal("0.2000");
+
+        for (int i = 0; i < 5000; i++) {
+            BigDecimal value = generator.generate();
+            assertEquals(4, value.scale(), "unexpected scale: " + value);
+            assertTrue(value.compareTo(low) >= 0 && value.compareTo(high) <= 0, "out of range: " + value);
+        }
+    }
+
+    @Test
+    void honoursScaleTwoWithinMonetaryRange() {
+        ScaledBigDecimalGenerator generator = new ScaledBigDecimalGenerator.Builder(new Random(7))
+                .start(0.01).end(9999.99).scale(2).build();
+
+        BigDecimal high = new BigDecimal("9999.99");
+
+        for (int i = 0; i < 5000; i++) {
+            BigDecimal value = generator.generate();
+            assertEquals(2, value.scale(), "unexpected scale: " + value);
+            assertTrue(value.compareTo(BigDecimal.ZERO) > 0 && value.compareTo(high) <= 0, "out of range: " + value);
+        }
+    }
+
+    @Test
+    void isDeterministicForAFixedSeed() {
+        ScaledBigDecimalGenerator first = new ScaledBigDecimalGenerator.Builder(new Random(99)).start(1.0).end(100.0).scale(2).build();
+        ScaledBigDecimalGenerator second = new ScaledBigDecimalGenerator.Builder(new Random(99)).start(1.0).end(100.0).scale(2).build();
+        assertEquals(first.generate(), second.generate());
+    }
+}

--- a/src/test/java/io/bloviate/gen/StaticGeneratorsTest.java
+++ b/src/test/java/io/bloviate/gen/StaticGeneratorsTest.java
@@ -18,6 +18,7 @@ package io.bloviate.gen;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,5 +51,20 @@ class StaticGeneratorsTest {
         StaticStringGenerator generator = new StaticStringGenerator.Builder(new Random()).value("CONSTANT").build();
         assertEquals("CONSTANT", generator.generate());
         assertEquals("CONSTANT", generator.generate());
+    }
+
+    @Test
+    void staticBigDecimalAlwaysReturnsConfiguredValue() {
+        StaticBigDecimalGenerator generator = new StaticBigDecimalGenerator.Builder(new Random()).value(new BigDecimal("300000.00")).build();
+        assertEquals(new BigDecimal("300000.00"), generator.generate());
+        assertEquals(new BigDecimal("300000.00"), generator.generate());
+    }
+
+    @Test
+    void staticBigDecimalAcceptsStringValueAndPreservesScale() {
+        StaticBigDecimalGenerator generator = new StaticBigDecimalGenerator.Builder(new Random()).value("-10.00").build();
+        BigDecimal value = generator.generate();
+        assertEquals(new BigDecimal("-10.00"), value);
+        assertEquals(2, value.scale());
     }
 }

--- a/src/test/java/io/bloviate/gen/tpcc/TPCCConfigurationTest.java
+++ b/src/test/java/io/bloviate/gen/tpcc/TPCCConfigurationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen.tpcc;
+
+import io.bloviate.db.ColumnConfiguration;
+import io.bloviate.db.TableConfiguration;
+import io.bloviate.gen.DataGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TPCCConfigurationTest {
+
+    private static final int W = 2;
+    private static final int I = 50;
+    private static final int D = 3;
+    private static final int C = 10;
+    private static final int L = 5;
+    private static final int NEW_ORDERS = 4;
+
+    private static TableConfiguration table(Set<TableConfiguration> tables, String name) {
+        return tables.stream().filter(t -> t.tableName().equals(name)).findFirst().orElseThrow();
+    }
+
+    private static DataGenerator<?> generator(TableConfiguration table, String column) {
+        ColumnConfiguration config = table.columnConfiguration(column);
+        assertNotNull(config, "expected an override for column " + column);
+        return config.generatorFactory().create(new Random(1));
+    }
+
+    @Test
+    void newOrderIsASubsetOfOrders() {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L, NEW_ORDERS);
+
+        long expectedOrders = (long) W * D * C;
+        long expectedNewOrders = (long) W * D * NEW_ORDERS;
+
+        assertEquals(expectedOrders, table(tables, "open_order").rowCount());
+        assertEquals(expectedNewOrders, table(tables, "new_order").rowCount());
+
+        // no_o_id must reference only the most-recent orders: [C - NEW_ORDERS + 1, C]
+        DataGenerator<?> noOId = generator(table(tables, "new_order"), "no_o_id");
+        int min = C - NEW_ORDERS + 1;
+        for (long i = 0; i < expectedNewOrders; i++) {
+            int value = (Integer) noOId.generate();
+            assertTrue(value >= min && value <= C, "no_o_id out of subset range: " + value);
+        }
+    }
+
+    @Test
+    void newOrdersPerDistrictDefaultsToClampedSpecValue() {
+        // small order count clamps the 900-default down to the available orders (full mirror)
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L);
+        assertEquals((long) W * D * C, table(tables, "new_order").rowCount());
+    }
+
+    @Test
+    void taxRatesStayWithinSpecRange() {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L, NEW_ORDERS);
+        DataGenerator<?> wTax = generator(table(tables, "warehouse"), "w_tax");
+        BigDecimal max = new BigDecimal("0.2000");
+        for (int i = 0; i < 1000; i++) {
+            BigDecimal value = (BigDecimal) wTax.generate();
+            assertEquals(4, value.scale());
+            assertTrue(value.compareTo(BigDecimal.ZERO) >= 0 && value.compareTo(max) <= 0, "w_tax out of range: " + value);
+        }
+    }
+
+    @Test
+    void seedValuesMatchSpec() {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L, NEW_ORDERS);
+        assertEquals(new BigDecimal("300000.00"), generator(table(tables, "warehouse"), "w_ytd").generate());
+        assertEquals(new BigDecimal("30000.00"), generator(table(tables, "district"), "d_ytd").generate());
+        assertEquals(new BigDecimal("50000.00"), generator(table(tables, "customer"), "c_credit_lim").generate());
+        assertEquals(new BigDecimal("-10.00"), generator(table(tables, "customer"), "c_balance").generate());
+        assertEquals(5, ((Integer) generator(table(tables, "order_line"), "ol_quantity").generate()).intValue());
+        // d_next_o_id is orders-per-district + 1
+        assertEquals(C + 1, ((Integer) generator(table(tables, "district"), "d_next_o_id").generate()).intValue());
+    }
+}


### PR DESCRIPTION
Closes gaps **1** and **3** of #421. Gaps 2 and 4 remain open (tracked in the issue) and stay documented as simplifications in the `TPCCConfiguration` javadoc.

## Gap 1 — `new_order` is a subset of orders
Per the spec, `new_order` holds only the most-recent orders per district (the highest `o_id`s), not a full mirror.

- `TPCCConfiguration` gains an explicit `newOrdersPerDistrict` (default `900`, clamped to orders-per-district; the smaller test cardinalities clamp down automatically).
- `no_o_id` is generated over the top range `[o - newOrders + 1, o]`, so the FK to `open_order` remains valid as a true subset.
- `new_order` row count is now `W * D * newOrders`.

## Gap 3 — spec value ranges for non-key columns
Non-key columns are configured with bounded generators matching spec clause 4.3.3.1:

- Ranges: `w_tax`/`d_tax` ∈ [0, 0.2], `c_discount` ∈ [0, 0.5], `i_price` ∈ [1, 100], `s_quantity` ∈ [10, 100], `o_carrier_id` ∈ [1, 10], `ol_amount` ∈ [0.01, 9999.99].
- Seeds: `w_ytd=300000.00`, `d_ytd=30000.00`, `d_next_o_id=O+1`, `s_ytd/s_order_cnt/s_remote_cnt=0`, `c_credit_lim=50000.00`, `c_balance=-10.00`, `c_ytd_payment=10.00`, `c_payment_cnt=1`, `c_delivery_cnt=0`, `h_amount=10.00`, `ol_quantity=5`.
- `c_data` (300–500 chars) and `c_phone` (16 numeric digits) get appropriate variable-string generators.

## New reusable generators
- `StaticBigDecimalGenerator` — a fixed `BigDecimal` (mirrors the existing `Static*` family).
- `ScaledBigDecimalGenerator` — a uniform decimal in `[start, end)` rounded to a fixed scale.

## Testing
- New unit tests: `ScaledBigDecimalGeneratorTest`, `StaticBigDecimalGenerator` cases in `StaticGeneratorsTest`, and `TPCCConfigurationTest` (subset count + id range, range/seed wiring).
- The Postgres/MySQL/CockroachDB filler tests now assert the `new_order` subset and the spec ranges/seeds against live databases via a shared `assertTpccColumnFidelity` helper.
- `./mvnw verify` — **103 tests, 0 failures** across all three databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)