### PR TITLE
feat(ext): full PostgreSQL and MySQL vendor-type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,29 @@ new FlatFileGenerator.Builder("output/users")
 
 ## 🗄️ Database Support
 
-| Database | Support Class | Status |
-|----------|---------------|--------|
-| PostgreSQL | `PostgresSupport` | ✅ Full Support |
-| MySQL | `MySQLSupport` | ✅ Full Support |
-| CockroachDB | `CockroachDBSupport` | ✅ Full Support |
-| Generic JDBC | `DefaultSupport` | ⚠️ Basic Support |
+| Database | Support Class | Coverage |
+|----------|---------------|----------|
+| PostgreSQL | `PostgresSupport` | Standard JDBC types **plus** PostgreSQL vendor types |
+| CockroachDB | `CockroachDBSupport` | Extends `PostgresSupport` (CockroachDB is wire-compatible) |
+| MySQL | `MySQLSupport` | Standard JDBC types **plus** `JSON` |
+| Generic JDBC | `DefaultSupport` | Standard JDBC types only |
+
+All four resolve the cross-database defaults for the common JDBC types (integers,
+decimals, strings, dates/times, booleans, binary, …). `PostgresSupport` and
+`MySQLSupport` add handling for vendor-specific types on top of those defaults.
+
+**PostgreSQL vendor types:** `uuid`, `json`, `jsonb`, `inet`, `cidr`, `macaddr`,
+`macaddr8`, `interval`, `bit`/`bit varying`, `xml`, and `text`/`integer`/`bigint`
+arrays.
+
+**MySQL vendor types:** `JSON` (generated as valid JSON rather than arbitrary text).
+`ENUM`, `SET`, `GEOMETRY`, and `YEAR` are **not** supported — they need value-aware or
+binary generation that standard JDBC metadata doesn't expose.
+
+> **PostgreSQL connection requirement:** the vendor types above are bound as their text
+> representations, and PostgreSQL won't implicitly cast `varchar` to `uuid`/`jsonb`/`bit`/etc.
+> Open the connection with `stringtype=unspecified` so the server infers each column's type:
+> `jdbc:postgresql://host/db?stringtype=unspecified`.
 
 You can let Bloviate pick the support implementation from the connection's
 metadata instead of hardcoding it:
