### PR TITLE
feat(tpcc): variable order-line count per order (gap 2), as reusable generators

### DIFF
--- a/src/main/java/io/bloviate/gen/ChildCardinality.java
+++ b/src/main/java/io/bloviate/gen/ChildCardinality.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+/**
+ * Deterministic mapping from a parent row's global (row-major) index to the number
+ * of child rows it owns, drawn from the inclusive range {@code [minChildren, maxChildren]}.
+ *
+ * <p>This models <em>variable parent-child cardinality</em> — a child table whose
+ * per-parent row count differs from row to row (e.g. TPC-C orders with a random number
+ * of order lines, or TPC-H orders with a random number of line items). It is the shared
+ * source of truth that lets a parent table and its child table agree on counts even though
+ * they are filled independently: a "number of children" column on the parent (see
+ * {@link ChildCountGenerator}) returns {@link #count(long) count(k)} for the k-th parent,
+ * and the child's key generators (see {@link ChildKeyComponentGenerator}) emit exactly that
+ * many rows for parent k. Because {@link #count(long)} is a pure function of the parent index
+ * (a splitmix64 hash, no random state), every consumer computes identical values.
+ *
+ * @see ChildCountGenerator
+ * @see ChildKeyComponentGenerator
+ */
+public final class ChildCardinality {
+
+    private final int minChildren;
+    private final int maxChildren;
+    private final long seed;
+
+    /**
+     * @param minChildren minimum children per parent (inclusive), {@code >= 0}
+     * @param maxChildren maximum children per parent (inclusive), {@code >= minChildren}
+     * @param seed        salt mixed into the hash, so different datasets can vary independently
+     */
+    public ChildCardinality(int minChildren, int maxChildren, long seed) {
+        if (minChildren < 0) {
+            throw new IllegalArgumentException("minChildren must be non-negative: " + minChildren);
+        }
+        if (maxChildren < minChildren) {
+            throw new IllegalArgumentException("maxChildren (" + maxChildren + ") must be >= minChildren (" + minChildren + ")");
+        }
+        this.minChildren = minChildren;
+        this.maxChildren = maxChildren;
+        this.seed = seed;
+    }
+
+    /**
+     * Returns the deterministic child count for the parent at the given global index.
+     *
+     * @param parentIndex the 0-based, row-major parent index
+     * @return a value in {@code [minChildren, maxChildren]}
+     */
+    public int count(long parentIndex) {
+        int range = maxChildren - minChildren + 1;
+        if (range == 1) {
+            return minChildren;
+        }
+        return minChildren + (int) Math.floorMod(mix(parentIndex + seed), range);
+    }
+
+    /**
+     * Returns the total number of child rows across the first {@code parentCount} parents,
+     * i.e. {@code sum(count(k))} for {@code k} in {@code [0, parentCount)}.
+     *
+     * <p>When the count is fixed ({@code minChildren == maxChildren}) this is closed-form
+     * and O(1). Otherwise it is a single O(parentCount) pass with no intermediate storage,
+     * so memory stays constant even for very large datasets.
+     *
+     * @param parentCount the number of parents
+     * @return the total child-row count
+     */
+    public long total(long parentCount) {
+        if (minChildren == maxChildren) {
+            return parentCount * minChildren;
+        }
+        long sum = 0;
+        for (long k = 0; k < parentCount; k++) {
+            sum += count(k);
+        }
+        return sum;
+    }
+
+    public int minChildren() {
+        return minChildren;
+    }
+
+    public int maxChildren() {
+        return maxChildren;
+    }
+
+    // splitmix64 finalizer — a well-distributed, deterministic mix of a 64-bit input
+    private static long mix(long value) {
+        long z = value + 0x9E3779B97F4A7C15L;
+        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
+        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
+        return z ^ (z >>> 31);
+    }
+}

