### PR TITLE
feat(tpcc): close gap 4 — o_c_id permutation + c_last load enumeration

### DIFF
--- a/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
+++ b/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Emits a deterministic random <em>permutation</em> of {@code [start, start + groupSize)} within
+ * each consecutive run of {@code groupSize} rows, advancing to a fresh permutation for the next
+ * group. Over the n-th row (0-based) it returns {@code start + permute(n % groupSize)} using a
+ * permutation keyed by {@code n / groupSize}, so each group is an independent shuffle.
+ *
+ * <p>This is the streaming, O(1)-memory building block for "shuffled 1:1 assignment within a
+ * group" — for example TPC-C's {@code o_c_id}, where each district's orders reference its customer
+ * ids {@code 1..C} in a random order (each customer gets exactly one order). It is schema-agnostic:
+ * any column that should be a per-group permutation of a contiguous id range can use it.
+ *
+ * <p>The permutation is produced by a small keyed Feistel network with cycle-walking, which is a
+ * bijection on {@code [0, groupSize)} without materialising a shuffle array — so memory is constant
+ * regardless of group size or row count, and the result is fully reproducible. The values do not
+ * depend on the injected random source; the per-group key is derived from a fixed {@code seed} and
+ * the group index, and counter state advances on every {@link #generate()}.
+ *
+ * <p>Supports group sizes up to {@code 2^30}.
+ */
+public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> {
+
+    private static final int ROUNDS = 4;
+
+    private final int groupSize;
+    private final int start;
+    private final long seed;
+    private final int halfBits;
+    private final long halfMask;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    @Override
+    public Integer generate() {
+        long n = counter.getAndIncrement();
+        long group = n / groupSize;
+        int position = (int) (n % groupSize);
+        long key = mix(seed + group);
+        return start + permute(position, key);
+    }
+
+    // cycle-walking: a Feistel permutation on [0, 2^(2*halfBits)) restricted to [0, groupSize)
+    private int permute(int position, long key) {
+        long value = position;
+        do {
+            value = feistel(value, key);
+        } while (value >= groupSize);
+        return (int) value;
+    }
+
+    private long feistel(long value, long key) {
+        long left = (value >>> halfBits) & halfMask;
+        long right = value & halfMask;
+        for (int round = 0; round < ROUNDS; round++) {
+            long f = roundFunction(right, round, key) & halfMask;
+            long nextLeft = right;
+            long nextRight = left ^ f;
+            left = nextLeft;
+            right = nextRight;
+        }
+        return (left << halfBits) | right;
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private int groupSize = 1;
+        private int start = 0;
+        private long seed = 0;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        /**
+         * The size of each permutation group; each run of this many rows is a fresh permutation
+         * of {@code [start, start + groupSize)}. Must be in {@code [1, 2^30]}.
+         */
+        public Builder groupSize(int groupSize) {
+            this.groupSize = groupSize;
+            return this;
+        }
+
+        public Builder start(int start) {
+            this.start = start;
+            return this;
+        }
+
+        /**
+         * Salt for the per-group permutation key; fix it for reproducible datasets.
+         */
+        public Builder seed(long seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        @Override
+        public GroupedPermutationGenerator build() {
+            return new GroupedPermutationGenerator(this);
+        }
+    }
+
+    private GroupedPermutationGenerator(Builder builder) {
+        super(builder.random);
+        if (builder.groupSize < 1 || builder.groupSize > (1 << 30)) {
+            throw new IllegalArgumentException("groupSize must be in [1, 2^30]: " + builder.groupSize);
+        }
+        this.groupSize = builder.groupSize;
+        this.start = builder.start;
+        this.seed = builder.seed;
+
+        // split point for a balanced Feistel whose domain (2^(2*halfBits)) covers groupSize
+        int bitsNeeded = groupSize <= 1 ? 0 : (32 - Integer.numberOfLeadingZeros(groupSize - 1));
+        this.halfBits = (bitsNeeded + 1) / 2;
+        this.halfMask = halfBits == 0 ? 0L : ((1L << halfBits) - 1);
+    }
+
+    private static long roundFunction(long right, int round, long key) {
+        long z = right * 0x9E3779B97F4A7C15L + key + (round + 1L) * 0xBF58476D1CE4E5B9L;
+        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
+        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
+        return z ^ (z >>> 31);
+    }
+
+    // splitmix64 finalizer — a well-distributed, deterministic mix of a 64-bit input
+    private static long mix(long value) {
+        long z = value + 0x9E3779B97F4A7C15L;
+        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
+        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
+        return z ^ (z >>> 31);
+    }
+}

--- a/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
+++ b/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
@@ -22,11 +22,20 @@ import io.bloviate.gen.AbstractDataGenerator;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Generates TPC-C customer last names (clause 4.3.2.3): three concatenated
- * syllables selected from a fixed set using a number drawn via {@code NURand}.
+ * syllables selected from a fixed set by a number in {@code [0, 999]}.
  * The result is at most 15 characters, fitting the {@code c_last varchar(16)} column.
+ *
+ * <p>By default the number is drawn via {@code NURand} for every row. To match the
+ * load procedure (clause 4.3.3.1), configure {@link Builder#groupSize(int) groupSize}
+ * (the customers per district) and {@link Builder#enumeratedCount(int) enumeratedCount}
+ * (typically {@value #MAX_ENUMERATED}): the first {@code enumeratedCount} customers of
+ * each district then enumerate the numbers {@code 0..enumeratedCount-1} deterministically
+ * — guaranteeing every distinct last name is present — and only the remaining customers
+ * use {@code NURand}.
  */
 public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
 
@@ -38,9 +47,33 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
     // Only the load-time constant is relevant to a data generator; the run-time constant is unused.
     private static final int C_LOAD = 157;
 
+    /** The spec enumerates last-name numbers {@code [0, 999]} for the first 1000 customers per district. */
+    public static final int MAX_ENUMERATED = 1000;
+
+    private final int groupSize;       // customers per district; only used when enumeratedCount > 0
+    private final int enumeratedCount; // first-N customers per district that enumerate 0..enumeratedCount-1
+    private final AtomicLong counter = new AtomicLong(0);
+
     @Override
     public String generate() {
-        int num = TPCCUtils.nonUniformRandom(255, C_LOAD, 0, 999, randomUtils);
+        int num;
+        if (enumeratedCount > 0) {
+            int position = (int) (counter.getAndIncrement() % groupSize); // position within the district
+            num = position < enumeratedCount ? position : TPCCUtils.nonUniformRandom(255, C_LOAD, 0, 999, randomUtils);
+        } else {
+            num = TPCCUtils.nonUniformRandom(255, C_LOAD, 0, 999, randomUtils);
+        }
+        return lastName(num);
+    }
+
+    /**
+     * Builds the TPC-C last name for a number in {@code [0, 999]} by indexing the syllable
+     * set with its three decimal digits.
+     *
+     * @param num a value in {@code [0, 999]}
+     * @return the concatenated three-syllable last name
+     */
+    public static String lastName(int num) {
         return SYLLABLES[num / 100] + SYLLABLES[(num / 10) % 10] + SYLLABLES[num % 10];
     }
 
@@ -51,17 +84,47 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
+        private int groupSize = 0;
+        private int enumeratedCount = 0;
+
         public Builder(Random random) {
             super(random);
         }
 
+        /**
+         * The number of customers per district, used to locate each row's position within its
+         * district when {@link #enumeratedCount(int)} is set.
+         */
+        public Builder groupSize(int groupSize) {
+            this.groupSize = groupSize;
+            return this;
+        }
+
+        /**
+         * The number of customers at the start of each district whose last name is enumerated
+         * deterministically ({@code 0..enumeratedCount-1}); the rest use {@code NURand}. Must be
+         * in {@code [0, }{@value #MAX_ENUMERATED}{@code ]}; {@code 0} disables enumeration.
+         */
+        public Builder enumeratedCount(int enumeratedCount) {
+            this.enumeratedCount = enumeratedCount;
+            return this;
+        }
+
         @Override
         public CustomerLastNameGenerator build() {
-            return new CustomerLastNameGenerator(random);
+            return new CustomerLastNameGenerator(random, groupSize, enumeratedCount);
         }
     }
 
-    private CustomerLastNameGenerator(Random random) {
+    private CustomerLastNameGenerator(Random random, int groupSize, int enumeratedCount) {
         super(random);
+        if (enumeratedCount < 0 || enumeratedCount > MAX_ENUMERATED) {
+            throw new IllegalArgumentException("enumeratedCount must be in [0, " + MAX_ENUMERATED + "]: " + enumeratedCount);
+        }
+        if (enumeratedCount > 0 && groupSize < 1) {
+            throw new IllegalArgumentException("groupSize must be >= 1 when enumeratedCount > 0");
+        }
+        this.groupSize = groupSize;
+        this.enumeratedCount = enumeratedCount;
     }
 }

--- a/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -23,6 +23,7 @@ import io.bloviate.gen.ChildCardinality;
 import io.bloviate.gen.ChildCountGenerator;
 import io.bloviate.gen.ChildKeyComponentGenerator;
 import io.bloviate.gen.CompositeKeyComponentGenerator;
+import io.bloviate.gen.GroupedPermutationGenerator;
 import io.bloviate.gen.IntegerGenerator;
 import io.bloviate.gen.ScaledBigDecimalGenerator;
 import io.bloviate.gen.StaticBigDecimalGenerator;
@@ -57,9 +58,10 @@ import java.util.Set;
  * <p>Two parts of the spec are still simplified relative to a strict benchmark
  * load:
  * <ul>
- *   <li>orders-per-district equals customers-per-district (one order per
- *       customer) and {@code o_c_id} is the identity rather than a per-district
- *       permutation of customer ids;</li>
+ *   <li>{@code o_c_id} is a per-district random permutation of customer ids (each
+ *       customer has exactly one order), but {@code c_last} uses {@code NURand} for
+ *       all rows rather than the spec's deterministic enumeration of the first 1000
+ *       names per district;</li>
  *   <li>delivery state is not modelled: {@code o_carrier_id} is always populated
  *       and {@code ol_delivery_d} is left to the default generator rather than
  *       being NULL for the most recent (undelivered) orders.</li>
@@ -76,6 +78,9 @@ public final class TPCCConfiguration {
 
     // salt for the deterministic per-order line-count hash; fixed so datasets are reproducible
     private static final long LINE_COUNT_SEED = 0x7C_3C_45_21_9ABCDEFL;
+
+    // salt for the per-district o_c_id permutation; fixed so datasets are reproducible
+    private static final long O_C_ID_PERMUTATION_SEED = 0x0C_1D_5EED_9ABCDEFL;
 
     private TPCCConfiguration() {
     }
@@ -205,7 +210,7 @@ public final class TPCCConfiguration {
                 key("o_w_id", 1, (long) d * o, w),
                 key("o_d_id", 1, o, d),
                 key("o_id", 1, 1, o),
-                key("o_c_id", 1, 1, c),
+                permutation("o_c_id", c, 1),
                 col("o_carrier_id", intRange(1, 10)),
                 childCount("o_ol_cnt", cardinality),
                 col("o_all_local", staticInt(1)))));
@@ -254,6 +259,15 @@ public final class TPCCConfiguration {
     private static ColumnConfiguration childSequence(String name, ChildCardinality cardinality) {
         return new ColumnConfiguration(name,
                 random -> new ChildKeyComponentGenerator.Builder(random).cardinality(cardinality).sequence().start(1).build());
+    }
+
+    /**
+     * A column that is a random permutation of {@code [start, start + groupSize)} within each
+     * consecutive run of {@code groupSize} rows (e.g. {@code o_c_id} per district).
+     */
+    private static ColumnConfiguration permutation(String name, int groupSize, int start) {
+        return new ColumnConfiguration(name,
+                random -> new GroupedPermutationGenerator.Builder(random).groupSize(groupSize).start(start).seed(O_C_ID_PERMUTATION_SEED).build());
     }
 
     /**

--- a/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -48,24 +48,20 @@ import java.util.Set;
  * configured with bounded generators matching the value ranges and seed values
  * from the TPC-C specification (clause 4.3.3.1).
  *
- * <p>In line with the spec, each order has a random {@code o_ol_cnt} number of
+ * <p>In line with the spec: each order has a random {@code o_ol_cnt} number of
  * order lines in {@code [minLinesPerOrder, maxLinesPerOrder]} (default
  * {@code [5, 15]}) and {@code order_line} holds exactly that many rows per order
- * (see {@link io.bloviate.gen.ChildCardinality}); and {@code new_order} holds only the most
- * recent {@code newOrdersPerDistrict} orders per district (the highest
- * {@code o_id}s) rather than mirroring every order.
+ * (see {@link io.bloviate.gen.ChildCardinality}); {@code new_order} holds only the
+ * most recent {@code newOrdersPerDistrict} orders per district (the highest
+ * {@code o_id}s) rather than mirroring every order; {@code o_c_id} is a per-district
+ * random permutation of customer ids (each customer has exactly one order); and
+ * {@code c_last} enumerates the first {@value #DEFAULT_ENUMERATED_LAST_NAMES} last
+ * names per district deterministically, using {@code NURand} only for the remainder.
  *
- * <p>Two parts of the spec are still simplified relative to a strict benchmark
- * load:
- * <ul>
- *   <li>{@code o_c_id} is a per-district random permutation of customer ids (each
- *       customer has exactly one order), but {@code c_last} uses {@code NURand} for
- *       all rows rather than the spec's deterministic enumeration of the first 1000
- *       names per district;</li>
- *   <li>delivery state is not modelled: {@code o_carrier_id} is always populated
- *       and {@code ol_delivery_d} is left to the default generator rather than
- *       being NULL for the most recent (undelivered) orders.</li>
- * </ul>
+ * <p>One part of the spec is still simplified relative to a strict benchmark load:
+ * delivery state is not modelled — {@code o_carrier_id} is always populated and
+ * {@code ol_delivery_d} is left to the default generator rather than being NULL for
+ * the most recent (undelivered) orders.
  */
 public final class TPCCConfiguration {
 
@@ -75,6 +71,7 @@ public final class TPCCConfiguration {
     public static final int DEFAULT_MIN_LINES_PER_ORDER = 5;
     public static final int DEFAULT_MAX_LINES_PER_ORDER = 15;
     public static final int DEFAULT_NEW_ORDERS_PER_DISTRICT = 900;
+    public static final int DEFAULT_ENUMERATED_LAST_NAMES = CustomerLastNameGenerator.MAX_ENUMERATED;
 
     // salt for the deterministic per-order line-count hash; fixed so datasets are reproducible
     private static final long LINE_COUNT_SEED = 0x7C_3C_45_21_9ABCDEFL;
@@ -185,7 +182,7 @@ public final class TPCCConfiguration {
                 key("c_d_id", 1, c, d),
                 key("c_id", 1, 1, c),
                 col("c_zip", zip()),
-                col("c_last", lastName()),
+                col("c_last", lastName(c)),
                 col("c_credit", credit()),
                 col("c_middle", staticString("OE")),
                 col("c_discount", scaledDecimal(0.0, 0.5, 4)),
@@ -290,8 +287,13 @@ public final class TPCCConfiguration {
         return random -> new DataColumnGenerator.Builder(random).build();
     }
 
-    private static ColumnGeneratorFactory lastName() {
-        return random -> new CustomerLastNameGenerator.Builder(random).build();
+    /**
+     * {@code c_last}: enumerates the first {@link #DEFAULT_ENUMERATED_LAST_NAMES} names per
+     * district deterministically (clause 4.3.3.1), using {@code NURand} for the remainder.
+     */
+    private static ColumnGeneratorFactory lastName(int customersPerDistrict) {
+        return random -> new CustomerLastNameGenerator.Builder(random)
+                .groupSize(customersPerDistrict).enumeratedCount(DEFAULT_ENUMERATED_LAST_NAMES).build();
     }
 
     private static ColumnGeneratorFactory credit() {

--- a/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -18,6 +18,7 @@ package io.bloviate.db;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.gen.tpcc.CustomerLastNameGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -89,11 +90,19 @@ public class BaseDatabaseTestCase {
         assertCount(connection, "select count(*) from order_line l join open_order o "
                 + "on l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id where l.ol_number > o.o_ol_cnt", 0);
 
-        // gap 4: o_c_id is a per-district random permutation of customer ids (each customer
+        // gap 4 part A: o_c_id is a per-district random permutation of customer ids (each customer
         // has exactly one order) — within range and with no duplicate within a district
         assertCount(connection, "select count(*) from open_order where o_c_id < 1 or o_c_id > " + customers, 0);
         assertCount(connection, "select count(*) from "
                 + "(select o_w_id, o_d_id, o_c_id from open_order group by o_w_id, o_d_id, o_c_id having count(*) > 1) dup", 0);
+
+        // gap 4 part B: c_last enumerates the first names per district deterministically. These tests
+        // use fewer than 1000 customers, so every customer is enumerated: c_id = k+1 -> lastName(k).
+        int enumerated = Math.min(customers, CustomerLastNameGenerator.MAX_ENUMERATED);
+        for (int k = 0; k < enumerated; k++) {
+            assertCount(connection, "select count(*) from customer where c_id = " + (k + 1)
+                    + " and c_last <> '" + CustomerLastNameGenerator.lastName(k) + "'", 0);
+        }
 
         // gap 1: new_order holds only the most-recent orders per district (highest o_id values)
         assertCount(connection, "select count(*) from new_order where no_o_id < " + (customers - newOrders + 1), 0);

--- a/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -89,6 +89,12 @@ public class BaseDatabaseTestCase {
         assertCount(connection, "select count(*) from order_line l join open_order o "
                 + "on l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id where l.ol_number > o.o_ol_cnt", 0);
 
+        // gap 4: o_c_id is a per-district random permutation of customer ids (each customer
+        // has exactly one order) — within range and with no duplicate within a district
+        assertCount(connection, "select count(*) from open_order where o_c_id < 1 or o_c_id > " + customers, 0);
+        assertCount(connection, "select count(*) from "
+                + "(select o_w_id, o_d_id, o_c_id from open_order group by o_w_id, o_d_id, o_c_id having count(*) > 1) dup", 0);
+
         // gap 1: new_order holds only the most-recent orders per district (highest o_id values)
         assertCount(connection, "select count(*) from new_order where no_o_id < " + (customers - newOrders + 1), 0);
 

--- a/src/test/java/io/bloviate/gen/GroupedPermutationGeneratorTest.java
+++ b/src/test/java/io/bloviate/gen/GroupedPermutationGeneratorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GroupedPermutationGeneratorTest {
+
+    private static GroupedPermutationGenerator generator(int groupSize, int start, long seed) {
+        return new GroupedPermutationGenerator.Builder(new Random()).groupSize(groupSize).start(start).seed(seed).build();
+    }
+
+    @Test
+    void eachGroupIsAPermutationOfTheRange() {
+        int groupSize = 50;
+        int start = 1;
+        int groups = 40;
+        GroupedPermutationGenerator generator = generator(groupSize, start, 12345);
+
+        for (int g = 0; g < groups; g++) {
+            Set<Integer> seen = new HashSet<>();
+            for (int i = 0; i < groupSize; i++) {
+                int value = generator.generate();
+                assertTrue(value >= start && value < start + groupSize, "out of range: " + value);
+                assertTrue(seen.add(value), "duplicate within group " + g + ": " + value);
+            }
+            assertEquals(groupSize, seen.size(), "group " + g + " is not a full permutation");
+        }
+    }
+
+    @Test
+    void worksForNonPowerOfTwoAndOddSizes() {
+        for (int groupSize : new int[]{1, 2, 3, 7, 13, 100, 999, 3000}) {
+            GroupedPermutationGenerator generator = generator(groupSize, 0, 777);
+            Set<Integer> seen = new HashSet<>();
+            for (int i = 0; i < groupSize; i++) {
+                seen.add(generator.generate());
+            }
+            assertEquals(groupSize, seen.size(), "size " + groupSize + " did not produce a permutation");
+            assertTrue(seen.stream().allMatch(v -> v >= 0 && v < groupSize), "out of range for size " + groupSize);
+        }
+    }
+
+    @Test
+    void groupSizeOneAlwaysReturnsStart() {
+        GroupedPermutationGenerator generator = generator(1, 5, 1);
+        for (int i = 0; i < 100; i++) {
+            assertEquals(5, generator.generate().intValue());
+        }
+    }
+
+    @Test
+    void isDeterministicForAFixedSeed() {
+        GroupedPermutationGenerator a = generator(64, 1, 2024);
+        GroupedPermutationGenerator b = generator(64, 1, 2024);
+        for (int i = 0; i < 256; i++) {
+            assertEquals(a.generate(), b.generate());
+        }
+    }
+
+    @Test
+    void actuallyShufflesAndDiffersAcrossGroups() {
+        int groupSize = 100;
+        GroupedPermutationGenerator generator = generator(groupSize, 0, 99);
+
+        int[] first = new int[groupSize];
+        int[] second = new int[groupSize];
+        boolean firstIsIdentity = true;
+        for (int i = 0; i < groupSize; i++) {
+            first[i] = generator.generate();
+            firstIsIdentity &= (first[i] == i);
+        }
+        for (int i = 0; i < groupSize; i++) {
+            second[i] = generator.generate();
+        }
+
+        assertFalse(firstIsIdentity, "permutation should not be the identity for this seed/size");
+
+        boolean differsAcrossGroups = false;
+        for (int i = 0; i < groupSize; i++) {
+            differsAcrossGroups |= (first[i] != second[i]);
+        }
+        assertTrue(differsAcrossGroups, "consecutive groups should have independent permutations");
+    }
+
+    @Test
+    void rejectsInvalidGroupSize() {
+        assertThrows(IllegalArgumentException.class, () -> generator(0, 0, 1));
+        assertThrows(IllegalArgumentException.class, () -> generator(-5, 0, 1));
+    }
+}

--- a/src/test/java/io/bloviate/gen/tpcc/TPCCConfigurationTest.java
+++ b/src/test/java/io/bloviate/gen/tpcc/TPCCConfigurationTest.java
@@ -22,6 +22,7 @@ import io.bloviate.gen.DataGenerator;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
@@ -126,5 +127,25 @@ class TPCCConfigurationTest {
     void fixedLineCountGivesClosedFormOrderLineRowCount() {
         Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, 7, 7, NEW_ORDERS);
         assertEquals((long) W * D * C * 7, table(tables, "order_line").rowCount());
+    }
+
+    @Test
+    void orderCustomerIdIsAPerDistrictPermutation() {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+        DataGenerator<?> oCId = generator(table(tables, "open_order"), "o_c_id");
+
+        long districts = (long) W * D;
+        boolean sawShuffle = false;
+        for (long dist = 0; dist < districts; dist++) {
+            Set<Integer> seen = new HashSet<>();
+            for (int position = 0; position < C; position++) {
+                int value = (Integer) oCId.generate();
+                assertTrue(value >= 1 && value <= C, "o_c_id out of range: " + value);
+                assertTrue(seen.add(value), "duplicate o_c_id within a district: " + value);
+                sawShuffle |= (value != position + 1);
+            }
+            assertEquals(C, seen.size(), "o_c_id is not a full permutation of customers in a district");
+        }
+        assertTrue(sawShuffle, "expected o_c_id to be shuffled, not the identity");
     }
 }

--- a/src/test/java/io/bloviate/gen/tpcc/TpccGeneratorsTest.java
+++ b/src/test/java/io/bloviate/gen/tpcc/TpccGeneratorsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TpccGeneratorsTest {
@@ -87,5 +88,31 @@ class TpccGeneratorsTest {
             assertTrue(value.length() >= 9 && value.length() <= 15, "unexpected length: " + value);
             assertTrue(value.chars().allMatch(Character::isUpperCase), "expected upper-case letters: " + value);
         }
+    }
+
+    @Test
+    void customerLastNameEnumeratesFirstNamesPerDistrictThenUsesNurand() {
+        int groupSize = 10;
+        int enumerated = 4;
+        CustomerLastNameGenerator generator = new CustomerLastNameGenerator.Builder(new Random(1))
+                .groupSize(groupSize).enumeratedCount(enumerated).build();
+
+        // walk two full districts; the enumeration must restart at each district boundary
+        for (int district = 0; district < 2; district++) {
+            for (int position = 0; position < enumerated; position++) {
+                assertEquals(CustomerLastNameGenerator.lastName(position), generator.generate(),
+                        "enumerated name mismatch at district " + district + " position " + position);
+            }
+            for (int position = enumerated; position < groupSize; position++) {
+                String value = generator.generate(); // NURand path -> still a valid three-syllable name
+                assertTrue(value.length() >= 9 && value.length() <= 15, "unexpected length: " + value);
+            }
+        }
+    }
+
+    @Test
+    void customerLastNameRejectsEnumeratedCountAboveSpecMaximum() {
+        assertThrows(IllegalArgumentException.class, () -> new CustomerLastNameGenerator.Builder(new Random(1))
+                .groupSize(2000).enumeratedCount(CustomerLastNameGenerator.MAX_ENUMERATED + 1).build());
     }
 }


### PR DESCRIPTION
Closes **gap 4** of #421 (both halves).

> **Stacked on #438** (gap 2), which is stacked on #437 (gaps 1 & 3). Base is `feat/tpcc-fidelity-gap2` so the diff shows only the gap-4 changes — retarget down the stack as the parents merge.

## Part A — `o_c_id` permutation (generic)
Within each district, `o_c_id` is now a random permutation of customer ids `1..C` (each customer has exactly one order) instead of the identity `o_c_id = o_id`.

The "shuffled 1:1 assignment within a group" need recurs beyond TPC-C (shuffled foreign keys, anonymised sequential ids, sampling-without-replacement within partitions), so this is a general primitive in `io.bloviate.gen`:

- **`GroupedPermutationGenerator`** — a deterministic permutation of `[start, start+groupSize)` within each consecutive run of `groupSize` rows, re-keyed per group. Backed by a keyed **Feistel network with cycle-walking** — a bijection on `[0, groupSize)` with **no materialised shuffle array**, so memory is **O(1)** at any scale, output is reproducible, and arbitrary (non-power-of-two) sizes work. The injected `Random` is ignored (per-group key = fixed seed + group index), so the engine's FK reseed stays a no-op.

`TPCCConfiguration` wires `o_c_id` with `groupSize = customersPerDistrict`, `start = 1`. FK-valid by construction.

## Part B — `c_last` load enumeration (TPC-C-specific)
Per clause 4.3.3.1, the first 1000 customers of each district now get `c_last` by deterministically enumerating last-name numbers `0..999` (guaranteeing every distinct name is present); only the remaining customers use `NURand`. This half stays in the `tpcc` package — the value is the syllable construction + `NURand`, with little reusable surface.

- `CustomerLastNameGenerator` gains `groupSize` + `enumeratedCount` (default 1000, capped at `MAX_ENUMERATED = 1000`): it tracks each row's position within its district, enumerates `0..enumeratedCount-1` for the prefix, and uses `NURand` for the rest. The number→name construction is extracted to a public static `lastName(int)`. With no grouping configured it falls back to pure `NURand` (back-compatible).

## Remaining simplification
Only delivery state is left simplified (`o_carrier_id` always set, `ol_delivery_d` default) — documented in the `TPCCConfiguration` javadoc.

## Testing
- `GroupedPermutationGeneratorTest` — permutation property across many groups and odd/non-power-of-two sizes, determinism, group-size 1, actual shuffling + independent per-group orderings, invalid-size rejection.
- `TPCCConfigurationTest` — `o_c_id` is a per-district permutation of `1..C` and is shuffled.
- `TpccGeneratorsTest` — `c_last` enumeration restarts per district, the `NURand` branch still yields valid names, and over-max `enumeratedCount` is rejected.
- The Postgres/MySQL/CockroachDB filler tests assert both on live DBs: `o_c_id` range + no-duplicate-per-district ⇒ permutation, and `c_id = k+1 → lastName(k)` (customers < 1000 ⇒ all enumerated).
- `./mvnw verify` — **120 tests, 0 failures** across all three databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)