@@ -130,10 +147,10 @@ metadata instead of hardcoding it:
 DatabaseSupport support = DatabaseSupport.forConnection(connection);
 ```
 
-> **Note:** CockroachDB is reached through the PostgreSQL JDBC driver and
-> reports its product name as `PostgreSQL`, so auto-selection resolves it to
-> `PostgresSupport`. To use the CockroachDB-specific generators, pass
-> `new CockroachDBSupport()` explicitly.
+> **Note:** CockroachDB is reached through the PostgreSQL JDBC driver and reports its
+> product name as `PostgreSQL`, so auto-selection resolves it to `PostgresSupport`.
+> Because `CockroachDBSupport` extends `PostgresSupport` and adds no extra behavior, the
+> two are equivalent for data generation.
 
 ## 📖 Usage Examples
 

--- a/src/main/java/io/bloviate/ext/CockroachDBSupport.java
+++ b/src/main/java/io/bloviate/ext/CockroachDBSupport.java
@@ -16,54 +16,19 @@
 
 package io.bloviate.ext;
 
-import io.bloviate.gen.*;
-
-import java.sql.JDBCType;
-import java.util.Map;
-
 /**
- * CockroachDB-specific implementation of database support.
- * Provides CockroachDB-specific data generation and type mapping logic,
- * including support for CockroachDB's PostgreSQL-compatible types and
- * specialized data types like arrays, UUID, JSONB, and intervals.
+ * CockroachDB-specific {@link DatabaseSupport}.
+ *
+ * <p>CockroachDB is reached through the PostgreSQL JDBC driver and is wire-compatible with
+ * PostgreSQL, so its columns surface through JDBC exactly as PostgreSQL's do (UUID, JSONB,
+ * INET, INTERVAL, bit strings, and {@code _text}/{@code _int4}/{@code _int8} arrays). This
+ * class therefore extends {@link PostgresSupport} and inherits its full type handling; it
+ * exists as a distinct type for explicit selection and product-name resolution.
  *
  * @since 1.0.0
- * @see AbstractDatabaseSupport
+ * @see PostgresSupport
  * @see DatabaseSupport
  */
-public class CockroachDBSupport extends AbstractDatabaseSupport {
+public class CockroachDBSupport extends PostgresSupport {
 
-    @Override
-    protected void configure(Map<JDBCType, GeneratorFactory> registry) {
-        // CockroachDB BIT and BIT(n) are bit strings, not integers/booleans, so always
-        // generate a bit string -- including the single-bit case (the generic default
-        // would emit an integer for BIT(1), which CockroachDB rejects).
-        registry.put(JDBCType.BIT, (column, random) ->
-                new BitStringGenerator.Builder(random).size(column.maxSize()).build());
-
-        // ARRAY and OTHER are dispatched on the driver-reported type name.
-        registry.put(JDBCType.ARRAY, (column, random) -> {
-            if ("_text".equalsIgnoreCase(column.typeName())) {
-                return new StringArrayGenerator.Builder(random).build();
-            } else if ("_int8".equalsIgnoreCase(column.typeName()) || "_int4".equalsIgnoreCase(column.typeName())) {
-                return new IntegerArrayGenerator.Builder(random).build();
-            }
-            throw new UnsupportedOperationException("Data Type [" + column.typeName() + "] for ARRAY not supported");
-        });
-
-        registry.put(JDBCType.OTHER, (column, random) -> {
-            if ("uuid".equalsIgnoreCase(column.typeName())) {
-                return new UUIDGenerator.Builder(random).build();
-            } else if ("varbit".equalsIgnoreCase(column.typeName())) {
-                return new BitStringGenerator.Builder(random).size(column.maxSize()).build();
-            } else if ("inet".equalsIgnoreCase(column.typeName())) {
-                return new InetGenerator.Builder(random).build();
-            } else if ("interval".equalsIgnoreCase(column.typeName())) {
-                return new IntervalGenerator.Builder(random).build();
-            } else if ("jsonb".equalsIgnoreCase(column.typeName())) {
-                return new JsonbGenerator.Builder(random).build();
-            }
-            throw new UnsupportedOperationException("Data Type [" + column.typeName() + "] for OTHER not supported");
-        });
-    }
 }

--- a/src/main/java/io/bloviate/ext/DatabaseSupport.java
+++ b/src/main/java/io/bloviate/ext/DatabaseSupport.java
@@ -65,12 +65,12 @@ public interface DatabaseSupport {
      * {@link MySQLSupport}, and {@code "postgres"} to {@link PostgresSupport}. Anything
      * else (including {@code null}) falls back to {@link DefaultSupport}.
      *
-     * <p><strong>CockroachDB caveat:</strong> CockroachDB is typically reached through the
-     * PostgreSQL JDBC driver, which reports its product name as {@code "PostgreSQL"}. Such
-     * connections therefore resolve to {@link PostgresSupport}, not
-     * {@link CockroachDBSupport}. To use the CockroachDB-specific generators (jsonb, inet,
-     * arrays, bit strings, ...), pass {@code new CockroachDBSupport()} explicitly rather
-     * than relying on auto-selection.
+     * <p><strong>CockroachDB note:</strong> CockroachDB is typically reached through the
+     * PostgreSQL JDBC driver, which reports its product name as {@code "PostgreSQL"}, so such
+     * connections resolve to {@link PostgresSupport}. Because {@link CockroachDBSupport}
+     * extends {@link PostgresSupport} and adds no extra behavior, this resolves the same
+     * type handling (uuid, jsonb, inet, intervals, arrays, bit strings, ...); passing
+     * {@code new CockroachDBSupport()} explicitly is equivalent.
      *
      * @param productName the database product name, may be null
      * @return the matching support, or {@link DefaultSupport} if none matches

--- a/src/main/java/io/bloviate/ext/MySQLSupport.java
+++ b/src/main/java/io/bloviate/ext/MySQLSupport.java
@@ -16,11 +16,24 @@
 
 package io.bloviate.ext;
 
+import io.bloviate.gen.JsonbGenerator;
+import io.bloviate.gen.SimpleStringGenerator;
+
+import java.sql.JDBCType;
+import java.util.Map;
+
 /**
- * MySQL-specific implementation of database support.
- * Provides MySQL-specific data generation and type mapping logic.
- * This class inherits default behavior from AbstractDatabaseSupport
- * and can be extended to handle MySQL-specific data types and constraints.
+ * MySQL-specific {@link DatabaseSupport}.
+ *
+ * <p>MySQL's JDBC driver maps most types onto standard JDBC types that the cross-database
+ * defaults already handle. The notable exception is {@code JSON}, which the driver reports
+ * as {@link JDBCType#LONGVARCHAR} (type name {@code JSON}); a random string would fail the
+ * server's JSON validation, so this support routes {@code JSON} columns to a JSON generator
+ * while leaving ordinary text columns on the default string generator.
+ *
+ * <p>Some MySQL types remain unsupported because they need value-aware or binary generation
+ * that standard JDBC metadata doesn't expose: {@code ENUM}/{@code SET} (must match the
+ * declared member list), {@code GEOMETRY} (well-known binary), and {@code YEAR}.
  *
  * @since 1.0.0
  * @see AbstractDatabaseSupport
@@ -28,5 +41,18 @@ package io.bloviate.ext;
  */
 public class MySQLSupport extends AbstractDatabaseSupport {
 
+    @Override
+    protected void configure(Map<JDBCType, GeneratorFactory> registry) {
 
+        // MySQL JSON columns report as LONGVARCHAR with type name "JSON". Generate valid JSON
+        // for those; everything else on this JDBC type stays an ordinary string.
+        registry.put(JDBCType.LONGVARCHAR, (column, random) -> {
+            if ("json".equalsIgnoreCase(column.typeName())) {
+                return new JsonbGenerator.Builder(random).build();
+            }
+            Integer maxSize = column.maxSize();
+            int size = (maxSize == null || maxSize <= 0) ? 2000 : maxSize;
+            return new SimpleStringGenerator.Builder(random).size(size).build();
+        });
+    }
 }

--- a/src/main/java/io/bloviate/ext/PostgresSupport.java
+++ b/src/main/java/io/bloviate/ext/PostgresSupport.java
@@ -16,11 +16,50 @@
 
 package io.bloviate.ext;
 
+import io.bloviate.db.Column;
+import io.bloviate.gen.BitStringGenerator;
+import io.bloviate.gen.BooleanGenerator;
+import io.bloviate.gen.CidrGenerator;
+import io.bloviate.gen.InetGenerator;
+import io.bloviate.gen.IntegerArrayGenerator;
+import io.bloviate.gen.IntervalGenerator;
+import io.bloviate.gen.JsonbGenerator;
+import io.bloviate.gen.MacAddressGenerator;
+import io.bloviate.gen.StringArrayGenerator;
+import io.bloviate.gen.UUIDGenerator;
+import io.bloviate.gen.XmlGenerator;
+
+import java.sql.JDBCType;
+import java.util.Map;
+
 /**
- * PostgreSQL-specific implementation of database support.
- * Provides PostgreSQL-specific data generation and type mapping logic.
- * This class inherits default behavior from AbstractDatabaseSupport
- * and can be extended to handle PostgreSQL-specific data types and constraints.
+ * PostgreSQL-specific {@link DatabaseSupport}.
+ *
+ * <p>On top of the cross-database defaults, this registers generators for the PostgreSQL
+ * types the JDBC driver surfaces as {@link JDBCType#OTHER}, {@link JDBCType#ARRAY},
+ * {@link JDBCType#SQLXML}, and {@link JDBCType#BIT}, dispatching on the driver-reported
+ * type name:
+ *
+ * <ul>
+ *   <li>{@code uuid}, {@code json}, {@code jsonb}, {@code inet}, {@code cidr},
+ *       {@code macaddr}, {@code macaddr8}, {@code interval}, {@code varbit} (all reported
+ *       as {@code OTHER})</li>
+ *   <li>{@code _text}, {@code _int2}, {@code _int4}, {@code _int8} arrays (reported as
+ *       {@code ARRAY})</li>
+ *   <li>{@code xml} (reported as {@code SQLXML})</li>
+ *   <li>{@code bit}/{@code bit(n)} and {@code boolean} (both reported as {@code BIT},
+ *       distinguished by type name)</li>
+ * </ul>
+ *
+ * <p>Because CockroachDB speaks the PostgreSQL wire protocol through the same JDBC driver,
+ * {@link CockroachDBSupport} extends this class and inherits all of the above.
+ *
+ * <p><strong>Connection requirement:</strong> these extension types are generated as their
+ * text representations and bound as strings. PostgreSQL will not implicitly cast
+ * {@code character varying} to {@code uuid}, {@code jsonb}, {@code inet}, {@code bit}, etc.,
+ * so the JDBC connection must be opened with {@code stringtype=unspecified} (e.g.
+ * {@code jdbc:postgresql://host/db?stringtype=unspecified}) for the server to infer each
+ * column's type. Standard column types do not require this.
  *
  * @since 1.0.0
  * @see AbstractDatabaseSupport
@@ -28,5 +67,59 @@ package io.bloviate.ext;
  */
 public class PostgresSupport extends AbstractDatabaseSupport {
 
+    @Override
+    protected void configure(Map<JDBCType, GeneratorFactory> registry) {
 
+        // PostgreSQL reports both bit/bit(n) and boolean as JDBCType.BIT, distinguished by
+        // type name. The generic default would emit an integer for a single bit, which the
+        // server rejects for a bit column.
+        registry.put(JDBCType.BIT, (column, random) -> {
+            if ("bool".equalsIgnoreCase(column.typeName())) {
+                return new BooleanGenerator.Builder(random).build();
+            }
+            return new BitStringGenerator.Builder(random).size(bitStringSize(column)).build();
+        });
+
+        // Arrays are dispatched on the driver-reported element type name.
+        registry.put(JDBCType.ARRAY, (column, random) -> {
+            String typeName = column.typeName();
+            if ("_text".equalsIgnoreCase(typeName)) {
+                return new StringArrayGenerator.Builder(random).build();
+            } else if ("_int8".equalsIgnoreCase(typeName) || "_int4".equalsIgnoreCase(typeName) || "_int2".equalsIgnoreCase(typeName)) {
+                return new IntegerArrayGenerator.Builder(random).build();
+            }
+            throw new UnsupportedOperationException("Data Type [" + typeName + "] for ARRAY not supported");
+        });
+
+        // xml surfaces as its own JDBC type.
+        registry.put(JDBCType.SQLXML, (column, random) -> new XmlGenerator.Builder(random).build());
+
+        // Most PostgreSQL extension types surface as OTHER, dispatched on the type name.
+        registry.put(JDBCType.OTHER, (column, random) -> {
+            String typeName = column.typeName() == null ? "" : column.typeName().toLowerCase();
+            return switch (typeName) {
+                case "uuid" -> new UUIDGenerator.Builder(random).build();
+                case "json", "jsonb" -> new JsonbGenerator.Builder(random).build();
+                case "inet" -> new InetGenerator.Builder(random).build();
+                case "cidr" -> new CidrGenerator.Builder(random).build();
+                case "macaddr" -> new MacAddressGenerator.Builder(random).build();
+                case "macaddr8" -> new MacAddressGenerator.Builder(random).octets(8).build();
+                case "interval" -> new IntervalGenerator.Builder(random).build();
+                case "varbit" -> new BitStringGenerator.Builder(random).size(bitStringSize(column)).build();
+                default -> throw new UnsupportedOperationException("Data Type [" + column.typeName() + "] for OTHER not supported");
+            };
+        });
+    }
+
+    /**
+     * Bit-string length to generate, falling back to a small default when the column reports
+     * no usable length (e.g. unbounded {@code bit varying}).
+     */
+    private static int bitStringSize(Column column) {
+        Integer maxSize = column.maxSize();
+        if (maxSize == null || maxSize <= 0 || maxSize > 256) {
+            return 8;
+        }
+        return maxSize;
+    }
 }

--- a/src/main/java/io/bloviate/gen/CidrGenerator.java
+++ b/src/main/java/io/bloviate/gen/CidrGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates IPv4 CIDR network specifications of the form {@code a.b.c.0/24}.
+ *
+ * <p>The host portion is always zero (a {@code /24} network), so the value is a valid
+ * PostgreSQL {@code cidr} where all bits to the right of the network mask must be zero.
+ */
+public class CidrGenerator extends AbstractDataGenerator<String> {
+
+    private final IntegerGenerator octetGenerator;
+
+    @Override
+    public String generate() {
+        return octetGenerator.generate() + "." + octetGenerator.generate() + "." + octetGenerator.generate() + ".0/24";
+    }
+
+    @Override
+    public String generateAsString() {
+        return generate();
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public CidrGenerator build() {
+            return new CidrGenerator(this);
+        }
+    }
+
+    private CidrGenerator(Builder builder) {
+        super(builder.random);
+        this.octetGenerator = new IntegerGenerator.Builder(random).start(1).end(256).build();
+    }
+}

--- a/src/main/java/io/bloviate/gen/MacAddressGenerator.java
+++ b/src/main/java/io/bloviate/gen/MacAddressGenerator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates MAC addresses as colon-separated hex octets, e.g. {@code 08:00:2b:01:02:03}.
+ *
+ * <p>Defaults to six octets (PostgreSQL {@code macaddr}); set {@link Builder#octets(int)}
+ * to {@code 8} for the EUI-64 {@code macaddr8} form.
+ */
+public class MacAddressGenerator extends AbstractDataGenerator<String> {
+
+    private final int octets;
+    private final IntegerGenerator octetGenerator;
+
+    @Override
+    public String generate() {
+        StringBuilder builder = new StringBuilder(octets * 3);
+        for (int i = 0; i < octets; i++) {
+            if (i > 0) {
+                builder.append(':');
+            }
+            builder.append(String.format("%02x", octetGenerator.generate()));
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public String generateAsString() {
+        return generate();
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        private int octets = 6;
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        public Builder octets(int octets) {
+            this.octets = octets;
+            return this;
+        }
+
+        @Override
+        public MacAddressGenerator build() {
+            return new MacAddressGenerator(this);
+        }
+    }
+
+    private MacAddressGenerator(Builder builder) {
+        super(builder.random);
+        this.octets = builder.octets;
+        this.octetGenerator = new IntegerGenerator.Builder(random).start(0).end(256).build();
+    }
+}

--- a/src/main/java/io/bloviate/gen/XmlGenerator.java
+++ b/src/main/java/io/bloviate/gen/XmlGenerator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+/**
+ * Generates small well-formed XML documents, e.g. {@code <bloviate>a1b2c3d4</bloviate>}.
+ *
+ * <p>The element content is alphanumeric, so the result needs no entity escaping and is
+ * accepted by strict {@code xml} columns (e.g. PostgreSQL {@code xml}).
+ */
+public class XmlGenerator extends AbstractDataGenerator<String> {
+
+    private final SimpleStringGenerator contentGenerator;
+
+    @Override
+    public String generate() {
+        return "<bloviate>" + contentGenerator.generate() + "</bloviate>";
+    }
+
+    @Override
+    public String generateAsString() {
+        return generate();
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<String> {
+
+        public Builder(Random random) {
+            super(random);
+        }
+
+        @Override
+        public XmlGenerator build() {
+            return new XmlGenerator(this);
+        }
+    }
+
+    private XmlGenerator(Builder builder) {
+        super(builder.random);
+        this.contentGenerator = new SimpleStringGenerator.Builder(random).size(16).letters(true).numbers(true).build();
+    }
+}

--- a/src/test/java/io/bloviate/db/BasePostgresTest.java
+++ b/src/test/java/io/bloviate/db/BasePostgresTest.java
@@ -30,9 +30,14 @@ class BasePostgresTest extends BaseDatabaseTestCase {
 
     protected void fillDatabase(String initScript, DatabaseConfiguration configuration, Verifier verifier) throws SQLException {
 
-        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:14-alpine")
+        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
                 .withDatabaseName("bloviate")
                 .withUrlParam("rewriteBatchedInserts", "true")
+                // let the server infer the type of string-bound parameters so values for
+                // uuid/json/jsonb/inet/cidr/macaddr/bit/varbit/xml/interval columns are
+                // accepted; without this pgjdbc sends them as character varying and the
+                // server refuses the implicit cast
+                .withUrlParam("stringtype", "unspecified")
                 .withInitScript(initScript)) {
 
             database.start();

--- a/src/test/java/io/bloviate/db/MySqlFillerTest.java
+++ b/src/test/java/io/bloviate/db/MySqlFillerTest.java
@@ -51,6 +51,17 @@ class MySqlFillerTest extends BaseMySqlTest {
     }
 
     @Test
+    void fillTestTables() throws SQLException {
+        // exercises the MySQL JSON type (which a plain string generator would fail to
+        // satisfy) alongside the standard types; the fill throws on any invalid value
+        DatabaseConfiguration configuration = new DatabaseConfiguration(128, 5, new MySQLSupport(), new HashSet<>());
+        fillDatabase("create_tables.mysql.sql", configuration, connection -> {
+            assertRowCount(connection, "json_doc", 5);
+            assertRowCount(connection, "standard_table", 5);
+        });
+    }
+
+    @Test
     void fillTPCCWithColumnConfigs() throws SQLException {
 
         int w = 2;

--- a/src/test/java/io/bloviate/db/PostgresFillerTest.java
+++ b/src/test/java/io/bloviate/db/PostgresFillerTest.java
@@ -95,6 +95,24 @@ class PostgresFillerTest extends BasePostgresTest {
     }
 
     @Test
+    void fillTestTables() throws SQLException {
+        // exercises the PostgreSQL vendor types (uuid, json/jsonb, inet/cidr/macaddr,
+        // bit/varbit, interval, arrays, xml); any unsupported type or invalid generated
+        // value would make the fill itself throw
+        DatabaseConfiguration configuration = new DatabaseConfiguration(128, 5, new PostgresSupport(), new HashSet<>());
+        fillDatabase("create_tables.postgres.sql", configuration, connection -> {
+            assertRowCount(connection, "uuid_table", 5);
+            assertRowCount(connection, "json_table", 5);
+            assertRowCount(connection, "network_table", 5);
+            assertRowCount(connection, "bit_table", 5);
+            assertRowCount(connection, "interval_table", 5);
+            assertRowCount(connection, "array_table", 5);
+            assertRowCount(connection, "doc_table", 5);
+            assertRowCount(connection, "standard_table", 5);
+        });
+    }
+
+    @Test
     void fillTPCCWithColumnConfigs() throws SQLException {
 
         int w = 2;          // warehouses

--- a/src/test/java/io/bloviate/ext/DatabaseSupportTest.java
+++ b/src/test/java/io/bloviate/ext/DatabaseSupportTest.java
@@ -66,38 +66,76 @@ class DatabaseSupportTest {
     }
 
     @Test
-    void postgresAndMySqlBehaveLikeDefault() {
-        assertInstanceOf(IntegerGenerator.class, generatorFor(new PostgresSupport(), JDBCType.INTEGER, 10, "int4"));
-        assertInstanceOf(IntegerGenerator.class, generatorFor(new MySQLSupport(), JDBCType.INTEGER, 10, "int4"));
+    void postgresStillMapsStandardTypes() {
+        DatabaseSupport support = new PostgresSupport();
+
+        assertInstanceOf(IntegerGenerator.class, generatorFor(support, JDBCType.INTEGER, 10, "int4"));
+        assertInstanceOf(SimpleStringGenerator.class, generatorFor(support, JDBCType.VARCHAR, 32, "varchar"));
+        // PostgreSQL reports boolean as JDBCType.BIT with type name "bool"
+        assertInstanceOf(BooleanGenerator.class, generatorFor(support, JDBCType.BIT, 1, "bool"));
     }
 
     @Test
-    void cockroachOverridesBitToBitString() {
-        DatabaseSupport support = new CockroachDBSupport();
+    void postgresDispatchesBitVarbitAndArraysAndXml() {
+        DatabaseSupport support = new PostgresSupport();
 
-        // CRDB treats BIT(1) as a bit string, unlike the default which would use BitGenerator
         assertInstanceOf(BitStringGenerator.class, generatorFor(support, JDBCType.BIT, 1, "bit"));
+        assertInstanceOf(BitStringGenerator.class, generatorFor(support, JDBCType.OTHER, 3, "varbit"));
+        assertInstanceOf(StringArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_text"));
+        assertInstanceOf(IntegerArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_int8"));
+        assertInstanceOf(IntegerArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_int4"));
+        assertInstanceOf(XmlGenerator.class, generatorFor(support, JDBCType.SQLXML, null, "xml"));
     }
 
     @Test
-    void cockroachDispatchesArrayAndOtherByTypeName() {
+    void postgresDispatchesOtherByTypeName() {
+        DatabaseSupport support = new PostgresSupport();
+
+        assertInstanceOf(UUIDGenerator.class, generatorFor(support, JDBCType.OTHER, null, "uuid"));
+        assertInstanceOf(JsonbGenerator.class, generatorFor(support, JDBCType.OTHER, null, "json"));
+        assertInstanceOf(JsonbGenerator.class, generatorFor(support, JDBCType.OTHER, null, "jsonb"));
+        assertInstanceOf(InetGenerator.class, generatorFor(support, JDBCType.OTHER, null, "inet"));
+        assertInstanceOf(CidrGenerator.class, generatorFor(support, JDBCType.OTHER, null, "cidr"));
+        assertInstanceOf(MacAddressGenerator.class, generatorFor(support, JDBCType.OTHER, null, "macaddr"));
+        assertInstanceOf(MacAddressGenerator.class, generatorFor(support, JDBCType.OTHER, null, "macaddr8"));
+        assertInstanceOf(IntervalGenerator.class, generatorFor(support, JDBCType.OTHER, null, "interval"));
+    }
+
+    @Test
+    void postgresRejectsUnknownOtherAndArrayTypeNames() {
+        DatabaseSupport support = new PostgresSupport();
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> generatorFor(support, JDBCType.OTHER, null, "geometry"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> generatorFor(support, JDBCType.ARRAY, null, "_point"));
+    }
+
+    @Test
+    void cockroachInheritsPostgresTypeHandling() {
         DatabaseSupport support = new CockroachDBSupport();
 
+        // CockroachDBSupport extends PostgresSupport, so it resolves the same generators
+        assertInstanceOf(BitStringGenerator.class, generatorFor(support, JDBCType.BIT, 1, "bit"));
         assertInstanceOf(StringArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_text"));
         assertInstanceOf(IntegerArrayGenerator.class, generatorFor(support, JDBCType.ARRAY, null, "_int8"));
         assertInstanceOf(UUIDGenerator.class, generatorFor(support, JDBCType.OTHER, null, "uuid"));
         assertInstanceOf(InetGenerator.class, generatorFor(support, JDBCType.OTHER, null, "inet"));
         assertInstanceOf(JsonbGenerator.class, generatorFor(support, JDBCType.OTHER, null, "jsonb"));
+        assertInstanceOf(IntegerGenerator.class, generatorFor(support, JDBCType.INTEGER, 10, "int4"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> generatorFor(support, JDBCType.OTHER, null, "geometry"));
     }
 
     @Test
-    void cockroachStillProvidesDefaultsAndRejectsUnknownTypeNames() {
-        DatabaseSupport support = new CockroachDBSupport();
+    void mySqlMapsJsonButLeavesTextAsString() {
+        DatabaseSupport support = new MySQLSupport();
 
-        // inherited default still works
-        assertInstanceOf(IntegerGenerator.class, generatorFor(support, JDBCType.INTEGER, 10, "int4"));
-        // unknown ARRAY/OTHER type names are rejected
-        assertThrows(UnsupportedOperationException.class,
-                () -> generatorFor(support, JDBCType.OTHER, null, "geometry"));
+        // JSON reports as LONGVARCHAR with type name "JSON"
+        assertInstanceOf(JsonbGenerator.class, generatorFor(support, JDBCType.LONGVARCHAR, 1073741823, "JSON"));
+        // ordinary text on the same JDBC type stays a string
+        assertInstanceOf(SimpleStringGenerator.class, generatorFor(support, JDBCType.LONGVARCHAR, 65535, "TEXT"));
+        // standard types still behave like the default
+        assertInstanceOf(IntegerGenerator.class, generatorFor(support, JDBCType.INTEGER, 10, "INT"));
     }
 }

--- a/src/test/resources/create_tables.mysql.sql
+++ b/src/test/resources/create_tables.mysql.sql
@@ -1,0 +1,29 @@
+-- NB: "json_table" is reserved (the JSON_TABLE() function), so this is named "json_doc"
+CREATE TABLE json_doc
+(
+    id INT NOT NULL AUTO_INCREMENT,
+    a  JSON,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE standard_table
+(
+    id INT NOT NULL AUTO_INCREMENT,
+    a  TINYINT UNSIGNED, -- the default TINYINT generator produces 0..255 (unsigned range)
+    b  SMALLINT,
+    c  INT,
+    d  BIGINT,
+    e  DECIMAL(10, 2),
+    f  FLOAT,
+    g  DOUBLE,
+    h  VARCHAR(50),
+    i  CHAR(5),
+    j  TEXT,
+    k  BOOLEAN,
+    l  DATE,
+    m  TIME,
+    n  DATETIME,
+    o  BLOB,
+    p  VARBINARY(50),
+    PRIMARY KEY (id)
+);

--- a/src/test/resources/create_tables.postgres.sql
+++ b/src/test/resources/create_tables.postgres.sql
@@ -1,0 +1,62 @@
+CREATE TABLE uuid_table (
+    id uuid PRIMARY KEY,
+    a  uuid
+);
+
+CREATE TABLE json_table (
+    id uuid PRIMARY KEY,
+    a  json,
+    b  jsonb
+);
+
+CREATE TABLE network_table (
+    id uuid PRIMARY KEY,
+    a  inet,
+    b  cidr,
+    c  macaddr,
+    d  macaddr8
+);
+
+CREATE TABLE bit_table (
+    id uuid PRIMARY KEY,
+    a  bit,
+    b  bit(3),
+    c  bit varying,
+    d  bit varying(3)
+);
+
+CREATE TABLE interval_table (
+    id uuid PRIMARY KEY,
+    a  interval
+);
+
+CREATE TABLE array_table (
+    id uuid PRIMARY KEY,
+    a  text[],
+    b  integer[],
+    c  bigint[]
+);
+
+CREATE TABLE doc_table (
+    id uuid PRIMARY KEY,
+    a  xml
+);
+
+CREATE TABLE standard_table (
+    id uuid PRIMARY KEY,
+    a  smallint,
+    b  integer,
+    c  bigint,
+    d  real,
+    e  double precision,
+    f  numeric(10, 2),
+    g  varchar(50),
+    h  char(5),
+    i  text,
+    j  boolean,
+    k  date,
+    l  time,
+    m  timestamp,
+    n  timestamptz,
+    o  bytea
+);


### PR DESCRIPTION
Closes #443.

## Problem

`PostgresSupport` and `MySQLSupport` were empty subclasses of `AbstractDatabaseSupport`, so they only handled the standard JDBC types and threw `UnsupportedOperationException` on vendor-specific columns — despite the README advertising "Full Support". Only `CockroachDBSupport` registered any vendor types.

## What changed

**PostgreSQL** (`PostgresSupport`) now dispatches the types pgjdbc reports as `OTHER`/`ARRAY`/`SQLXML`/`BIT`, keyed on the driver-reported type name:

| Category | Types |
|----------|-------|
| `OTHER` | `uuid`, `json`, `jsonb`, `inet`, `cidr`, `macaddr`, `macaddr8`, `interval`, `varbit` |
| `ARRAY` | `_text`, `_int2`, `_int4`, `_int8` |
| `SQLXML` | `xml` |
| `BIT` | `bit`/`bit(n)` → bit string; `boolean` (also reported as `BIT`) → boolean |

**MySQL** (`MySQLSupport`) now generates valid JSON for `JSON` columns (reported as `LONGVARCHAR` / type name `JSON`) instead of arbitrary text that fails JSON validation. `ENUM`, `SET`, `GEOMETRY`, and `YEAR` remain unsupported (they need value-aware or binary generation that JDBC metadata doesn't expose) and are documented as such.

**CockroachDB** — since it's wire-compatible with PostgreSQL through the same JDBC driver, `CockroachDBSupport` now **extends `PostgresSupport`** and inherits its full type handling rather than maintaining a parallel copy.

## New generators

`CidrGenerator`, `MacAddressGenerator` (6 or 8 octets), `XmlGenerator`. The remaining types reuse existing generators (`UUIDGenerator`, `JsonbGenerator`, `InetGenerator`, `IntervalGenerator`, `BitStringGenerator`, `BooleanGenerator`, `StringArrayGenerator`, `IntegerArrayGenerator`).

## Tests

- Driver type reporting was confirmed empirically against **postgres:18** and **mysql:9.7** before coding the dispatch.
- New `create_tables.{postgres,mysql}.sql` type schemas + `fillTestTables` integration tests on real containers.
- Expanded `DatabaseSupportTest` unit coverage for the new dispatch (incl. CockroachDB inheriting it).
- Bumped the Postgres test image `14-alpine` → `18-alpine`.
- Full suite green: **129 tests**.

## Connection requirement (PostgreSQL)

Vendor values are bound as text, and PostgreSQL won't implicitly cast `varchar` → `uuid`/`jsonb`/`bit`/etc. Connections must set `stringtype=unspecified` (`jdbc:postgresql://host/db?stringtype=unspecified`) so the server infers each column's type. Documented in the `PostgresSupport` javadoc and the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)