--- a/src/main/java/io/bloviate/gen/ChildCountGenerator.java
+++ b/src/main/java/io/bloviate/gen/ChildCountGenerator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Emits a parent table's "number of children" column under variable parent-child
+ * cardinality: for the k-th row (0-based) it returns
+ * {@link ChildCardinality#count(long) cardinality.count(k)} (for example TPC-C's
+ * {@code o_ol_cnt}). Sharing the same {@link ChildCardinality} instance with the child
+ * table's {@link ChildKeyComponentGenerator}s guarantees that each parent's declared
+ * child count equals the number of child rows generated for it.
+ *
+ * <p>The produced values do not depend on the random source; counter state is held by
+ * the generator instance and advances on every {@link #generate()}.
+ */
+public class ChildCountGenerator extends AbstractDataGenerator<Integer> {
+
+    private final ChildCardinality cardinality;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    @Override
+    public Integer generate() {
+        return cardinality.count(counter.getAndIncrement());
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private ChildCardinality cardinality;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder cardinality(ChildCardinality cardinality) {
+            this.cardinality = cardinality;
+            return this;
+        }
+
+        @Override
+        public ChildCountGenerator build() {
+            return new ChildCountGenerator(this);
+        }
+    }
+
+    private ChildCountGenerator(Builder builder) {
+        super(builder.random);
+        if (builder.cardinality == null) {
+            throw new IllegalStateException("cardinality is required");
+        }
+        this.cardinality = builder.cardinality;
+    }
+}

--- a/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
+++ b/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Emits one component of a child table's composite key when each parent has a
+ * <em>variable</em> number of children (see {@link ChildCardinality}), which the
+ * fixed-cardinality {@link CompositeKeyComponentGenerator} cannot express.
+ *
+ * <p>The child key is {@code (parent-key-components..., sequence)}: every child row
+ * repeats its parent's key and adds a 1-based sequence number within the parent. A
+ * generator instance emits a single one of those components, in one of two modes:
+ * <ul>
+ *   <li><b>parent component</b> — the value of one dimension of the parent's key.
+ *       Computed from the parent's global index with the same
+ *       {@code start + ((parentIndex / repeat) % cycle)} formula used by the parent's own
+ *       {@link CompositeKeyComponentGenerator}, so the values line up exactly.</li>
+ *   <li><b>sequence</b> — the child's position within its parent, as
+ *       {@code start + positionWithinParent} (so {@code start = 1} yields {@code 1, 2, 3, ...}).</li>
+ * </ul>
+ *
+ * <p>Each instance walks the parents incrementally with a private cursor
+ * {@code (parentIndex, childrenRemaining, position)}, advancing by one child on every
+ * {@link #generate()} and re-reading the next parent's child count from the shared
+ * {@link ChildCardinality} when the current parent is exhausted. Because the cardinality is
+ * deterministic and each key column is generated exactly once per row, the separate
+ * generators for the different key components advance in lockstep and produce a consistent
+ * child-key tuple per row, with no shared mutable state. Parents with a zero child count are
+ * skipped.
+ *
+ * <p>The produced values do not depend on the random source.
+ */
+public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> {
+
+    private final ChildCardinality cardinality;
+    private final boolean sequence;
+    private final int start;
+    private final long repeat;
+    private final int cycle;
+
+    // private walk cursor; generation for a single table is sequential, but guard anyway
+    private long parentIndex = -1;
+    private int childrenRemaining = 0;
+    private int position = 0;
+
+    @Override
+    public synchronized Integer generate() {
+        if (childrenRemaining == 0) {
+            do {
+                parentIndex++;
+                childrenRemaining = cardinality.count(parentIndex);
+            } while (childrenRemaining == 0);
+            position = 0;
+        }
+        int currentPosition = position; // 0-based position within the current parent
+        childrenRemaining--;
+        position++;
+
+        if (sequence) {
+            return start + currentPosition;
+        }
+        return start + (int) ((parentIndex / repeat) % cycle);
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private ChildCardinality cardinality;
+        private boolean sequence = false;
+        private int start = 1;
+        private long repeat = 1;
+        private int cycle = 1;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder cardinality(ChildCardinality cardinality) {
+            this.cardinality = cardinality;
+            return this;
+        }
+
+        /**
+         * Emit the child's 1-based sequence number within its parent (using {@code start}
+         * as the base). Mutually exclusive with {@link #repeat(long)}/{@link #cycle(int)}.
+         */
+        public Builder sequence() {
+            this.sequence = true;
+            return this;
+        }
+
+        public Builder start(int start) {
+            this.start = start;
+            return this;
+        }
+
+        /**
+         * For a parent-component generator, the number of consecutive parents that share this
+         * dimension's value — i.e. the product of the sizes of all parent dimensions nested
+         * inside this one (mirrors {@link CompositeKeyComponentGenerator}).
+         */
+        public Builder repeat(long repeat) {
+            this.repeat = repeat;
+            return this;
+        }
+
+        /**
+         * For a parent-component generator, the size of this parent dimension.
+         */
+        public Builder cycle(int cycle) {
+            this.cycle = cycle;
+            return this;
+        }
+
+        @Override
+        public ChildKeyComponentGenerator build() {
+            return new ChildKeyComponentGenerator(this);
+        }
+    }
+
+    private ChildKeyComponentGenerator(Builder builder) {
+        super(builder.random);
+        if (builder.cardinality == null) {
+            throw new IllegalStateException("cardinality is required");
+        }
+        this.cardinality = builder.cardinality;
+        this.sequence = builder.sequence;
+        this.start = builder.start;
+        this.repeat = builder.repeat;
+        this.cycle = builder.cycle;
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -19,6 +19,9 @@ package io.bloviate.gen.tpcc;
 import io.bloviate.db.ColumnConfiguration;
 import io.bloviate.db.ColumnGeneratorFactory;
 import io.bloviate.db.TableConfiguration;
+import io.bloviate.gen.ChildCardinality;
+import io.bloviate.gen.ChildCountGenerator;
+import io.bloviate.gen.ChildKeyComponentGenerator;
 import io.bloviate.gen.CompositeKeyComponentGenerator;
 import io.bloviate.gen.IntegerGenerator;
 import io.bloviate.gen.ScaledBigDecimalGenerator;
@@ -44,27 +47,35 @@ import java.util.Set;
  * configured with bounded generators matching the value ranges and seed values
  * from the TPC-C specification (clause 4.3.3.1).
  *
+ * <p>In line with the spec, each order has a random {@code o_ol_cnt} number of
+ * order lines in {@code [minLinesPerOrder, maxLinesPerOrder]} (default
+ * {@code [5, 15]}) and {@code order_line} holds exactly that many rows per order
+ * (see {@link io.bloviate.gen.ChildCardinality}); and {@code new_order} holds only the most
+ * recent {@code newOrdersPerDistrict} orders per district (the highest
+ * {@code o_id}s) rather than mirroring every order.
+ *
  * <p>Two parts of the spec are still simplified relative to a strict benchmark
  * load:
  * <ul>
  *   <li>orders-per-district equals customers-per-district (one order per
  *       customer) and {@code o_c_id} is the identity rather than a per-district
  *       permutation of customer ids;</li>
- *   <li>each order has a fixed number of lines ({@code o_ol_cnt} is constant)
- *       rather than a random {@code [5, 15]}, and {@code o_carrier_id} is always
- *       populated rather than NULL for the most recent (undelivered) orders.</li>
+ *   <li>delivery state is not modelled: {@code o_carrier_id} is always populated
+ *       and {@code ol_delivery_d} is left to the default generator rather than
+ *       being NULL for the most recent (undelivered) orders.</li>
  * </ul>
- * In line with the spec, however, {@code new_order} holds only the most recent
- * {@code newOrdersPerDistrict} orders per district (the highest {@code o_id}s)
- * rather than mirroring every order.
  */
 public final class TPCCConfiguration {
 
     public static final int DEFAULT_ITEMS = 100_000;
     public static final int DEFAULT_DISTRICTS_PER_WAREHOUSE = 10;
     public static final int DEFAULT_CUSTOMERS_PER_DISTRICT = 3_000;
-    public static final int DEFAULT_LINES_PER_ORDER = 10;
+    public static final int DEFAULT_MIN_LINES_PER_ORDER = 5;
+    public static final int DEFAULT_MAX_LINES_PER_ORDER = 15;
     public static final int DEFAULT_NEW_ORDERS_PER_DISTRICT = 900;
+
+    // salt for the deterministic per-order line-count hash; fixed so datasets are reproducible
+    private static final long LINE_COUNT_SEED = 0x7C_3C_45_21_9ABCDEFL;
 
     private TPCCConfiguration() {
     }
@@ -76,7 +87,8 @@ public final class TPCCConfiguration {
      * @return the set of table configurations
      */
     public static Set<TableConfiguration> build(int warehouses) {
-        return build(warehouses, DEFAULT_ITEMS, DEFAULT_DISTRICTS_PER_WAREHOUSE, DEFAULT_CUSTOMERS_PER_DISTRICT, DEFAULT_LINES_PER_ORDER);
+        return build(warehouses, DEFAULT_ITEMS, DEFAULT_DISTRICTS_PER_WAREHOUSE, DEFAULT_CUSTOMERS_PER_DISTRICT,
+                DEFAULT_MIN_LINES_PER_ORDER, DEFAULT_MAX_LINES_PER_ORDER);
     }
 
     /**
@@ -88,11 +100,13 @@ public final class TPCCConfiguration {
      * @param items                number of items (I)
      * @param districtsPerWarehouse districts per warehouse (D)
      * @param customersPerDistrict  customers per district (C); also used as orders per district
-     * @param linesPerOrder         order lines per order (L)
+     * @param minLinesPerOrder      minimum order lines per order (inclusive)
+     * @param maxLinesPerOrder      maximum order lines per order (inclusive); pass the same value
+     *                              as {@code minLinesPerOrder} for a fixed line count
      * @return the set of table configurations
      */
-    public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int linesPerOrder) {
-        return build(warehouses, items, districtsPerWarehouse, customersPerDistrict, linesPerOrder,
+    public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int minLinesPerOrder, int maxLinesPerOrder) {
+        return build(warehouses, items, districtsPerWarehouse, customersPerDistrict, minLinesPerOrder, maxLinesPerOrder,
                 Math.min(customersPerDistrict, DEFAULT_NEW_ORDERS_PER_DISTRICT));
     }
 
@@ -104,26 +118,30 @@ public final class TPCCConfiguration {
      * @param items                  number of items (I)
      * @param districtsPerWarehouse  districts per warehouse (D)
      * @param customersPerDistrict   customers per district (C); also used as orders per district
-     * @param linesPerOrder          order lines per order (L)
+     * @param minLinesPerOrder       minimum order lines per order (inclusive)
+     * @param maxLinesPerOrder       maximum order lines per order (inclusive); pass the same value
+     *                               as {@code minLinesPerOrder} for a fixed line count
      * @param newOrdersPerDistrict   most-recent orders per district mirrored into {@code new_order};
      *                               clamped to {@code [0, customersPerDistrict]}
      * @return the set of table configurations
      */
-    public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int linesPerOrder, int newOrdersPerDistrict) {
+    public static Set<TableConfiguration> build(int warehouses, int items, int districtsPerWarehouse, int customersPerDistrict, int minLinesPerOrder, int maxLinesPerOrder, int newOrdersPerDistrict) {
 
         final int w = warehouses;
         final int i = items;
         final int d = districtsPerWarehouse;
         final int c = customersPerDistrict;
         final int o = customersPerDistrict; // one order per customer
-        final int l = linesPerOrder;
         final int no = Math.max(0, Math.min(newOrdersPerDistrict, o)); // new_order is a subset of orders
+
+        // shared, deterministic per-order line counts so open_order.o_ol_cnt and order_line agree
+        final ChildCardinality cardinality = new ChildCardinality(minLinesPerOrder, maxLinesPerOrder, LINE_COUNT_SEED);
 
         final long stockRows = (long) w * i;
         final long districtRows = (long) w * d;
         final long customerRows = (long) w * d * c;
         final long orderRows = (long) w * d * o;
-        final long orderLineRows = (long) w * d * o * l;
+        final long orderLineRows = cardinality.total(orderRows);
         final long newOrderRows = (long) w * d * no;
 
         Set<TableConfiguration> tables = new HashSet<>();
@@ -189,7 +207,7 @@ public final class TPCCConfiguration {
                 key("o_id", 1, 1, o),
                 key("o_c_id", 1, 1, c),
                 col("o_carrier_id", intRange(1, 10)),
-                col("o_ol_cnt", staticInt(l)),
+                childCount("o_ol_cnt", cardinality),
                 col("o_all_local", staticInt(1)))));
 
         tables.add(new TableConfiguration("new_order", newOrderRows, set(
@@ -197,17 +215,45 @@ public final class TPCCConfiguration {
                 key("no_d_id", 1, no, d),
                 key("no_o_id", o - no + 1, 1, no))));
 
+        // order_line has a variable number of rows per order; its parent-key components mirror
+        // the open_order key generators (same start/repeat/cycle, applied to the parent index),
+        // and ol_number is the 1-based line sequence within each order
         tables.add(new TableConfiguration("order_line", orderLineRows, set(
-                key("ol_w_id", 1, (long) d * o * l, w),
-                key("ol_d_id", 1, (long) o * l, d),
-                key("ol_o_id", 1, l, o),
-                key("ol_number", 1, 1, l),
-                key("ol_supply_w_id", 1, (long) d * o * l, w),
+                childKey("ol_w_id", cardinality, 1, (long) d * o, w),
+                childKey("ol_d_id", cardinality, 1, o, d),
+                childKey("ol_o_id", cardinality, 1, 1, o),
+                childSequence("ol_number", cardinality),
+                childKey("ol_supply_w_id", cardinality, 1, (long) d * o, w),
                 key("ol_i_id", 1, 1, i),
                 col("ol_quantity", staticInt(5)),
                 col("ol_amount", scaledDecimal(0.01, 9999.99, 2)))));
 
         return tables;
+    }
+
+    /**
+     * A parent table's "number of children" column, driven by the shared {@code cardinality}.
+     */
+    private static ColumnConfiguration childCount(String name, ChildCardinality cardinality) {
+        return new ColumnConfiguration(name,
+                random -> new ChildCountGenerator.Builder(random).cardinality(cardinality).build());
+    }
+
+    /**
+     * A child-key component that repeats a parent-key dimension, computed from the parent index
+     * with the same {@code start + ((parentIndex / repeat) % cycle)} formula as the parent's key.
+     */
+    private static ColumnConfiguration childKey(String name, ChildCardinality cardinality, int start, long repeat, int cycle) {
+        return new ColumnConfiguration(name,
+                random -> new ChildKeyComponentGenerator.Builder(random).cardinality(cardinality).start(start).repeat(repeat).cycle(cycle).build());
+    }
+
+    /**
+     * A child-key component emitting the 1-based sequence number of a child within its parent.
+     */
+    private static ColumnConfiguration childSequence(String name, ChildCardinality cardinality) {
+        return new ColumnConfiguration(name,
+                random -> new ChildKeyComponentGenerator.Builder(random).cardinality(cardinality).sequence().start(1).build());
     }
 
     /**

--- a/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -66,20 +66,28 @@ public class BaseDatabaseTestCase {
 
     /**
      * Asserts that a TPC-C dataset produced by {@code TPCCConfiguration} matches the spec's
-     * value ranges and seed values (issue #421, gaps 1 and 3). The SQL is portable across
+     * value ranges and seed values (issue #421, gaps 1, 2 and 3). The SQL is portable across
      * PostgreSQL, MySQL and CockroachDB.
      *
      * @param connection      an open connection to the filled database
      * @param customers       customers (and orders) per district
-     * @param linesPerOrder   order lines per order
+     * @param minLines        minimum order lines per order (inclusive)
+     * @param maxLines        maximum order lines per order (inclusive)
      * @param newOrders       most-recent orders per district mirrored into {@code new_order}
      */
-    protected static void assertTpccColumnFidelity(Connection connection, int customers, int linesPerOrder, int newOrders) throws SQLException {
+    protected static void assertTpccColumnFidelity(Connection connection, int customers, int minLines, int maxLines, int newOrders) throws SQLException {
         // realistic value generators were applied (unchanged from the original TPC-C support)
         assertCount(connection, "select count(*) from customer where c_credit not in ('GC','BC')", 0);
         assertCount(connection, "select count(*) from customer where c_zip not like '____11111'", 0);
         assertCount(connection, "select count(*) from customer where c_middle <> 'OE'", 0);
-        assertCount(connection, "select count(*) from open_order where o_ol_cnt <> " + linesPerOrder, 0);
+
+        // gap 2: each order has o_ol_cnt lines in [minLines, maxLines], and order_line holds
+        // exactly that many rows per order (o_ol_cnt agrees with the actual line count)
+        assertCount(connection, "select count(*) from open_order where o_ol_cnt < " + minLines + " or o_ol_cnt > " + maxLines, 0);
+        assertCount(connection, "select count(*) from open_order o where o.o_ol_cnt <> "
+                + "(select count(*) from order_line l where l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id)", 0);
+        assertCount(connection, "select count(*) from order_line l join open_order o "
+                + "on l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id where l.ol_number > o.o_ol_cnt", 0);
 
         // gap 1: new_order holds only the most-recent orders per district (highest o_id values)
         assertCount(connection, "select count(*) from new_order where no_o_id < " + (customers - newOrders + 1), 0);

--- a/src/test/java/io/bloviate/db/CockroachDBFillerTest.java
+++ b/src/test/java/io/bloviate/db/CockroachDBFillerTest.java
@@ -58,11 +58,12 @@ class CockroachDBFillerTest extends BaseCockroachTest {
         int i = 10;
         int d = 2;
         int c = 3;
-        int l = 2;
+        int minLines = 5;
+        int maxLines = 15;
         int newOrders = 2;
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(
-                128, 10, new CockroachDBSupport(), TPCCConfiguration.build(w, i, d, c, l, newOrders));
+                128, 10, new CockroachDBSupport(), TPCCConfiguration.build(w, i, d, c, minLines, maxLines, newOrders));
 
         fillDatabase("create_tpcc.cockroachdb.sql", configuration, connection -> {
             assertRowCount(connection, "warehouse", w);
@@ -73,9 +74,9 @@ class CockroachDBFillerTest extends BaseCockroachTest {
             assertRowCount(connection, "history", (long) w * d * c);
             assertRowCount(connection, "open_order", (long) w * d * c);
             assertRowCount(connection, "new_order", (long) w * d * newOrders);
-            assertRowCount(connection, "order_line", (long) w * d * c * l);
+            // order_line row count is variable; asserted relationally in assertTpccColumnFidelity
 
-            assertTpccColumnFidelity(connection, c, l, newOrders);
+            assertTpccColumnFidelity(connection, c, minLines, maxLines, newOrders);
         });
     }
 

--- a/src/test/java/io/bloviate/db/MySqlFillerTest.java
+++ b/src/test/java/io/bloviate/db/MySqlFillerTest.java
@@ -57,11 +57,12 @@ class MySqlFillerTest extends BaseMySqlTest {
         int i = 10;
         int d = 2;
         int c = 3;
-        int l = 2;
+        int minLines = 5;
+        int maxLines = 15;
         int newOrders = 2;
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(
-                128, 10, new MySQLSupport(), TPCCConfiguration.build(w, i, d, c, l, newOrders));
+                128, 10, new MySQLSupport(), TPCCConfiguration.build(w, i, d, c, minLines, maxLines, newOrders));
 
         fillDatabase("create_tpcc.mysql.sql", configuration, connection -> {
             assertRowCount(connection, "warehouse", w);
@@ -72,9 +73,9 @@ class MySqlFillerTest extends BaseMySqlTest {
             assertRowCount(connection, "history", (long) w * d * c);
             assertRowCount(connection, "open_order", (long) w * d * c);
             assertRowCount(connection, "new_order", (long) w * d * newOrders);
-            assertRowCount(connection, "order_line", (long) w * d * c * l);
+            // order_line row count is variable; asserted relationally in assertTpccColumnFidelity
 
-            assertTpccColumnFidelity(connection, c, l, newOrders);
+            assertTpccColumnFidelity(connection, c, minLines, maxLines, newOrders);
         });
     }
 }

--- a/src/test/java/io/bloviate/db/PostgresFillerTest.java
+++ b/src/test/java/io/bloviate/db/PostgresFillerTest.java
@@ -101,11 +101,12 @@ class PostgresFillerTest extends BasePostgresTest {
         int i = 10;         // items
         int d = 2;          // districts per warehouse
         int c = 3;          // customers (and orders) per district
-        int l = 2;          // lines per order
+        int minLines = 5;   // minimum order lines per order
+        int maxLines = 15;  // maximum order lines per order
         int newOrders = 2;  // most-recent orders per district mirrored into new_order
 
         DatabaseConfiguration configuration = new DatabaseConfiguration(
-                128, 10, new PostgresSupport(), TPCCConfiguration.build(w, i, d, c, l, newOrders));
+                128, 10, new PostgresSupport(), TPCCConfiguration.build(w, i, d, c, minLines, maxLines, newOrders));
 
         fillDatabase("create_tpcc.postgres.sql", configuration, connection -> {
             // cardinalities of the dense cartesian-product fill; if any composite key
@@ -118,9 +119,10 @@ class PostgresFillerTest extends BasePostgresTest {
             assertRowCount(connection, "history", (long) w * d * c);
             assertRowCount(connection, "open_order", (long) w * d * c);
             assertRowCount(connection, "new_order", (long) w * d * newOrders);
-            assertRowCount(connection, "order_line", (long) w * d * c * l);
+            // order_line has a variable number of rows per order; its total is asserted
+            // relationally (== sum of o_ol_cnt) inside assertTpccColumnFidelity
 
-            assertTpccColumnFidelity(connection, c, l, newOrders);
+            assertTpccColumnFidelity(connection, c, minLines, maxLines, newOrders);
         });
     }
 }

--- a/src/test/java/io/bloviate/gen/ChildCardinalityTest.java
+++ b/src/test/java/io/bloviate/gen/ChildCardinalityTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChildCardinalityTest {
+
+    @Test
+    void countStaysWithinInclusiveRangeAndIsDeterministic() {
+        ChildCardinality cardinality = new ChildCardinality(5, 15, 0xABCDEFL);
+        for (long k = 0; k < 10_000; k++) {
+            int count = cardinality.count(k);
+            assertTrue(count >= 5 && count <= 15, "out of range at " + k + ": " + count);
+            assertEquals(count, cardinality.count(k), "non-deterministic at " + k);
+        }
+    }
+
+    @Test
+    void totalMatchesTheSumOfCounts() {
+        ChildCardinality cardinality = new ChildCardinality(1, 9, 42);
+        long expected = 0;
+        for (long k = 0; k < 5_000; k++) {
+            expected += cardinality.count(k);
+        }
+        assertEquals(expected, cardinality.total(5_000));
+    }
+
+    @Test
+    void totalIsClosedFormWhenCountIsFixed() {
+        ChildCardinality fixed = new ChildCardinality(7, 7, 1);
+        assertEquals(7L * 1_000_000, fixed.total(1_000_000));
+        for (long k = 0; k < 100; k++) {
+            assertEquals(7, fixed.count(k));
+        }
+    }
+
+    @Test
+    void countGeneratorEmitsCardinalityCountPerParentInOrder() {
+        ChildCardinality cardinality = new ChildCardinality(5, 15, 99);
+        ChildCountGenerator generator = new ChildCountGenerator.Builder(new Random()).cardinality(cardinality).build();
+        for (long k = 0; k < 1_000; k++) {
+            assertEquals(cardinality.count(k), generator.generate().intValue(), "mismatch at parent " + k);
+        }
+    }
+
+    @Test
+    void childKeysAgreeWithParentCountsAndDecomposeRowMajor() {
+        // parent key space: W=2 x D=2 x O=3 = 12 parents, row-major (warehouse outermost)
+        int w = 2, d = 2, o = 3;
+        long parents = (long) w * d * o;
+        ChildCardinality cardinality = new ChildCardinality(1, 4, 7);
+
+        long total = cardinality.total(parents);
+
+        // child key generators mirror the parent key's start/repeat/cycle, plus a sequence column
+        ChildKeyComponentGenerator wId = childKey(cardinality, 1, (long) d * o, w);
+        ChildKeyComponentGenerator dId = childKey(cardinality, 1, o, d);
+        ChildKeyComponentGenerator oId = childKey(cardinality, 1, 1, o);
+        ChildKeyComponentGenerator supplyW = childKey(cardinality, 1, (long) d * o, w);
+        ChildKeyComponentGenerator number = new ChildKeyComponentGenerator.Builder(new Random()).cardinality(cardinality).sequence().start(1).build();
+
+        // collect the sequence numbers seen for each parent index
+        List<List<Integer>> seqByParent = new ArrayList<>();
+        for (int k = 0; k < parents; k++) {
+            seqByParent.add(new ArrayList<>());
+        }
+
+        for (long row = 0; row < total; row++) {
+            int wv = wId.generate();
+            int dv = dId.generate();
+            int ov = oId.generate();
+            int sv = supplyW.generate();
+            int nv = number.generate();
+
+            assertEquals(wv, sv, "supply warehouse should equal the order warehouse");
+
+            int parentIndex = (wv - 1) * (d * o) + (dv - 1) * o + (ov - 1);
+            seqByParent.get(parentIndex).add(nv);
+        }
+
+        for (int k = 0; k < parents; k++) {
+            int expectedCount = cardinality.count(k);
+            List<Integer> seqs = seqByParent.get(k);
+            assertEquals(expectedCount, seqs.size(), "row count for parent " + k + " must equal o_ol_cnt");
+            // ol_number must be exactly 1..expectedCount in order
+            for (int line = 0; line < expectedCount; line++) {
+                assertEquals(line + 1, seqs.get(line).intValue(), "non-contiguous sequence for parent " + k);
+            }
+        }
+    }
+
+    private static ChildKeyComponentGenerator childKey(ChildCardinality cardinality, int start, long repeat, int cycle) {
+        return new ChildKeyComponentGenerator.Builder(new Random())
+                .cardinality(cardinality).start(start).repeat(repeat).cycle(cycle).build();
+    }
+}

--- a/src/test/java/io/bloviate/gen/TpchOrderLineExampleTest.java
+++ b/src/test/java/io/bloviate/gen/TpchOrderLineExampleTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import io.bloviate.db.ColumnConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Worked example: applying the generic variable parent-child cardinality generators
+ * ({@link ChildCardinality}, {@link ChildKeyComponentGenerator}, {@link ChildCountGenerator})
+ * to a schema <em>other than</em> TPC-C — the TPC-H {@code ORDERS -> LINEITEM} relationship,
+ * where each order has a random number of line items (the spec draws this from {@code [1, 7]}).
+ *
+ * <p>This is deliberately simpler than TPC-C: a TPC-H order is identified by a single
+ * {@code o_orderkey}, so the child's parent-key component is just one dimension rather than a
+ * three-part composite. To populate {@code LINEITEM} you register, on its
+ * {@code TableConfiguration}, the column overrides built in {@link #lineitemColumns} and set the
+ * table's row count to {@code lineitemsPerOrder.total(orderCount)}. The matching
+ * {@code ChildCardinality} instance is shared so the parent and child agree on counts:
+ *
+ * <pre>{@code
+ * ChildCardinality lineitemsPerOrder = new ChildCardinality(1, 7, seed);
+ * long orderCount   = scaleFactor * 1_500_000L;       // TPC-H ORDERS cardinality
+ * long lineitemRows = lineitemsPerOrder.total(orderCount);
+ *
+ * // LINEITEM.l_orderkey — the parent's single-column key, applied to the parent index
+ * new ColumnConfiguration("l_orderkey", r -> new ChildKeyComponentGenerator.Builder(r)
+ *         .cardinality(lineitemsPerOrder).start(1).repeat(1).cycle((int) orderCount).build());
+ * // LINEITEM.l_linenumber — 1-based line sequence within each order
+ * new ColumnConfiguration("l_linenumber", r -> new ChildKeyComponentGenerator.Builder(r)
+ *         .cardinality(lineitemsPerOrder).sequence().start(1).build());
+ * }</pre>
+ *
+ * <p>TPC-H {@code ORDERS} has no stored line-count column, so {@link ChildCountGenerator} is
+ * optional here — it is shown only to illustrate that, were you to add a derived count column,
+ * sharing the same {@code ChildCardinality} keeps it consistent with the generated line items.
+ */
+class TpchOrderLineExampleTest {
+
+    // a small order count for the example; real TPC-H uses scaleFactor * 1,500,000 orders
+    private static final long ORDER_COUNT = 1_000;
+    private static final int MIN_LINES = 1;
+    private static final int MAX_LINES = 7;
+    private static final long SEED = 0x7C_3C_45_21_9ABCDEFL;
+
+    /**
+     * The {@code LINEITEM} key column overrides you would register on its {@code TableConfiguration}.
+     */
+    private static List<ColumnConfiguration> lineitemColumns(ChildCardinality lineitemsPerOrder, long orderCount) {
+        return List.of(
+                new ColumnConfiguration("l_orderkey", random -> new ChildKeyComponentGenerator.Builder(random)
+                        .cardinality(lineitemsPerOrder).start(1).repeat(1).cycle((int) orderCount).build()),
+                new ColumnConfiguration("l_linenumber", random -> new ChildKeyComponentGenerator.Builder(random)
+                        .cardinality(lineitemsPerOrder).sequence().start(1).build()));
+    }
+
+    @Test
+    void lineitemRowsAgreeWithOrders() {
+        ChildCardinality lineitemsPerOrder = new ChildCardinality(MIN_LINES, MAX_LINES, SEED);
+
+        // LINEITEM row count = sum over all orders of lines(order)
+        long lineitemRows = lineitemsPerOrder.total(ORDER_COUNT);
+
+        // build the generators exactly as the fill engine would, from the column overrides
+        List<ColumnConfiguration> columns = lineitemColumns(lineitemsPerOrder, ORDER_COUNT);
+        DataGenerator<?> lOrderKey = columns.get(0).generatorFactory().create(new Random());
+        DataGenerator<?> lLineNumber = columns.get(1).generatorFactory().create(new Random());
+
+        // optional derived ORDERS count column, shown for completeness
+        ChildCountGenerator oLineCount = new ChildCountGenerator.Builder(new Random())
+                .cardinality(lineitemsPerOrder).build();
+
+        // walk every LINEITEM row and group its line numbers by order key
+        Map<Integer, List<Integer>> linesByOrder = new HashMap<>();
+        for (long row = 0; row < lineitemRows; row++) {
+            int orderKey = (Integer) lOrderKey.generate();
+            int lineNumber = (Integer) lLineNumber.generate();
+            assertTrue(orderKey >= 1 && orderKey <= ORDER_COUNT, "l_orderkey out of range: " + orderKey);
+            linesByOrder.computeIfAbsent(orderKey, k -> new ArrayList<>()).add(lineNumber);
+        }
+
+        // every order has exactly count(order) line items, numbered 1..count, and the totals agree
+        long summed = 0;
+        for (long k = 0; k < ORDER_COUNT; k++) {
+            int orderKey = (int) (k + 1);
+            int expected = lineitemsPerOrder.count(k);
+            assertEquals(expected, oLineCount.generate().intValue(), "o_lineitem_cnt mismatch for order " + orderKey);
+
+            List<Integer> lines = linesByOrder.get(orderKey);
+            assertNotNull(lines, "order " + orderKey + " has no line items");
+            assertEquals(expected, lines.size(), "line count mismatch for order " + orderKey);
+            for (int line = 0; line < expected; line++) {
+                assertEquals(line + 1, lines.get(line).intValue(), "non-contiguous l_linenumber for order " + orderKey);
+            }
+            summed += expected;
+        }
+
+        assertEquals(summed, lineitemRows, "LINEITEM row count must equal the sum of per-order line counts");
+        assertEquals(ORDER_COUNT, linesByOrder.size(), "every order should have at least one line item (min = 1)");
+    }
+}

--- a/src/test/java/io/bloviate/gen/tpcc/TPCCConfigurationTest.java
+++ b/src/test/java/io/bloviate/gen/tpcc/TPCCConfigurationTest.java
@@ -35,7 +35,8 @@ class TPCCConfigurationTest {
     private static final int I = 50;
     private static final int D = 3;
     private static final int C = 10;
-    private static final int L = 5;
+    private static final int MIN_LINES = 5;
+    private static final int MAX_LINES = 15;
     private static final int NEW_ORDERS = 4;
 
     private static TableConfiguration table(Set<TableConfiguration> tables, String name) {
@@ -50,7 +51,7 @@ class TPCCConfigurationTest {
 
     @Test
     void newOrderIsASubsetOfOrders() {
-        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L, NEW_ORDERS);
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
 
         long expectedOrders = (long) W * D * C;
         long expectedNewOrders = (long) W * D * NEW_ORDERS;
@@ -70,13 +71,13 @@ class TPCCConfigurationTest {
     @Test
     void newOrdersPerDistrictDefaultsToClampedSpecValue() {
         // small order count clamps the 900-default down to the available orders (full mirror)
-        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L);
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES);
         assertEquals((long) W * D * C, table(tables, "new_order").rowCount());
     }
 
     @Test
     void taxRatesStayWithinSpecRange() {
-        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L, NEW_ORDERS);
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
         DataGenerator<?> wTax = generator(table(tables, "warehouse"), "w_tax");
         BigDecimal max = new BigDecimal("0.2000");
         for (int i = 0; i < 1000; i++) {
@@ -88,7 +89,7 @@ class TPCCConfigurationTest {
 
     @Test
     void seedValuesMatchSpec() {
-        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, L, NEW_ORDERS);
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
         assertEquals(new BigDecimal("300000.00"), generator(table(tables, "warehouse"), "w_ytd").generate());
         assertEquals(new BigDecimal("30000.00"), generator(table(tables, "district"), "d_ytd").generate());
         assertEquals(new BigDecimal("50000.00"), generator(table(tables, "customer"), "c_credit_lim").generate());
@@ -96,5 +97,34 @@ class TPCCConfigurationTest {
         assertEquals(5, ((Integer) generator(table(tables, "order_line"), "ol_quantity").generate()).intValue());
         // d_next_o_id is orders-per-district + 1
         assertEquals(C + 1, ((Integer) generator(table(tables, "district"), "d_next_o_id").generate()).intValue());
+    }
+
+    @Test
+    void orderLineRowCountEqualsSumOfVariableLineCounts() {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+
+        long orders = (long) W * D * C;
+        DataGenerator<?> oOlCnt = generator(table(tables, "open_order"), "o_ol_cnt");
+
+        long sum = 0;
+        boolean sawVariation = false;
+        int first = (Integer) oOlCnt.generate();
+        sum += first;
+        for (long k = 1; k < orders; k++) {
+            int count = (Integer) oOlCnt.generate();
+            assertTrue(count >= MIN_LINES && count <= MAX_LINES, "o_ol_cnt out of range: " + count);
+            sawVariation |= (count != first);
+            sum += count;
+        }
+
+        assertTrue(sawVariation, "expected variable line counts across orders");
+        assertEquals(sum, table(tables, "order_line").rowCount(),
+                "order_line row count must equal the sum of o_ol_cnt across all orders");
+    }
+
+    @Test
+    void fixedLineCountGivesClosedFormOrderLineRowCount() {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, 7, 7, NEW_ORDERS);
+        assertEquals((long) W * D * C * 7, table(tables, "order_line").rowCount());
     }
 }


### PR DESCRIPTION
Closes gap **2** of #421.

> **Stacked on #437** (gaps 1 & 3). Base is `feat/tpcc-fidelity-gap1-gap3` so the diff shows only the gap-2 changes — retarget to `main` once #437 merges.

## What
Each order now has a random `o_ol_cnt ∈ [minLinesPerOrder, maxLinesPerOrder]` (default `[5,15]`), and `order_line` holds **exactly** that many rows per order — with `open_order.o_ol_cnt` agreeing with the actual per-order line count, even though the two tables are filled independently.

## Design — generic, not TPC-C-specific
The fixed-cardinality `CompositeKeyComponentGenerator` can't express variable per-parent child counts. Per discussion, this is implemented as **reusable primitives in `io.bloviate.gen`**, since other benchmark schemas need the same parent→child variable cardinality (TPC-H orders→lineitem, TPC-DS, TPC-E):

- **`ChildCardinality`** — deterministic `parentIndex → childCount ∈ [min,max]` via a splitmix64 hash. The shared source of truth that lets parent and child tables agree with no runtime coordination. `total()` is O(1) when `min==max`, otherwise an O(parentCount) pass with **O(1) memory** (no prefix-sum array), so very large datasets are unaffected.
- **`ChildCountGenerator`** — emits a parent's "number of children" column (e.g. `o_ol_cnt`).
- **`ChildKeyComponentGenerator`** — emits one child composite-key component: either a **parent-key dimension** (same `start + (parentIndex/repeat)%cycle` formula as the parent's own key) or the **1-based sequence** within the parent. Each instance walks parents with a private O(1) cursor; because counts are deterministic and each key column is generated once per row, the separate key generators advance in lockstep with no shared mutable state.

`TPCCConfiguration` just supplies the schema-specific `(start, repeat, cycle)` for each `order_line` key dimension and shares one `ChildCardinality` between `o_ol_cnt` and the child keys. The `build()` signatures now take `minLinesPerOrder`/`maxLinesPerOrder` (pass equal values for a fixed count).

## Large-dataset note
No memory regression — generation stays O(1) memory and O(1) amortized per row. The only added cost is one O(parentCount) summation at config-build time to compute the (now non-constant) `order_line` row count; it's O(1) for the fixed-count case and dwarfed by insert time otherwise.

## Remaining simplification
Delivery state is still not modelled (`o_carrier_id` always set, `ol_delivery_d` left to the default generator) — that's a cross-cutting concern, not the cardinality problem gap 2 targets. Documented in the `TPCCConfiguration` javadoc.

## Testing
- `ChildCardinalityTest` — range/determinism, `total()` (incl. fixed closed-form), and a full walk proving per-parent line counts, contiguous `1..o_ol_cnt` sequences, and correct row-major parent decomposition.
- `TPCCConfigurationTest` — `order_line` row count `== Σ o_ol_cnt`, variability, and the fixed-count closed form.
- The Postgres/MySQL/CockroachDB filler tests assert the per-order invariant on live DBs: `o_ol_cnt == COUNT(order_line)` per order and `ol_number <= o_ol_cnt`.
- `./mvnw verify` — **110 tests, 0 failures** across all three databases (e.g. 12 orders → 103 order lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)