### PR TITLE
feat(ext): pluggable custom data generators via registry + ServiceLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A powerful Java library for generating realistic test data for JDBC-compatible r
 - [Usage Examples](#-usage-examples)
   - [Per-Table Row Counts](#per-table-row-counts)
   - [Per-Column Generation Overrides](#per-column-generation-overrides)
+  - [Custom Generator Registry](#custom-generator-registry)
   - [Composite Keys & Foreign Key Fidelity](#composite-keys--foreign-key-fidelity)
   - [Variable Parent/Child Cardinality](#variable-parentchild-cardinality)
   - [TPC-C Benchmark Data](#tpc-c-benchmark-data)
@@ -229,6 +230,69 @@ new DatabaseFiller.Builder(connection, config)
 
 Column names are matched **case-insensitively**. Any column without an override keeps
 its default, type-based generator.
+
+### Custom Generator Registry
+
+Per-column overrides are precise but must be wired one column at a time. When you want a
+custom generator applied **broadly** — every column named `email`, every `uuid` vendor
+type, or every `INTEGER` — register it once on a `GeneratorRegistry` and attach it to the
+`DatabaseConfiguration`. No subclassing of `DatabaseSupport` required.
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.ext.GeneratorRegistry;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.*;
+import java.sql.JDBCType;
+import java.util.Set;
+
+GeneratorRegistry registry = new GeneratorRegistry.Builder()
+    // by column-name pattern (case-insensitive regex, full match)
+    .registerColumnNamePattern("email",
+        (column, random) -> new SimpleStringGenerator.Builder(random).size(column.maxSize()).build())
+    // by vendor type name (case-insensitive)
+    .registerTypeName("uuid",
+        (column, random) -> new UUIDGenerator.Builder(random).build())
+    // by JDBCType (overrides the built-in default for that type)
+    .registerJdbcType(JDBCType.INTEGER,
+        (column, random) -> new IntegerGenerator.Builder(random).start(1).end(1000).build())
+    // auto-discover GeneratorPlugins contributed by other jars on the classpath
+    .discover()
+    .build();
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    128, 100, new PostgresSupport(), null, registry);
+
+new DatabaseFiller.Builder(connection, config)
+    .build()
+    .fill();
+```
+
+**Resolution precedence** (first match wins, highest to lowest):
+
+1. per-column `ColumnConfiguration` (from a `TableConfiguration`)
+2. registry **column-name pattern**
+3. registry **vendor type name**
+4. registry **JDBCType**
+5. built-in `DatabaseSupport` default
+
+Every path is constructed with the engine's seeded `Random`, so custom generators stay
+**reproducible** exactly like the built-ins.
+
+**Plugin discovery.** Third-party jars can contribute rules automatically by implementing
+`io.bloviate.ext.GeneratorPlugin` and declaring it in
+`META-INF/services/io.bloviate.ext.GeneratorPlugin`. Calling `.discover()` on the builder
+loads every such plugin via `ServiceLoader`:
+
+```java
+public class MyGenerators implements GeneratorPlugin {
+    @Override
+    public void contribute(GeneratorRegistry.Builder builder) {
+        builder.registerTypeName("geometry",
+            (column, random) -> new MyGeometryGenerator.Builder(random).build());
+    }
+}
+```
 
 ### Composite Keys & Foreign Key Fidelity
 

--- a/src/main/java/io/bloviate/db/DatabaseConfiguration.java
+++ b/src/main/java/io/bloviate/db/DatabaseConfiguration.java
@@ -17,6 +17,7 @@
 package io.bloviate.db;
 
 import io.bloviate.ext.DatabaseSupport;
+import io.bloviate.ext.GeneratorRegistry;
 
 import java.util.Set;
 
@@ -39,13 +40,29 @@ import java.util.Set;
  * @param defaultRowCount the default number of rows to generate for each table
  * @param databaseSupport the database-specific support implementation
  * @param tableConfigurations optional per-table configuration overrides
- * 
+ * @param generatorRegistry optional registry of custom generator rules (by column-name pattern,
+ *        vendor type name, or JDBCType), consulted between per-column overrides and the
+ *        {@code databaseSupport} defaults; may be null
+ *
  * @author Tim Veil
  * @see DatabaseSupport
  * @see TableConfiguration
+ * @see GeneratorRegistry
  * @see DatabaseFiller
  */
-public record DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations) {
+public record DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry) {
+
+    /**
+     * Creates a configuration with no custom {@link GeneratorRegistry}.
+     *
+     * @param batchSize the number of rows to include in each batch INSERT operation
+     * @param defaultRowCount the default number of rows to generate for each table
+     * @param databaseSupport the database-specific support implementation
+     * @param tableConfigurations optional per-table configuration overrides
+     */
+    public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations) {
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null);
+    }
 
     /**
      * Retrieves the table-specific configuration for the given table name.

--- a/src/main/java/io/bloviate/db/TableFiller.java
+++ b/src/main/java/io/bloviate/db/TableFiller.java
@@ -17,6 +17,7 @@
 package io.bloviate.db;
 
 import io.bloviate.ext.DatabaseSupport;
+import io.bloviate.ext.GeneratorRegistry;
 import io.bloviate.gen.DataGenerator;
 import io.bloviate.util.DatabaseUtils;
 import org.apache.commons.lang3.time.StopWatch;
@@ -101,15 +102,23 @@ public class TableFiller implements Fillable {
                 seed = column.hashCode();
             }
 
-            // an explicit per-column configuration overrides the auto-detected generator;
-            // either way the generator is seeded by the engine so it stays reproducible
+            // resolve the generator by precedence; the generator is always seeded by the engine
+            // so it stays reproducible regardless of which path provides it:
+            //   per-column config > custom registry (name > typeName > JDBCType) > support default
+            Random random = new Random(seed);
+
             ColumnConfiguration columnConfiguration = tableConfiguration != null
                     ? tableConfiguration.columnConfiguration(column.name())
                     : null;
 
-            DataGenerator<?> dataGenerator = columnConfiguration != null
-                    ? columnConfiguration.generatorFactory().create(new Random(seed))
-                    : databaseSupport.getDataGenerator(column, new Random(seed));
+            DataGenerator<?> dataGenerator;
+            if (columnConfiguration != null) {
+                dataGenerator = columnConfiguration.generatorFactory().create(random);
+            } else {
+                GeneratorRegistry registry = databaseConfiguration.generatorRegistry();
+                DataGenerator<?> custom = registry != null ? registry.resolve(column, random) : null;
+                dataGenerator = custom != null ? custom : databaseSupport.getDataGenerator(column, random);
+            }
 
             generatorMap.put(column, dataGenerator);
             seedMap.put(column, seed);

--- a/src/main/java/io/bloviate/ext/GeneratorPlugin.java
+++ b/src/main/java/io/bloviate/ext/GeneratorPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+/**
+ * Service-provider interface that lets a jar contribute custom generator rules to a
+ * {@link GeneratorRegistry} without subclassing {@link DatabaseSupport}.
+ *
+ * <p>Implementations register matchers (column-name pattern, vendor type name, and/or
+ * {@link java.sql.JDBCType}) on the supplied {@link GeneratorRegistry.Builder}. Plugins are
+ * picked up automatically by {@link GeneratorRegistry.Builder#discover()} via the standard
+ * {@link java.util.ServiceLoader} mechanism: declare the implementation in
+ * {@code META-INF/services/io.bloviate.ext.GeneratorPlugin}. They can also be registered
+ * explicitly with {@link GeneratorRegistry.Builder#register(GeneratorPlugin)}.
+ *
+ * <p>Generators contributed this way remain reproducible: the fill engine constructs each
+ * generator with an engine-managed seed, exactly as it does for built-in generators.
+ *
+ * @see GeneratorRegistry
+ * @see io.bloviate.gen.DataGenerator
+ */
+@FunctionalInterface
+public interface GeneratorPlugin {
+
+    /**
+     * Contributes generator rules to the registry under construction.
+     *
+     * @param builder the registry builder to register matchers on
+     */
+    void contribute(GeneratorRegistry.Builder builder);
+}

--- a/src/main/java/io/bloviate/ext/GeneratorRegistry.java
+++ b/src/main/java/io/bloviate/ext/GeneratorRegistry.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import io.bloviate.db.Column;
+import io.bloviate.gen.DataGenerator;
+
+import java.sql.JDBCType;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.ServiceLoader;
+import java.util.regex.Pattern;
+
+/**
+ * A user-facing registry of custom {@link GeneratorFactory} rules that lets callers override
+ * data generation <em>without</em> subclassing {@link DatabaseSupport}.
+ *
+ * <p>A registry is attached to a
+ * {@link io.bloviate.db.DatabaseConfiguration DatabaseConfiguration} and consulted by the fill
+ * engine for every column. It supports three kinds of matchers, resolved in a fixed, documented
+ * order of precedence:
+ *
+ * <ol>
+ *   <li><strong>column-name pattern</strong> &mdash; a case-insensitive regular expression matched
+ *       against {@link Column#name()}; rules are tried in registration order and the first to match
+ *       wins</li>
+ *   <li><strong>vendor type name</strong> &mdash; an exact, case-insensitive match against
+ *       {@link Column#typeName()} (e.g. {@code "uuid"}, {@code "jsonb"})</li>
+ *   <li><strong>{@link JDBCType}</strong> &mdash; a match against {@link Column#jdbcType()}</li>
+ * </ol>
+ *
+ * <p>The registry sits between the highest-precedence per-column
+ * {@link io.bloviate.db.ColumnConfiguration ColumnConfiguration} override and the built-in
+ * {@link DatabaseSupport} defaults. The full engine precedence is therefore:
+ *
+ * <pre>
+ *   per-column ColumnConfiguration
+ *     &gt; registry column-name pattern
+ *     &gt; registry vendor typeName
+ *     &gt; registry JDBCType
+ *     &gt; built-in DatabaseSupport default
+ * </pre>
+ *
+ * <p>If no rule matches, {@link #resolve(Column, Random)} returns {@code null} and the engine falls
+ * back to the {@link DatabaseSupport} default. Matched generators are constructed with the
+ * engine-supplied, seeded {@link Random}, so they remain reproducible like every built-in generator.
+ *
+ * <p>Instances are immutable and built through the {@link Builder}. External jars can contribute
+ * rules automatically by providing a {@link GeneratorPlugin} discovered via
+ * {@link Builder#discover()}.
+ *
+ * @see GeneratorPlugin
+ * @see GeneratorFactory
+ * @see io.bloviate.db.DatabaseConfiguration
+ */
+public final class GeneratorRegistry {
+
+    private record NameRule(Pattern pattern, GeneratorFactory factory) {
+    }
+
+    private final List<NameRule> nameRules;
+    private final Map<String, GeneratorFactory> typeNameRules;
+    private final Map<JDBCType, GeneratorFactory> jdbcTypeRules;
+
+    private GeneratorRegistry(Builder builder) {
+        this.nameRules = List.copyOf(builder.nameRules);
+        this.typeNameRules = Map.copyOf(builder.typeNameRules);
+        this.jdbcTypeRules = builder.jdbcTypeRules.isEmpty()
+                ? Map.of()
+                : new EnumMap<>(builder.jdbcTypeRules);
+    }
+
+    /**
+     * Resolves the custom generator for a column, honouring the documented precedence
+     * (name pattern &gt; vendor typeName &gt; JDBCType).
+     *
+     * @param column the column metadata to match against
+     * @param random the engine-seeded random source to construct the generator with
+     * @return the matching generator, or {@code null} if no rule applies (caller should fall back to
+     * the {@link DatabaseSupport} default)
+     */
+    public DataGenerator<?> resolve(Column column, Random random) {
+        String name = column.name();
+        if (name != null) {
+            for (NameRule rule : nameRules) {
+                if (rule.pattern().matcher(name).matches()) {
+                    return rule.factory().create(column, random);
+                }
+            }
+        }
+
+        String typeName = column.typeName();
+        if (typeName != null) {
+            GeneratorFactory byTypeName = typeNameRules.get(typeName.toLowerCase(Locale.ROOT));
+            if (byTypeName != null) {
+                return byTypeName.create(column, random);
+            }
+        }
+
+        GeneratorFactory byJdbcType = jdbcTypeRules.get(column.jdbcType());
+        if (byJdbcType != null) {
+            return byJdbcType.create(column, random);
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds an immutable {@link GeneratorRegistry}. Registration methods may be called in any
+     * order and any number of times; {@code register*} methods return {@code this} for chaining.
+     *
+     * <p>Within a single matcher kind, later registrations win for vendor type names and
+     * {@link JDBCType}s (last-write replaces), while column-name patterns preserve registration
+     * order (first match wins at resolution time).
+     */
+    public static final class Builder {
+
+        private final List<NameRule> nameRules = new ArrayList<>();
+        private final Map<String, GeneratorFactory> typeNameRules = new LinkedHashMap<>();
+        private final Map<JDBCType, GeneratorFactory> jdbcTypeRules = new EnumMap<>(JDBCType.class);
+
+        /**
+         * Registers a generator for columns whose {@link Column#name() name} matches the given
+         * regular expression. Matching is full ({@link java.util.regex.Matcher#matches()}) and
+         * case-insensitive &mdash; use {@code "email"} or {@code ".*_email"} rather than relying on
+         * substring search. Patterns are evaluated in registration order; the first match wins.
+         *
+         * @param regex   the column-name pattern (full-match, case-insensitive)
+         * @param factory the generator factory to use on a match
+         * @return this builder
+         */
+        public Builder registerColumnNamePattern(String regex, GeneratorFactory factory) {
+            nameRules.add(new NameRule(Pattern.compile(regex, Pattern.CASE_INSENSITIVE), factory));
+            return this;
+        }
+
+        /**
+         * Registers a generator for columns whose database-specific {@link Column#typeName() type
+         * name} equals the given value, ignoring case (e.g. {@code "uuid"}, {@code "jsonb"}).
+         *
+         * @param typeName the vendor type name to match
+         * @param factory  the generator factory to use on a match
+         * @return this builder
+         */
+        public Builder registerTypeName(String typeName, GeneratorFactory factory) {
+            typeNameRules.put(typeName.toLowerCase(Locale.ROOT), factory);
+            return this;
+        }
+
+        /**
+         * Registers a generator override for a {@link JDBCType}. This takes precedence over the
+         * built-in {@link DatabaseSupport} default for that type.
+         *
+         * @param jdbcType the JDBC type to match
+         * @param factory  the generator factory to use on a match
+         * @return this builder
+         */
+        public Builder registerJdbcType(JDBCType jdbcType, GeneratorFactory factory) {
+            jdbcTypeRules.put(jdbcType, factory);
+            return this;
+        }
+
+        /**
+         * Applies a {@link GeneratorPlugin} immediately, letting it register rules at this point in
+         * the builder chain.
+         *
+         * @param plugin the plugin to apply
+         * @return this builder
+         */
+        public Builder register(GeneratorPlugin plugin) {
+            plugin.contribute(this);
+            return this;
+        }
+
+        /**
+         * Discovers and applies every {@link GeneratorPlugin} visible to the current thread's
+         * context class loader via {@link ServiceLoader}. Discovery order is not specified by
+         * {@code ServiceLoader}; call this where you want discovered rules to apply relative to your
+         * explicit registrations.
+         *
+         * @return this builder
+         */
+        public Builder discover() {
+            for (GeneratorPlugin plugin : ServiceLoader.load(GeneratorPlugin.class)) {
+                plugin.contribute(this);
+            }
+            return this;
+        }
+
+        /**
+         * @return an immutable registry holding the rules registered so far
+         */
+        public GeneratorRegistry build() {
+            return new GeneratorRegistry(this);
+        }
+    }
+}

--- a/src/test/java/io/bloviate/db/DatabaseConfigurationTest.java
+++ b/src/test/java/io/bloviate/db/DatabaseConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.ext.DefaultSupport;
+import io.bloviate.ext.GeneratorRegistry;
+import io.bloviate.gen.IntegerGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class DatabaseConfigurationTest {
+
+    @Test
+    void backCompatConstructorHasNoGeneratorRegistry() {
+        DatabaseConfiguration configuration = new DatabaseConfiguration(128, 100, new DefaultSupport(), null);
+
+        assertNull(configuration.generatorRegistry());
+    }
+
+    @Test
+    void registryIsRetained() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerJdbcType(JDBCType.INTEGER, (column, random) -> new IntegerGenerator.Builder(random).build())
+                .build();
+
+        DatabaseConfiguration configuration = new DatabaseConfiguration(128, 100, new DefaultSupport(), null, registry);
+
+        assertSame(registry, configuration.generatorRegistry());
+    }
+}

--- a/src/test/java/io/bloviate/ext/GeneratorRegistryTest.java
+++ b/src/test/java/io/bloviate/ext/GeneratorRegistryTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import io.bloviate.db.Column;
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.gen.IntegerGenerator;
+import io.bloviate.gen.SimpleStringGenerator;
+import io.bloviate.gen.UUIDGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GeneratorRegistryTest {
+
+    private static Column column(String name, JDBCType type, String typeName) {
+        return new Column(name, "t", null, null, type, 32, null, typeName, false, true, null, 1);
+    }
+
+    @Test
+    void resolvesByColumnNamePattern() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerColumnNamePattern("email", (c, r) -> new SimpleStringGenerator.Builder(r).size(c.maxSize()).build())
+                .build();
+
+        assertInstanceOf(SimpleStringGenerator.class, registry.resolve(column("EMAIL", JDBCType.VARCHAR, "varchar"), new Random(1)));
+    }
+
+    @Test
+    void resolvesByVendorTypeName() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerTypeName("uuid", (c, r) -> new UUIDGenerator.Builder(r).build())
+                .build();
+
+        // case-insensitive match on typeName
+        assertInstanceOf(UUIDGenerator.class, registry.resolve(column("id", JDBCType.OTHER, "UUID"), new Random(1)));
+    }
+
+    @Test
+    void resolvesByJdbcType() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerJdbcType(JDBCType.INTEGER, (c, r) -> new IntegerGenerator.Builder(r).build())
+                .build();
+
+        assertInstanceOf(IntegerGenerator.class, registry.resolve(column("qty", JDBCType.INTEGER, "int4"), new Random(1)));
+    }
+
+    @Test
+    void columnNamePatternOutranksTypeNameAndJdbcType() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerColumnNamePattern("id", (c, r) -> new SimpleStringGenerator.Builder(r).size(8).build())
+                .registerTypeName("uuid", (c, r) -> new UUIDGenerator.Builder(r).build())
+                .registerJdbcType(JDBCType.OTHER, (c, r) -> new IntegerGenerator.Builder(r).build())
+                .build();
+
+        // name pattern wins even though typeName and jdbcType rules also match
+        assertInstanceOf(SimpleStringGenerator.class, registry.resolve(column("id", JDBCType.OTHER, "uuid"), new Random(1)));
+    }
+
+    @Test
+    void typeNameOutranksJdbcType() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerTypeName("uuid", (c, r) -> new UUIDGenerator.Builder(r).build())
+                .registerJdbcType(JDBCType.OTHER, (c, r) -> new IntegerGenerator.Builder(r).build())
+                .build();
+
+        assertInstanceOf(UUIDGenerator.class, registry.resolve(column("id", JDBCType.OTHER, "uuid"), new Random(1)));
+    }
+
+    @Test
+    void firstRegisteredColumnNamePatternWins() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerColumnNamePattern(".*name", (c, r) -> new SimpleStringGenerator.Builder(r).size(8).build())
+                .registerColumnNamePattern("first_name", (c, r) -> new UUIDGenerator.Builder(r).build())
+                .build();
+
+        // both patterns match "first_name"; the first registered one wins
+        assertInstanceOf(SimpleStringGenerator.class, registry.resolve(column("first_name", JDBCType.VARCHAR, "varchar"), new Random(1)));
+    }
+
+    @Test
+    void returnsNullWhenNothingMatches() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerTypeName("uuid", (c, r) -> new UUIDGenerator.Builder(r).build())
+                .build();
+
+        assertNull(registry.resolve(column("qty", JDBCType.INTEGER, "int4"), new Random(1)));
+    }
+
+    @Test
+    void matchedGeneratorRemainsReproducibleUnderSeeding() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .registerJdbcType(JDBCType.INTEGER, (c, r) -> new IntegerGenerator.Builder(r).build())
+                .build();
+
+        Column column = column("qty", JDBCType.INTEGER, "int4");
+
+        DataGenerator<?> first = registry.resolve(column, new Random(42));
+        DataGenerator<?> second = registry.resolve(column, new Random(42));
+
+        assertEquals(first.generate(), second.generate());
+    }
+
+    @Test
+    void explicitlyRegisteredPluginContributesRules() {
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .register(builder -> builder.registerTypeName("uuid", (c, r) -> new UUIDGenerator.Builder(r).build()))
+                .build();
+
+        assertInstanceOf(UUIDGenerator.class, registry.resolve(column("id", JDBCType.OTHER, "uuid"), new Random(1)));
+    }
+
+    @Test
+    void serviceLoaderDiscoversPlugin() {
+        // TestGeneratorPlugin is declared in META-INF/services/io.bloviate.ext.GeneratorPlugin
+        GeneratorRegistry registry = new GeneratorRegistry.Builder()
+                .discover()
+                .build();
+
+        assertInstanceOf(UUIDGenerator.class, registry.resolve(column("anything", JDBCType.OTHER, "custom_uuid"), new Random(1)));
+    }
+}

--- a/src/test/java/io/bloviate/ext/TestGeneratorPlugin.java
+++ b/src/test/java/io/bloviate/ext/TestGeneratorPlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import io.bloviate.gen.UUIDGenerator;
+
+/**
+ * Test {@link GeneratorPlugin} registered via {@code META-INF/services} to exercise
+ * {@link GeneratorRegistry.Builder#discover()} ServiceLoader discovery.
+ */
+public class TestGeneratorPlugin implements GeneratorPlugin {
+
+    @Override
+    public void contribute(GeneratorRegistry.Builder builder) {
+        builder.registerTypeName("custom_uuid", (column, random) -> new UUIDGenerator.Builder(random).build());
+    }
+}

--- a/src/test/resources/META-INF/services/io.bloviate.ext.GeneratorPlugin
+++ b/src/test/resources/META-INF/services/io.bloviate.ext.GeneratorPlugin
@@ -1,0 +1,1 @@
+io.bloviate.ext.TestGeneratorPlugin


### PR DESCRIPTION
Closes #446.

## What

Adds a user-facing way to register custom data generators **without subclassing `DatabaseSupport`**, plus a discovery mechanism for third-party jars.

- **`GeneratorRegistry`** (`io.bloviate.ext`) — builder-based registry with three matcher kinds:
  - `registerColumnNamePattern(regex, factory)` — case-insensitive, full-match regex on column name
  - `registerTypeName(typeName, factory)` — case-insensitive vendor type name (e.g. `uuid`, `jsonb`)
  - `registerJdbcType(JDBCType, factory)` — overrides the built-in default for a type
- **`GeneratorPlugin`** SPI — external jars contribute rules via `META-INF/services`; `Builder.discover()` loads them with `ServiceLoader`. `register(plugin)` applies one explicitly.
- Registry is an optional 5th component on the `DatabaseConfiguration` record; the existing **4-arg constructor still works** (delegates with `null`), so no caller changes are required.
- `TableFiller` consults the registry between per-column overrides and the `DatabaseSupport` default.

## Resolution precedence (documented in code + README)

```
per-column ColumnConfiguration
  > registry column-name pattern
  > registry vendor typeName
  > registry JDBCType
  > built-in DatabaseSupport default
```

Every path constructs the generator with the engine's seeded `Random`, so custom generators stay **reproducible** like the built-ins.

## Acceptance criteria (#446)

- [x] Register a custom generator by JDBCType, typeName, and/or column-name pattern without subclassing `DatabaseSupport`
- [x] Documented, deterministic precedence among matchers
- [x] Custom generators remain reproducible under the engine's seeding
- [x] Docs + example in README

Semantic/name-based realistic-data matching was deliberately left out of scope (candidate for its own issue), per the issue's suggestion.

## Tests

- `GeneratorRegistryTest` (10): precedence, case-insensitivity, first-match-wins, null fallback, seeding reproducibility, explicit + ServiceLoader-discovered plugins
- `DatabaseConfigurationTest` (2): backward-compat constructor, registry retention
- Full suite green incl. Docker-backed Postgres/MySQL/CockroachDB filler integration tests: **141 tests, 0 failures** via `./mvnw verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)