### PR TITLE
docs: refocus README on usage, split build/contribute into CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to Bloviate
+
+Thanks for your interest in improving Bloviate! This guide covers how to build the
+project locally, run the test suite, and submit changes.
+
+## Prerequisites
+
+- **Java 25 or higher** (the build targets `--release 25`)
+- **Maven** — use the bundled wrapper (`./mvnw`); no separate install required
+- **Docker** — required to run the integration tests, which spin up real databases
+  via [TestContainers](https://testcontainers.com/). [OrbStack](https://orbstack.dev/)
+  or Docker Desktop both work.
+
+## Building the Project
+
+```bash
+# Compile the project
+./mvnw compile
+
+# Compile, run all tests, and verify
+./mvnw verify
+
+# Package the JAR
+./mvnw package
+
+# Clean and recompile from scratch
+./mvnw clean compile
+```
+
+## Running Tests
+
+The project uses TestContainers for integration testing against real databases, so
+Docker must be running.
+
+```bash
+# Run all tests
+./mvnw test
+
+# Run a specific test class
+./mvnw test -Dtest=PostgresFillerTest
+
+# Run database-specific integration tests
+./mvnw test -Dtest=PostgresFillerTest
+./mvnw test -Dtest=MySqlFillerTest
+./mvnw test -Dtest=CockroachDBFillerTest
+```
+
+Test schemas live under `src/test/resources/` (TPCC, AuctionMark, Wikipedia, and
+others). `BaseDatabaseTestCase` provides the shared `DataSource` plumbing and the
+fidelity assertions used by the TPC-C tests.
+
+## Local Databases with Docker
+
+The `docker/` directory contains throwaway database instances for manual
+experimentation (separate from the TestContainers used in tests):
+
+```bash
+# PostgreSQL
+cd docker/postgres && ./up.sh
+
+# MySQL
+cd docker/mysql && ./up.sh
+
+# CockroachDB
+cd docker/crdb && ./up.sh
+```
+
+Each directory provides `up.sh`, `down.sh`, and `prune.sh` scripts.
+
+## Submitting Changes
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feat/amazing-feature`)
+3. Make your changes, following the commit message format below
+4. Ensure `./mvnw verify` passes (tests included)
+5. Push to your fork (`git push origin feat/amazing-feature`)
+6. Open a Pull Request
+
+> **Note:** PR **titles** are validated by commitlint and must follow the
+> Conventional Commits format described below.
+
+### Commit & PR Title Format
+
+This project uses [Conventional Commits](https://conventionalcommits.org/) to drive
+automatic semantic versioning via semantic-release:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+**Commit types and version impact:**
+
+| Type | Version bump |
+|------|--------------|
+| `feat:` | Minor (new feature) |
+| `fix:` | Patch (bug fix) |
+| `perf:` | Patch (performance) |
+| `refactor:` | Patch (refactor) |
+| `feat!:` or `BREAKING CHANGE:` | Major |
+| `docs:`, `style:`, `test:`, `ci:`, `chore:` | None |
+
+**Examples:**
+
+```bash
+git commit -m "feat(database): add connection pooling support"
+git commit -m "fix(generator): resolve null pointer in StringGenerator"
+git commit -m "docs: update installation instructions"
+```
+
+### Development Guidelines
+
+- Follow existing code style and conventions
+- Add tests for new features
+- Update documentation as needed
+- Ensure all tests pass (`./mvnw verify`) before submitting a PR
+- Use conventional commit messages — and a conventional PR title — for automatic
+  versioning
+
+## Getting Help
+
+- **Issues**: [GitHub Issues](https://github.com/timveil/bloviate/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/timveil/bloviate/discussions)
+- **Email**: tjveil@gmail.com

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ A powerful Java library for generating realistic test data for JDBC-compatible r
 ## 🚀 Features
 
 - **Automatic Schema Discovery**: Connects to existing databases and analyzes table structure, relationships, and constraints
-- **Smart Data Generation**: Generates appropriate data based on column types and database-specific features  
+- **Smart Data Generation**: Generates appropriate data based on column types and database-specific features
 - **Foreign Key Support**: Handles complex table dependencies using topological sorting
+- **Per-Column Control**: Override generation for individual columns with custom, reproducible generators
+- **Composite Keys & Referential Fidelity**: Generate collision-free composite keys and variable parent/child cardinalities that keep foreign keys consistent
+- **Benchmark-Ready**: Built-in TPC-C dataset configuration, with reusable building blocks for other benchmark schemas
 - **Multiple Database Support**: PostgreSQL, MySQL, CockroachDB with extensible architecture
 - **Flat File Generation**: Export data to CSV, TSV, and pipe-delimited formats
 - **Configurable Output**: Control batch sizes, record counts, and custom data generation rules
@@ -19,14 +22,20 @@ A powerful Java library for generating realistic test data for JDBC-compatible r
 
 ## 📋 Table of Contents
 
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Database Support](#database-support)
-- [Usage Examples](#usage-examples)
-- [Configuration](#configuration)
-- [Development](#development)
-- [Contributing](#contributing)
-- [License](#license)
+- [Installation](#-installation)
+- [Quick Start](#-quick-start)
+- [Database Support](#-database-support)
+- [Usage Examples](#-usage-examples)
+  - [Per-Table Row Counts](#per-table-row-counts)
+  - [Per-Column Generation Overrides](#per-column-generation-overrides)
+  - [Composite Keys & Foreign Key Fidelity](#composite-keys--foreign-key-fidelity)
+  - [Variable Parent/Child Cardinality](#variable-parentchild-cardinality)
+  - [TPC-C Benchmark Data](#tpc-c-benchmark-data)
+  - [Flat File Formats](#flat-file-formats)
+  - [Data Generator Types](#data-generator-types)
+- [Configuration](#-configuration)
+- [Contributing](#-contributing)
+- [License](#-license)
 
 ## 📦 Installation
 
@@ -128,30 +137,204 @@ DatabaseSupport support = DatabaseSupport.forConnection(connection);
 
 ## 📖 Usage Examples
 
-### Advanced Database Configuration
+By default Bloviate inspects the schema and picks a generator for every column based
+on its JDBC type. The examples below show how to take progressively more control —
+from overriding row counts, to overriding individual columns, all the way to
+generating fully referentially-consistent benchmark datasets with composite keys.
+
+Configuration is layered:
+
+- **`DatabaseConfiguration`** — global defaults: batch size, default row count,
+  database support, and an optional set of per-table overrides.
+- **`TableConfiguration`** — overrides the row count for one table, and optionally
+  carries per-column overrides.
+- **`ColumnConfiguration`** — overrides how a single column is generated, via a
+  `ColumnGeneratorFactory` (a `Random -> DataGenerator<?>` lambda). The engine hands
+  the factory a column-seeded `Random` so output stays reproducible.
+
+### Per-Table Row Counts
+
+Generate different numbers of rows for specific tables while every other table uses
+the default:
 
 ```java
 import io.bloviate.db.*;
+import io.bloviate.ext.PostgresSupport;
 import java.util.Set;
 
-// Per-table overrides (each TableConfiguration names its table; 50 rows for "users")
+// "users" gets 50 rows; all other tables fall back to the default (100)
 Set<TableConfiguration> tableConfigs = Set.of(
     new TableConfiguration("users", 50)
 );
 
 DatabaseConfiguration config = new DatabaseConfiguration(
     10,                    // batch size
-    100,                   // default records per table
+    100,                   // default rows per table
     new PostgresSupport(), // database support
     tableConfigs           // table-specific overrides
 );
 
-DatabaseFiller filler = new DatabaseFiller.Builder(connection, config)
-    .build();
-filler.fill();
+new DatabaseFiller.Builder(connection, config)
+    .build()
+    .fill();
 ```
 
-### Different File Formats
+### Per-Column Generation Overrides
+
+Pin a specific column to a custom generator. Here the `status_code` column on
+`orders` is constrained to integers in `[1, 10)` instead of the type's default:
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.IntegerGenerator;
+import java.util.Set;
+
+// ColumnGeneratorFactory is a `Random -> DataGenerator<?>` lambda.
+// The engine supplies a column-seeded Random for reproducible output.
+Set<ColumnConfiguration> columnConfigs = Set.of(
+    new ColumnConfiguration("status_code",
+        random -> new IntegerGenerator.Builder(random).start(1).end(10).build())
+);
+
+// 1,000 rows for "orders", with the column override applied
+Set<TableConfiguration> tableConfigs = Set.of(
+    new TableConfiguration("orders", 1000, columnConfigs)
+);
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    128, 100, new PostgresSupport(), tableConfigs);
+
+new DatabaseFiller.Builder(connection, config)
+    .build()
+    .fill();
+```
+
+Column names are matched **case-insensitively**. Any column without an override keeps
+its default, type-based generator.
+
+### Composite Keys & Foreign Key Fidelity
+
+For schemas with composite primary keys, `CompositeKeyComponentGenerator` fills each
+key component as one dimension of a dense, row-ordered **cartesian product**. Each
+component emits `start + ((rowNumber / repeat) % cycle)`, so a table receives exactly
+its cartesian cardinality of rows with unique, collision-free keys — and a child
+table reusing the *same* formula produces foreign keys that line up exactly with its
+parent's keys.
+
+For example, a `stock` table keyed by `(s_w_id, s_i_id)` across 2 warehouses × 10
+items (20 rows) — `repeat` for the outer dimension is the size of the inner one:
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.gen.CompositeKeyComponentGenerator;
+import java.util.Set;
+
+int warehouses = 2, items = 10;
+
+Set<ColumnConfiguration> stockKey = Set.of(
+    // outer dimension: changes every `items` rows, cycles through warehouses
+    new ColumnConfiguration("s_w_id",
+        r -> new CompositeKeyComponentGenerator.Builder(r)
+                .start(1).repeat(items).cycle(warehouses).build()),
+    // inner dimension: changes every row, cycles through items
+    new ColumnConfiguration("s_i_id",
+        r -> new CompositeKeyComponentGenerator.Builder(r)
+                .start(1).repeat(1).cycle(items).build())
+);
+
+Set<TableConfiguration> tableConfigs = Set.of(
+    new TableConfiguration("stock", (long) warehouses * items, stockKey)
+);
+// → (1,1) (1,2) ... (1,10) (2,1) ... (2,10): every pair exactly once
+```
+
+### Variable Parent/Child Cardinality
+
+Real schemas rarely have a fixed number of children per parent (an order has *some*
+number of line items). `ChildCardinality` assigns each parent a deterministic child
+count in `[min, max]`, and the matching generators keep a parent table and its child
+table perfectly in sync — no shared mutable state, O(1) memory, reproducible from a
+seed.
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.gen.*;
+import java.util.Set;
+
+long orders = 1000;
+
+// each order gets 1–10 lines; the same seed makes the split reproducible
+ChildCardinality cardinality = new ChildCardinality(1, 10, 42L);
+long orderLineRows = cardinality.total(orders); // exact total, computed up front
+
+// parent: a column holding each order's line count
+Set<ColumnConfiguration> orderCols = Set.of(
+    new ColumnConfiguration("line_count",
+        r -> new ChildCountGenerator.Builder(r).cardinality(cardinality).build())
+);
+
+// child: parent key repeated per line, plus a 1-based line sequence
+Set<ColumnConfiguration> lineCols = Set.of(
+    new ColumnConfiguration("order_id",
+        r -> new ChildKeyComponentGenerator.Builder(r)
+                .cardinality(cardinality).start(1).repeat(1).cycle((int) orders).build()),
+    new ColumnConfiguration("line_number",
+        r -> new ChildKeyComponentGenerator.Builder(r)
+                .cardinality(cardinality).sequence().start(1).build())
+);
+
+Set<TableConfiguration> tableConfigs = Set.of(
+    new TableConfiguration("orders", orders, orderCols),
+    new TableConfiguration("order_lines", orderLineRows, lineCols)
+);
+```
+
+### TPC-C Benchmark Data
+
+Bloviate ships a ready-made configuration for the full **TPC-C** schema. A single
+call wires up all nine tables with spec-faithful cardinalities, composite keys,
+foreign-key fidelity, variable order-line counts, per-district customer-id
+permutations, deterministic last-name enumeration, and delivery state — matching the
+TPC-C initial database population (clause 4.3.3.1).
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
+import java.util.Set;
+
+// Build all TPC-C table configs for a given scale factor (number of warehouses)
+Set<TableConfiguration> tpcc = TPCCConfiguration.build(2);
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    128, 100, new PostgresSupport(), tpcc);
+
+new DatabaseFiller.Builder(connection, config)
+    .build()
+    .fill();
+```
+
+Need finer control over the cardinalities? An overload exposes every dimension:
+
+```java
+Set<TableConfiguration> tpcc = TPCCConfiguration.build(
+    2,    // warehouses (scale factor)
+    100,  // items
+    10,   // districts per warehouse
+    3000, // customers (and orders) per district
+    5,    // min order lines per order
+    15    // max order lines per order
+);
+```
+
+The corresponding DDL lives in `src/test/resources/create_tpcc.{postgres,mysql,cockroachdb}.sql`.
+The reusable building blocks behind `TPCCConfiguration` — `CompositeKeyComponentGenerator`,
+`ChildCardinality`, `GroupedPermutationGenerator` (per-group shuffles), and
+`GroupedPrefixGenerator` (nullable/sparse columns) — live in `io.bloviate.gen` and can
+be composed for other benchmark schemas (TPC-H, TPC-DS, and so on).
+
+### Flat File Formats
 
 ```java
 import io.bloviate.file.*;
@@ -197,7 +380,19 @@ new InstantGenerator.Builder(random).build()
 new BooleanGenerator.Builder(random).build()
 new JsonbGenerator.Builder(random).build()
 new InetGenerator.Builder(random).build()
+
+// Constant / fixed-scale generators (handy for column overrides)
+new StaticStringGenerator.Builder(random).value("OE").build()
+new StaticIntegerGenerator.Builder(random).value(0).build()
+new ScaledBigDecimalGenerator.Builder(random).start(0.0).end(0.2).scale(4).build()
+
+// Deterministic / sequential generators
+new SequentialIntegerGenerator.Builder(random).start(1).end(1000).build()
 ```
+
+Additional generators cover `Long`, `Float`, `Byte`, `Short`, `Character`,
+`java.sql` date/time types, arrays, and CockroachDB-specific types (bit strings,
+intervals). See the `io.bloviate.gen` package for the full set.
 
 ## ⚙️ Configuration
 
@@ -206,7 +401,8 @@ new InetGenerator.Builder(random).build()
 - **Batch Size**: Number of records inserted in each batch operation
 - **Record Count**: Default number of records to generate per table
 - **Database Support**: Database-specific implementation for optimal compatibility
-- **Table Configurations**: Override settings for specific tables
+- **Table Configurations**: Override the row count for specific tables
+- **Column Configurations**: Override the generator for specific columns (case-insensitive, reproducible)
 
 ### File Generation Options
 
@@ -214,94 +410,17 @@ new InetGenerator.Builder(random).build()
 - **Row Count**: Number of rows to generate
 - **Custom Column Definitions**: Full control over data generation
 
-## 🛠️ Development
-
-### Building the Project
-
-```bash
-# Compile the project
-./mvnw compile
-
-# Run tests
-./mvnw test
-
-# Package the JAR
-./mvnw package
-```
-
-### Running Tests
-
-The project uses TestContainers for integration testing with real databases:
-
-```bash
-# Run all tests
-./mvnw test
-
-# Run specific database tests
-./mvnw test -Dtest=PostgresFillerTest
-./mvnw test -Dtest=MySqlFillerTest
-./mvnw test -Dtest=CockroachDBFillerTest
-```
-
-### Docker Support
-
-Start local database instances for development:
-
-```bash
-# PostgreSQL
-cd docker/postgres && ./up.sh
-
-# MySQL  
-cd docker/mysql && ./up.sh
-
-# CockroachDB
-cd docker/crdb && ./up.sh
-```
-
 ## 🤝 Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes following our commit message format
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+Contributions are welcome! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for how to build
+the project, run the test suite, spin up local databases, and submit pull requests.
 
-### Commit Message Format
+A couple of highlights:
 
-This project uses [Conventional Commits](https://conventionalcommits.org/) for automatic semantic versioning:
-
-```
-<type>(<scope>): <description>
-
-[optional body]
-
-[optional footer]
-```
-
-**Commit types and version impact:**
-- `feat:` → Minor version bump (new features)
-- `fix:` → Patch version bump (bug fixes) 
-- `perf:` → Patch version bump (performance improvements)
-- `refactor:` → Patch version bump (code refactoring)
-- `feat!:` or `BREAKING CHANGE:` → Major version bump
-
-**No version bump:**
-- `docs:`, `style:`, `test:`, `ci:`, `chore:`
-
-**Examples:**
-```bash
-git commit -m "feat(database): add connection pooling support"
-git commit -m "fix(generator): resolve null pointer in StringGenerator"  
-git commit -m "docs: update installation instructions"
-```
-
-### Development Guidelines
-
-- Follow existing code style and conventions
-- Add tests for new features
-- Update documentation as needed
-- Ensure all tests pass before submitting PR
-- Use conventional commit messages for automatic versioning
+- The project targets **Java 25** and uses **TestContainers** (so Docker is required to
+  run the integration tests).
+- Commit messages **and PR titles** follow [Conventional Commits](https://conventionalcommits.org/),
+  which drives automatic semantic versioning.
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary

Refocuses the README on **what/why/how-to-use** and moves all build, test, Docker, and contribution-workflow content into a new `CONTRIBUTING.md`.

### CONTRIBUTING.md (new)
- Prerequisites (Java 25, Maven wrapper, Docker for TestContainers)
- Building (`./mvnw compile|verify|package`) and running tests
- Local databases via the `docker/` scripts
- PR workflow, Conventional Commits table, and the **PR-title-must-be-conventional** note (commitlint enforces it)

### README.md
- Trimmed the Development/Contributing sections down to a pointer to `CONTRIBUTING.md`
- Expanded **Usage Examples** to cover the column-config and TPC-C work:
  - Per-column generation overrides (`ColumnConfiguration` + `ColumnGeneratorFactory`)
  - Composite keys & FK fidelity (`CompositeKeyComponentGenerator` cartesian products)
  - Variable parent/child cardinality (`ChildCardinality` / `ChildCountGenerator` / `ChildKeyComponentGenerator`)
  - TPC-C benchmark data (`TPCCConfiguration.build(...)`)
- Added new Features bullets, TOC entries, and constrained/specialized generators to the generator list

All example snippets use real signatures pulled from the source, so they're copy-paste accurate. Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)