### PR TITLE
feat(benchmarks): add JMH and end-to-end fill benchmark harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target/
 *.iml
 *.csv
 .env
+
+# maven-shade-plugin output
+dependency-reduced-pom.xml

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,123 @@
+# Bloviate Benchmarks
+
+Performance baseline for [issue #447](https://github.com/timveil/bloviate/issues/447)
+("performance optimizations for large datasets"). These benchmarks exist so that the
+optimizations tracked in that issue — parallel table fill, transaction/commit tuning,
+batch-rewrite, and hot-loop micro-opts — can be measured against a trustworthy "before",
+and so regressions are caught.
+
+Everything lives in the **`bloviate-benchmarks`** module. It is never published (deploy,
+install, source, javadoc and JaCoCo are all skipped) and nothing in `bloviate-core` depends
+on it.
+
+There are two complementary suites, because the work being optimized spans two regimes:
+
+| Suite | What it measures | Where the wins show up | Tool |
+|-------|------------------|------------------------|------|
+| **CPU micro-benchmarks** | raw value generation and per-cell generator dispatch, no database | hot-loop micro-opts, generator-level changes | JMH |
+| **End-to-end fill** | `DatabaseFiller.fill()` throughput (rows/sec) against a real DB | parallel table fill, commit tuning, batch rewrite | plain JUnit runner |
+
+## CPU micro-benchmarks (JMH)
+
+Pure-CPU, no Docker. Resolve generators exactly the way `TableFiller` does
+(`DatabaseSupport.getDataGenerator(column, random)`), so the numbers reflect real engine cost.
+
+- `GeneratorBenchmark` — throughput of `generate()` / `generateAsString()` across a spread of
+  column types (int, numeric, varchar, timestamp, uuid, jsonb, …).
+- `RowDispatchBenchmark` — models the inner loop of `TableFiller.fill()`: the per-cell
+  `generatorMap.get(column)` HashMap lookup plus `generate()` over a wide row. This is the
+  baseline for the planned "index generators by array position" change.
+
+Build the runnable uber-jar and run it:
+
+```bash
+./mvnw -q -DskipTests -pl bloviate-benchmarks -am package
+java -jar bloviate-benchmarks/target/benchmarks.jar
+```
+
+Useful invocations (standard JMH CLI — flags take a space):
+
+```bash
+# one benchmark, quick
+java -jar bloviate-benchmarks/target/benchmarks.jar RowDispatchBenchmark
+
+# restrict GeneratorBenchmark to specific column types
+java -jar bloviate-benchmarks/target/benchmarks.jar GeneratorBenchmark.generate \
+    -p genCase=UUID,VARCHAR_SHORT
+
+# fewer forks/iterations while iterating locally
+java -jar bloviate-benchmarks/target/benchmarks.jar -f 1 -wi 2 -i 3
+```
+
+## End-to-end fill (real database)
+
+Opt-in JUnit runners tagged `@Tag("benchmark")`, one per database, reusing the same
+TestContainers stack as the core tests. They are **skipped by a normal build** and only run
+under the `bench` profile. Requires Docker (OrbStack works).
+
+Each measured iteration truncates the schema, times a full `DatabaseFiller.fill()` (metadata
+fetch included), and prints `rows/sec`. A fixed seed makes every iteration generate identical
+data, so timings are comparable across runs and across optimization branches.
+
+- `PostgresFillBenchmark` — TPC-C schema **and** a deliberately wide, FK-free schema
+  (`create_wide.postgres.sql`); the wide one is the parallel-table-fill target.
+- `MySqlFillBenchmark`, `CockroachFillBenchmark` — TPC-C schema.
+
+```bash
+# all end-to-end benchmarks (Postgres + MySQL + CockroachDB)
+./mvnw -pl bloviate-benchmarks -am -Pbench test
+
+# just Postgres, just the wide schema, larger dataset
+./mvnw -pl bloviate-benchmarks -am -Pbench test \
+    -Dtest='PostgresFillBenchmark#wide' -Dbench.rows=500000
+```
+
+Output lines look like:
+
+```
+[bench] postgres/wide    iteration 1        500,000 rows     3.612 s         138,430 rows/s
+[bench] postgres/wide    best               500,000 rows     3.580 s         139,664 rows/s
+[bench] postgres/wide    mean               500,000 rows     3.601 s         138,850 rows/s
+```
+
+### Tuning (system properties)
+
+| Property | Default | Meaning |
+|----------|--------:|---------|
+| `bench.warmup` | 1 | untimed warmup fills (JIT / pool / cache priming) |
+| `bench.iterations` | 3 | timed fills; best and mean are reported |
+| `bench.batch` | 1000 | JDBC batch size (`DatabaseConfiguration.batchSize`) |
+| `bench.rows` | 50000 | default row count for the **wide** schema (per table) |
+| `bench.warehouses` | 1 | TPC-C scale factor (W) |
+| `bench.items` | 10000 | TPC-C items (I) |
+| `bench.districts` | 10 | TPC-C districts per warehouse (D) |
+| `bench.customers` | 300 | TPC-C customers/orders per district (C) |
+| `bench.minLines` / `bench.maxLines` | 5 / 15 | TPC-C order lines per order |
+
+The defaults produce a modest (~60k-row TPC-C / ~500k-row wide) dataset that runs quickly;
+scale them up for a real large-dataset measurement.
+
+## Recording a baseline
+
+Run on a quiet machine and record the environment alongside the numbers — JMH scores and
+fill throughput are only comparable within the same hardware/JDK/DB image.
+
+- Machine / CPU:
+- JDK:
+- Docker / DB image:
+
+### CPU (JMH, ops/us — higher is better)
+
+| Benchmark | Score | Notes |
+|-----------|------:|-------|
+| `RowDispatchBenchmark.dispatchRow` | | 16-column row |
+| `GeneratorBenchmark.generate` (per `genCase`) | | |
+
+### End-to-end (rows/sec — higher is better)
+
+| Scenario | Rows | rows/sec (best) | Notes |
+|----------|-----:|----------------:|-------|
+| `postgres/tpcc` | | | |
+| `postgres/wide` | | | |
+| `mysql/tpcc` | | | |
+| `cockroach/tpcc` | | | |

--- a/bloviate-benchmarks/pom.xml
+++ b/bloviate-benchmarks/pom.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Tim Veil
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.bloviate</groupId>
+        <artifactId>bloviate-parent</artifactId>
+        <version>2.7.0</version>
+    </parent>
+
+    <artifactId>bloviate-benchmarks</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>Bloviate Benchmarks</name>
+    <description>JMH micro-benchmarks and end-to-end fill timing for Bloviate; not published</description>
+
+    <properties>
+        <!-- this module is a measurement harness, never a published artifact -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <jacoco.skip>true</jacoco.skip>
+
+        <!-- end-to-end fill runners are opt-in; the 'bench' profile flips this to false -->
+        <skipBenchmarks>true</skipBenchmarks>
+    </properties>
+
+    <dependencies>
+
+        <!-- the engine under test -->
+        <dependency>
+            <groupId>io.bloviate</groupId>
+            <artifactId>bloviate-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- JMH (CPU micro-benchmarks) -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- end-to-end fill runners (src/test) reuse the same container stack as the core tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>cockroachdb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- wire the JMH annotation processor that generates the benchmark runners -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- package a runnable JMH uber-jar: target/benchmarks.jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jmh-uber-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!-- drop signatures and module descriptors that break a merged uber-jar -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- end-to-end fill runners are JUnit tests tagged @Tag("benchmark"); skipped unless -Pbench -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipBenchmarks}</skipTests>
+                    <groups>benchmark</groups>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <profiles>
+        <!-- ./mvnw -pl bloviate-benchmarks -am -Pbench test  -> runs the end-to-end fill runners -->
+        <profile>
+            <id>bench</id>
+            <properties>
+                <skipBenchmarks>false</skipBenchmarks>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/BenchColumns.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/BenchColumns.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Column;
+
+import java.sql.JDBCType;
+import java.util.List;
+
+/**
+ * Builds synthetic {@link Column} metadata for the JMH benchmarks so they can resolve real
+ * generators via {@link io.bloviate.ext.DatabaseSupport#getDataGenerator} — the same path
+ * {@link io.bloviate.db.TableFiller} uses — without standing up a database.
+ */
+final class BenchColumns {
+
+    private BenchColumns() {
+    }
+
+    /**
+     * Creates a {@link Column} carrying only the metadata the generators actually read
+     * ({@code maxSize}/{@code maxDigits} for sized types, {@code typeName} for the PostgreSQL
+     * extension types dispatched as {@code OTHER}).
+     */
+    static Column column(String name, JDBCType jdbcType, String typeName, Integer maxSize, Integer maxDigits) {
+        return new Column(name, "bench", null, null, jdbcType, maxSize, maxDigits, typeName, false, false, null, 1);
+    }
+
+    /**
+     * A representative "wide" row mixing common standard types with a couple of PostgreSQL
+     * extension types — the shape {@link RowDispatchBenchmark} iterates to measure per-cell
+     * generator dispatch.
+     */
+    static List<Column> wideRow() {
+        return List.of(
+                column("id", JDBCType.BIGINT, "int8", null, null),
+                column("code", JDBCType.INTEGER, "int4", null, null),
+                column("ref_id", JDBCType.BIGINT, "int8", null, null),
+                column("name", JDBCType.VARCHAR, "varchar", 64, null),
+                column("description", JDBCType.VARCHAR, "varchar", 256, null),
+                column("status", JDBCType.VARCHAR, "varchar", 16, null),
+                column("price", JDBCType.NUMERIC, "numeric", 12, 2),
+                column("score", JDBCType.DOUBLE, "float8", null, null),
+                column("ratio", JDBCType.REAL, "float4", null, null),
+                column("quantity", JDBCType.INTEGER, "int4", null, null),
+                column("active", JDBCType.BOOLEAN, "bool", null, null),
+                column("created", JDBCType.TIMESTAMP, "timestamp", null, null),
+                column("updated", JDBCType.TIMESTAMP, "timestamp", null, null),
+                column("flags", JDBCType.BIT, "bit", 8, null),
+                column("external_id", JDBCType.OTHER, "uuid", null, null),
+                column("payload", JDBCType.OTHER, "jsonb", null, null));
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/GeneratorBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/GeneratorBenchmark.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Column;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.DataGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.sql.JDBCType;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-generator throughput of {@link DataGenerator#generate()} and
+ * {@link DataGenerator#generateAsString()} across a representative spread of column types.
+ *
+ * <p>Each case resolves its generator the same way {@link io.bloviate.db.TableFiller} does —
+ * {@code DatabaseSupport.getDataGenerator(column, random)} — so the numbers reflect the real
+ * generation cost the engine pays per cell. This is the baseline that the issue-#447
+ * generator-level micro-optimizations (#2, #5) are measured against.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class GeneratorBenchmark {
+
+    /** Fixed seed so every run generates the same value stream — reproducibility over time. */
+    private static final long SEED = 42L;
+
+    /** Representative column types; JMH expands a value-less {@link Param} over every constant. */
+    public enum GenCase {
+        INTEGER(BenchColumns.column("c", JDBCType.INTEGER, "int4", null, null)),
+        BIGINT(BenchColumns.column("c", JDBCType.BIGINT, "int8", null, null)),
+        DOUBLE(BenchColumns.column("c", JDBCType.DOUBLE, "float8", null, null)),
+        NUMERIC(BenchColumns.column("c", JDBCType.NUMERIC, "numeric", 12, 2)),
+        VARCHAR_SHORT(BenchColumns.column("c", JDBCType.VARCHAR, "varchar", 16, null)),
+        VARCHAR_LONG(BenchColumns.column("c", JDBCType.VARCHAR, "varchar", 256, null)),
+        BOOLEAN(BenchColumns.column("c", JDBCType.BOOLEAN, "bool", null, null)),
+        DATE(BenchColumns.column("c", JDBCType.DATE, "date", null, null)),
+        TIMESTAMP(BenchColumns.column("c", JDBCType.TIMESTAMP, "timestamp", null, null)),
+        BIT(BenchColumns.column("c", JDBCType.BIT, "bit", 8, null)),
+        UUID(BenchColumns.column("c", JDBCType.OTHER, "uuid", null, null)),
+        JSONB(BenchColumns.column("c", JDBCType.OTHER, "jsonb", null, null));
+
+        private final Column column;
+
+        GenCase(Column column) {
+            this.column = column;
+        }
+    }
+
+    @Param
+    public GenCase genCase;
+
+    private DataGenerator<?> generator;
+
+    @Setup
+    public void setup() {
+        generator = new PostgresSupport().getDataGenerator(genCase.column, new java.util.Random(SEED));
+    }
+
+    @Benchmark
+    public Object generate() {
+        return generator.generate();
+    }
+
+    @Benchmark
+    public String generateAsString() {
+        return generator.generateAsString();
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/RowDispatchBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/RowDispatchBenchmark.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Column;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.DataGenerator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Models the per-cell dispatch in {@link io.bloviate.db.TableFiller#fill()} (the inner loop at
+ * {@code TableFiller.java:149-164}) <em>without</em> JDBC: for each column it does the
+ * {@code generatorMap.get(column)} HashMap lookup and calls {@code generate()}, sinking the
+ * result into a {@link Blackhole}.
+ *
+ * <p>This isolates the dispatch overhead the issue-#447 hot-loop micro-optimization (#5) targets
+ * — replacing the per-cell {@link Map#get} (keyed on the {@link Column} record's value-based
+ * hashCode) with positional array indexing — giving that change a clean before/after baseline.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class RowDispatchBenchmark {
+
+    private List<Column> filteredColumns;
+    private Map<Column, DataGenerator<?>> generatorMap;
+
+    @Setup
+    public void setup() {
+        filteredColumns = BenchColumns.wideRow();
+
+        // mirror TableFiller's setup: one seeded generator per column, resolved through DatabaseSupport
+        generatorMap = new HashMap<>();
+        PostgresSupport support = new PostgresSupport();
+        long seed = 1L;
+        for (Column column : filteredColumns) {
+            generatorMap.put(column, support.getDataGenerator(column, new Random(seed++)));
+        }
+    }
+
+    @Benchmark
+    public void dispatchRow(Blackhole blackhole) {
+        for (Column column : filteredColumns) {
+            DataGenerator<?> generator = generatorMap.get(column);
+            blackhole.consume(generator.generate());
+        }
+    }
+}

--- a/bloviate-benchmarks/src/test/java/io/bloviate/bench/AbstractFillBenchmark.java
+++ b/bloviate-benchmarks/src/test/java/io/bloviate/bench/AbstractFillBenchmark.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.db.Database;
+import io.bloviate.db.DatabaseConfiguration;
+import io.bloviate.db.DatabaseFiller;
+import io.bloviate.db.Table;
+import io.bloviate.db.TableConfiguration;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
+import io.bloviate.util.DatabaseUtils;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Repeatable end-to-end fill timing harness — the issue-#447 baseline for the IO/concurrency-bound
+ * optimizations (#1 parallel table fill, #3 commit tuning, #4 batch rewrite).
+ *
+ * <p>Each measured iteration truncates the schema, times a full {@link DatabaseFiller#fill()}
+ * (metadata fetch included, exactly what a user pays), and reports throughput as rows/second. A
+ * fixed {@link #SEED} makes every iteration generate identical data, so timings are comparable
+ * across runs and across optimization branches. JMH is deliberately not used here: it forks JVMs
+ * and runs short timed bursts, which fits poorly with multi-second container fills.
+ *
+ * <p>Tunable via system properties: {@code bench.warmup} (default 1), {@code bench.iterations}
+ * (3), {@code bench.rows} (default-row-count for the wide schema, 50,000), {@code bench.warehouses}
+ * (TPC-C scale factor, 1), {@code bench.batch} (JDBC batch size, 1000).
+ */
+abstract class AbstractFillBenchmark {
+
+    /** Fixed base seed → identical data every iteration and every run (reproducibility). */
+    protected static final long SEED = 42L;
+
+    protected static final int WARMUP_FILLS = Integer.getInteger("bench.warmup", 1);
+    protected static final int MEASURED_FILLS = Integer.getInteger("bench.iterations", 3);
+    protected static final long ROWS = Long.getLong("bench.rows", 50_000L);
+    protected static final int BATCH_SIZE = Integer.getInteger("bench.batch", 1000);
+
+    // TPC-C cardinalities; modest defaults (~60k rows) keep a casual run quick, scale up via -D
+    protected static final int WAREHOUSES = Integer.getInteger("bench.warehouses", 1);
+    protected static final int ITEMS = Integer.getInteger("bench.items", 10_000);
+    protected static final int DISTRICTS = Integer.getInteger("bench.districts", 10);
+    protected static final int CUSTOMERS = Integer.getInteger("bench.customers", 300);
+    protected static final int MIN_LINES = Integer.getInteger("bench.minLines", 5);
+    protected static final int MAX_LINES = Integer.getInteger("bench.maxLines", 15);
+
+    /** TPC-C table configuration at the {@code bench.*} scale, shared by every DB runner. */
+    protected static Set<TableConfiguration> tpccTables() {
+        return TPCCConfiguration.build(WAREHOUSES, ITEMS, DISTRICTS, CUSTOMERS, MIN_LINES, MAX_LINES);
+    }
+
+    protected static HikariDataSource dataSource(JdbcDatabaseContainer<?> container) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(container.getJdbcUrl());
+        config.setUsername(container.getUsername());
+        config.setPassword(container.getPassword());
+        config.setDriverClassName(container.getDriverClassName());
+        return new HikariDataSource(config);
+    }
+
+    /**
+     * DB-specific bulk clear of all user tables between fills (foreign keys make ordering matter,
+     * so each database overrides this with the right cascade / FK-check handling).
+     */
+    protected abstract void truncateAll(Connection connection, List<String> tables) throws SQLException;
+
+    /**
+     * Runs warmup fills, then {@link #MEASURED_FILLS} timed fills, printing per-iteration and
+     * best/mean throughput. The container must already be started with its schema applied.
+     */
+    protected void runBenchmark(String label, JdbcDatabaseContainer<?> container, DatabaseConfiguration configuration) throws SQLException {
+        try (HikariDataSource dataSource = dataSource(container);
+             Connection connection = dataSource.getConnection()) {
+
+            List<String> tables = tableNames(connection);
+
+            // warmup primes the JIT, connection pool and DB caches; not timed
+            for (int i = 0; i < WARMUP_FILLS; i++) {
+                truncateAll(connection, tables);
+                fill(connection, configuration);
+            }
+
+            // the dataset is deterministic, so the row total is the same for every iteration
+            long totalRows = countRows(connection, tables);
+
+            long bestNanos = Long.MAX_VALUE;
+            long sumNanos = 0;
+            for (int i = 0; i < MEASURED_FILLS; i++) {
+                truncateAll(connection, tables);
+                long start = System.nanoTime();
+                fill(connection, configuration);
+                long elapsed = System.nanoTime() - start;
+                bestNanos = Math.min(bestNanos, elapsed);
+                sumNanos += elapsed;
+                report(label, "iteration " + (i + 1), elapsed, totalRows);
+            }
+
+            report(label, "best", bestNanos, totalRows);
+            report(label, "mean", sumNanos / MEASURED_FILLS, totalRows);
+        }
+    }
+
+    private static void fill(Connection connection, DatabaseConfiguration configuration) throws SQLException {
+        new DatabaseFiller.Builder(connection, configuration).build().fill();
+    }
+
+    private static List<String> tableNames(Connection connection) throws SQLException {
+        List<String> names = new ArrayList<>();
+        Database database = DatabaseUtils.getMetadata(connection);
+        for (Table table : database.tables()) {
+            names.add(table.name());
+        }
+        return names;
+    }
+
+    private static long countRows(Connection connection, List<String> tables) throws SQLException {
+        long total = 0;
+        try (Statement statement = connection.createStatement()) {
+            for (String table : tables) {
+                try (ResultSet resultSet = statement.executeQuery("select count(*) from " + table)) {
+                    resultSet.next();
+                    total += resultSet.getLong(1);
+                }
+            }
+        }
+        return total;
+    }
+
+    private static void report(String label, String phase, long nanos, long rows) {
+        double seconds = nanos / 1_000_000_000.0;
+        double rowsPerSecond = seconds > 0 ? rows / seconds : 0;
+        System.out.printf(Locale.ROOT, "[bench] %-16s %-13s %,12d rows  %8.3f s  %,14.0f rows/s%n",
+                label, phase, rows, seconds, rowsPerSecond);
+    }
+}

--- a/bloviate-benchmarks/src/test/java/io/bloviate/bench/CockroachFillBenchmark.java
+++ b/bloviate-benchmarks/src/test/java/io/bloviate/bench/CockroachFillBenchmark.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.DatabaseConfiguration;
+import io.bloviate.ext.CockroachDBSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.CockroachContainer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+/**
+ * End-to-end fill throughput on CockroachDB, driving the realistic TPC-C schema. Opt-in — run with
+ * {@code -Pbench}.
+ */
+@Tag("benchmark")
+class CockroachFillBenchmark extends AbstractFillBenchmark {
+
+    @Override
+    protected void truncateAll(Connection connection, List<String> tables) throws SQLException {
+        if (tables.isEmpty()) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("TRUNCATE " + String.join(", ", tables) + " CASCADE");
+        }
+    }
+
+    @Test
+    void tpcc() throws SQLException {
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                BATCH_SIZE, 0, new CockroachDBSupport(), tpccTables(), SEED);
+
+        try (CockroachContainer database = new CockroachContainer("cockroachdb/cockroach:latest")
+                .withUrlParam("rewriteBatchedInserts", "true")
+                .withInitScript("create_tpcc.cockroachdb.sql")
+                .withCommand("start-single-node --insecure --store=type=mem,size=.75")) {
+            database.start();
+            runBenchmark("cockroach/tpcc", database, configuration);
+        }
+    }
+}

--- a/bloviate-benchmarks/src/test/java/io/bloviate/bench/MySqlFillBenchmark.java
+++ b/bloviate-benchmarks/src/test/java/io/bloviate/bench/MySqlFillBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.DatabaseConfiguration;
+import io.bloviate.ext.MySQLSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+/**
+ * End-to-end fill throughput on MySQL, driving the realistic TPC-C schema. Opt-in — run with
+ * {@code -Pbench}.
+ */
+@Tag("benchmark")
+class MySqlFillBenchmark extends AbstractFillBenchmark {
+
+    @Override
+    protected void truncateAll(Connection connection, List<String> tables) throws SQLException {
+        if (tables.isEmpty()) {
+            return;
+        }
+        // MySQL refuses TRUNCATE on a table referenced by a foreign key, so disable the checks
+        // for the duration of the reset
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET FOREIGN_KEY_CHECKS = 0");
+            for (String table : tables) {
+                statement.execute("TRUNCATE TABLE " + table);
+            }
+            statement.execute("SET FOREIGN_KEY_CHECKS = 1");
+        }
+    }
+
+    @Test
+    void tpcc() throws SQLException {
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                BATCH_SIZE, 0, new MySQLSupport(), tpccTables(), SEED);
+
+        try (MySQLContainer<?> database = new MySQLContainer<>("mysql:9.7")
+                .withConfigurationOverride("mysql-conf")
+                .withDatabaseName("bloviate")
+                .withUrlParam("rewriteBatchedStatements", "true")
+                .withInitScript("create_tpcc.mysql.sql")) {
+            database.start();
+            runBenchmark("mysql/tpcc", database, configuration);
+        }
+    }
+}

--- a/bloviate-benchmarks/src/test/java/io/bloviate/bench/PostgresFillBenchmark.java
+++ b/bloviate-benchmarks/src/test/java/io/bloviate/bench/PostgresFillBenchmark.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.DatabaseConfiguration;
+import io.bloviate.ext.PostgresSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * End-to-end fill throughput on PostgreSQL: a realistic TPC-C schema and a deliberately wide,
+ * FK-free schema (the parallel-table-fill target). Opt-in — run with {@code -Pbench}.
+ */
+@Tag("benchmark")
+class PostgresFillBenchmark extends AbstractFillBenchmark {
+
+    private static PostgreSQLContainer<?> container(String initScript) {
+        return new PostgreSQLContainer<>("postgres:18-alpine")
+                .withDatabaseName("bloviate")
+                .withUrlParam("rewriteBatchedInserts", "true")
+                .withUrlParam("stringtype", "unspecified")
+                .withInitScript(initScript);
+    }
+
+    @Override
+    protected void truncateAll(Connection connection, List<String> tables) throws SQLException {
+        if (tables.isEmpty()) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("TRUNCATE " + String.join(", ", tables) + " CASCADE");
+        }
+    }
+
+    @Test
+    void tpcc() throws SQLException {
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                BATCH_SIZE, 0, new PostgresSupport(), tpccTables(), SEED);
+
+        try (PostgreSQLContainer<?> database = container("create_tpcc.postgres.sql")) {
+            database.start();
+            runBenchmark("postgres/tpcc", database, configuration);
+        }
+    }
+
+    @Test
+    void wide() throws SQLException {
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                BATCH_SIZE, ROWS, new PostgresSupport(), new HashSet<>(), SEED);
+
+        try (PostgreSQLContainer<?> database = container("create_wide.postgres.sql")) {
+            database.start();
+            runBenchmark("postgres/wide", database, configuration);
+        }
+    }
+}

--- a/bloviate-benchmarks/src/test/resources/create_tpcc.cockroachdb.sql
+++ b/bloviate-benchmarks/src/test/resources/create_tpcc.cockroachdb.sql
@@ -1,0 +1,138 @@
+CREATE TABLE warehouse (
+    w_id       int            NOT NULL,
+    w_ytd      decimal(12, 2) NOT NULL,
+    w_tax      decimal(4, 4)  NOT NULL,
+    w_name     varchar(10)    NOT NULL,
+    w_street_1 varchar(20)    NOT NULL,
+    w_street_2 varchar(20)    NOT NULL,
+    w_city     varchar(20)    NOT NULL,
+    w_state    char(2)        NOT NULL,
+    w_zip      char(9)        NOT NULL,
+    PRIMARY KEY (w_id)
+);
+
+CREATE TABLE item (
+    i_id    int           NOT NULL,
+    i_name  varchar(24)   NOT NULL,
+    i_price decimal(5, 2) NOT NULL,
+    i_data  varchar(50)   NOT NULL,
+    i_im_id int           NOT NULL,
+    PRIMARY KEY (i_id)
+);
+
+CREATE TABLE stock (
+    s_w_id       int           NOT NULL,
+    s_i_id       int           NOT NULL,
+    s_quantity   int           NOT NULL,
+    s_ytd        decimal(8, 2) NOT NULL,
+    s_order_cnt  int           NOT NULL,
+    s_remote_cnt int           NOT NULL,
+    s_data       varchar(50)   NOT NULL,
+    s_dist_01    char(24)      NOT NULL,
+    s_dist_02    char(24)      NOT NULL,
+    s_dist_03    char(24)      NOT NULL,
+    s_dist_04    char(24)      NOT NULL,
+    s_dist_05    char(24)      NOT NULL,
+    s_dist_06    char(24)      NOT NULL,
+    s_dist_07    char(24)      NOT NULL,
+    s_dist_08    char(24)      NOT NULL,
+    s_dist_09    char(24)      NOT NULL,
+    s_dist_10    char(24)      NOT NULL,
+    FOREIGN KEY (s_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    FOREIGN KEY (s_i_id) REFERENCES item (i_id) ON DELETE CASCADE,
+    PRIMARY KEY (s_w_id, s_i_id)
+);
+
+CREATE TABLE district (
+    d_w_id      int            NOT NULL,
+    d_id        int            NOT NULL,
+    d_ytd       decimal(12, 2) NOT NULL,
+    d_tax       decimal(4, 4)  NOT NULL,
+    d_next_o_id int            NOT NULL,
+    d_name      varchar(10)    NOT NULL,
+    d_street_1  varchar(20)    NOT NULL,
+    d_street_2  varchar(20)    NOT NULL,
+    d_city      varchar(20)    NOT NULL,
+    d_state     char(2)        NOT NULL,
+    d_zip       char(9)        NOT NULL,
+    FOREIGN KEY (d_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    PRIMARY KEY (d_w_id, d_id)
+);
+
+CREATE TABLE customer (
+    c_w_id         int            NOT NULL,
+    c_d_id         int            NOT NULL,
+    c_id           int            NOT NULL,
+    c_discount     decimal(4, 4)  NOT NULL,
+    c_credit       char(2)        NOT NULL,
+    c_last         varchar(16)    NOT NULL,
+    c_first        varchar(16)    NOT NULL,
+    c_credit_lim   decimal(12, 2) NOT NULL,
+    c_balance      decimal(12, 2) NOT NULL,
+    c_ytd_payment  float          NOT NULL,
+    c_payment_cnt  int            NOT NULL,
+    c_delivery_cnt int            NOT NULL,
+    c_street_1     varchar(20)    NOT NULL,
+    c_street_2     varchar(20)    NOT NULL,
+    c_city         varchar(20)    NOT NULL,
+    c_state        char(2)        NOT NULL,
+    c_zip          char(9)        NOT NULL,
+    c_phone        char(16)       NOT NULL,
+    c_since        timestamp      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    c_middle       char(2)        NOT NULL,
+    c_data         varchar(500)   NOT NULL,
+    FOREIGN KEY (c_w_id, c_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE,
+    PRIMARY KEY (c_w_id, c_d_id, c_id)
+);
+
+CREATE TABLE history (
+    h_c_id   int           NOT NULL,
+    h_c_d_id int           NOT NULL,
+    h_c_w_id int           NOT NULL,
+    h_d_id   int           NOT NULL,
+    h_w_id   int           NOT NULL,
+    h_date   timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    h_amount decimal(6, 2) NOT NULL,
+    h_data   varchar(24)   NOT NULL,
+    FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE,
+    FOREIGN KEY (h_w_id, h_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE
+);
+
+CREATE TABLE open_order
+(
+    o_w_id       int       NOT NULL,
+    o_d_id       int       NOT NULL,
+    o_id         int       NOT NULL,
+    o_c_id       int       NOT NULL,
+    o_carrier_id int                DEFAULT NULL,
+    o_ol_cnt     int       NOT NULL,
+    o_all_local  int       NOT NULL,
+    o_entry_d    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (o_w_id, o_d_id, o_id DESC),
+    FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE
+);
+
+CREATE TABLE new_order
+(
+    no_w_id int NOT NULL,
+    no_d_id int NOT NULL,
+    no_o_id int NOT NULL,
+    FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES open_order (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    PRIMARY KEY (no_w_id, no_d_id, no_o_id)
+);
+
+CREATE TABLE order_line (
+                            ol_w_id        int           NOT NULL,
+                            ol_d_id        int           NOT NULL,
+                            ol_o_id        int           NOT NULL,
+                            ol_number      int           NOT NULL,
+                            ol_i_id        int           NOT NULL,
+                            ol_delivery_d  timestamp NULL DEFAULT NULL,
+                            ol_amount      decimal(6, 2) NOT NULL,
+                            ol_supply_w_id int           NOT NULL,
+                            ol_quantity    int           NOT NULL,
+                            ol_dist_info   char(24)      NOT NULL,
+                            FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES open_order (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+                            FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE,
+                            PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)
+);

--- a/bloviate-benchmarks/src/test/resources/create_tpcc.mysql.sql
+++ b/bloviate-benchmarks/src/test/resources/create_tpcc.mysql.sql
@@ -1,0 +1,145 @@
+CREATE TABLE warehouse
+(
+    w_id       int            NOT NULL,
+    w_ytd      decimal(12, 2) NOT NULL,
+    w_tax      decimal(4, 4)  NOT NULL,
+    w_name     varchar(10)    NOT NULL,
+    w_street_1 varchar(20)    NOT NULL,
+    w_street_2 varchar(20)    NOT NULL,
+    w_city     varchar(20)    NOT NULL,
+    w_state    char(2)        NOT NULL,
+    w_zip      char(9)        NOT NULL,
+    PRIMARY KEY (w_id)
+);
+
+CREATE TABLE item
+(
+    i_id    int           NOT NULL,
+    i_name  varchar(24)   NOT NULL,
+    i_price decimal(5, 2) NOT NULL,
+    i_data  varchar(50)   NOT NULL,
+    i_im_id int           NOT NULL,
+    PRIMARY KEY (i_id)
+);
+
+CREATE TABLE stock
+(
+    s_w_id       int           NOT NULL,
+    s_i_id       int           NOT NULL,
+    s_quantity   int           NOT NULL,
+    s_ytd        decimal(8, 2) NOT NULL,
+    s_order_cnt  int           NOT NULL,
+    s_remote_cnt int           NOT NULL,
+    s_data       varchar(50)   NOT NULL,
+    s_dist_01    char(24)      NOT NULL,
+    s_dist_02    char(24)      NOT NULL,
+    s_dist_03    char(24)      NOT NULL,
+    s_dist_04    char(24)      NOT NULL,
+    s_dist_05    char(24)      NOT NULL,
+    s_dist_06    char(24)      NOT NULL,
+    s_dist_07    char(24)      NOT NULL,
+    s_dist_08    char(24)      NOT NULL,
+    s_dist_09    char(24)      NOT NULL,
+    s_dist_10    char(24)      NOT NULL,
+    FOREIGN KEY (s_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    FOREIGN KEY (s_i_id) REFERENCES item (i_id) ON DELETE CASCADE,
+    PRIMARY KEY (s_w_id, s_i_id)
+);
+
+CREATE TABLE district
+(
+    d_w_id      int            NOT NULL,
+    d_id        int            NOT NULL,
+    d_ytd       decimal(12, 2) NOT NULL,
+    d_tax       decimal(4, 4)  NOT NULL,
+    d_next_o_id int            NOT NULL,
+    d_name      varchar(10)    NOT NULL,
+    d_street_1  varchar(20)    NOT NULL,
+    d_street_2  varchar(20)    NOT NULL,
+    d_city      varchar(20)    NOT NULL,
+    d_state     char(2)        NOT NULL,
+    d_zip       char(9)        NOT NULL,
+    FOREIGN KEY (d_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    PRIMARY KEY (d_w_id, d_id)
+);
+
+CREATE TABLE customer
+(
+    c_w_id         int            NOT NULL,
+    c_d_id         int            NOT NULL,
+    c_id           int            NOT NULL,
+    c_discount     decimal(4, 4)  NOT NULL,
+    c_credit       char(2)        NOT NULL,
+    c_last         varchar(16)    NOT NULL,
+    c_first        varchar(16)    NOT NULL,
+    c_credit_lim   decimal(12, 2) NOT NULL,
+    c_balance      decimal(12, 2) NOT NULL,
+    c_ytd_payment  float          NOT NULL,
+    c_payment_cnt  int            NOT NULL,
+    c_delivery_cnt int            NOT NULL,
+    c_street_1     varchar(20)    NOT NULL,
+    c_street_2     varchar(20)    NOT NULL,
+    c_city         varchar(20)    NOT NULL,
+    c_state        char(2)        NOT NULL,
+    c_zip          char(9)        NOT NULL,
+    c_phone        char(16)       NOT NULL,
+    c_since        timestamp      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    c_middle       char(2)        NOT NULL,
+    c_data         varchar(500)   NOT NULL,
+    FOREIGN KEY (c_w_id, c_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE,
+    PRIMARY KEY (c_w_id, c_d_id, c_id)
+);
+
+CREATE TABLE history
+(
+    h_c_id   int           NOT NULL,
+    h_c_d_id int           NOT NULL,
+    h_c_w_id int           NOT NULL,
+    h_d_id   int           NOT NULL,
+    h_w_id   int           NOT NULL,
+    h_date   timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    h_amount decimal(6, 2) NOT NULL,
+    h_data   varchar(24)   NOT NULL,
+    FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE,
+    FOREIGN KEY (h_w_id, h_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE
+);
+
+CREATE TABLE open_order
+(
+    o_w_id       int       NOT NULL,
+    o_d_id       int       NOT NULL,
+    o_id         int       NOT NULL,
+    o_c_id       int       NOT NULL,
+    o_carrier_id int                DEFAULT NULL,
+    o_ol_cnt     int       NOT NULL,
+    o_all_local  int       NOT NULL,
+    o_entry_d    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (o_w_id, o_d_id, o_id DESC),
+    FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE
+);
+
+CREATE TABLE new_order
+(
+    no_w_id int NOT NULL,
+    no_d_id int NOT NULL,
+    no_o_id int NOT NULL,
+    FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES open_order (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    PRIMARY KEY (no_w_id, no_d_id, no_o_id)
+);
+
+CREATE TABLE order_line
+(
+    ol_w_id        int           NOT NULL,
+    ol_d_id        int           NOT NULL,
+    ol_o_id        int           NOT NULL,
+    ol_number      int           NOT NULL,
+    ol_i_id        int           NOT NULL,
+    ol_delivery_d  timestamp NULL DEFAULT NULL,
+    ol_amount      decimal(6, 2) NOT NULL,
+    ol_supply_w_id int           NOT NULL,
+    ol_quantity    int           NOT NULL,
+    ol_dist_info   char(24)      NOT NULL,
+    FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES open_order (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE,
+    PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)
+);

--- a/bloviate-benchmarks/src/test/resources/create_tpcc.postgres.sql
+++ b/bloviate-benchmarks/src/test/resources/create_tpcc.postgres.sql
@@ -1,0 +1,145 @@
+CREATE TABLE warehouse
+(
+    w_id       int            NOT NULL,
+    w_ytd      decimal(12, 2) NOT NULL,
+    w_tax      decimal(4, 4)  NOT NULL,
+    w_name     varchar(10)    NOT NULL,
+    w_street_1 varchar(20)    NOT NULL,
+    w_street_2 varchar(20)    NOT NULL,
+    w_city     varchar(20)    NOT NULL,
+    w_state    char(2)        NOT NULL,
+    w_zip      char(9)        NOT NULL,
+    PRIMARY KEY (w_id)
+);
+
+CREATE TABLE item
+(
+    i_id    int           NOT NULL,
+    i_name  varchar(24)   NOT NULL,
+    i_price decimal(5, 2) NOT NULL,
+    i_data  varchar(50)   NOT NULL,
+    i_im_id int           NOT NULL,
+    PRIMARY KEY (i_id)
+);
+
+CREATE TABLE stock
+(
+    s_w_id       int           NOT NULL,
+    s_i_id       int           NOT NULL,
+    s_quantity   int           NOT NULL,
+    s_ytd        decimal(8, 2) NOT NULL,
+    s_order_cnt  int           NOT NULL,
+    s_remote_cnt int           NOT NULL,
+    s_data       varchar(50)   NOT NULL,
+    s_dist_01    char(24)      NOT NULL,
+    s_dist_02    char(24)      NOT NULL,
+    s_dist_03    char(24)      NOT NULL,
+    s_dist_04    char(24)      NOT NULL,
+    s_dist_05    char(24)      NOT NULL,
+    s_dist_06    char(24)      NOT NULL,
+    s_dist_07    char(24)      NOT NULL,
+    s_dist_08    char(24)      NOT NULL,
+    s_dist_09    char(24)      NOT NULL,
+    s_dist_10    char(24)      NOT NULL,
+    FOREIGN KEY (s_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    FOREIGN KEY (s_i_id) REFERENCES item (i_id) ON DELETE CASCADE,
+    PRIMARY KEY (s_w_id, s_i_id)
+);
+
+CREATE TABLE district
+(
+    d_w_id      int            NOT NULL,
+    d_id        int            NOT NULL,
+    d_ytd       decimal(12, 2) NOT NULL,
+    d_tax       decimal(4, 4)  NOT NULL,
+    d_next_o_id int            NOT NULL,
+    d_name      varchar(10)    NOT NULL,
+    d_street_1  varchar(20)    NOT NULL,
+    d_street_2  varchar(20)    NOT NULL,
+    d_city      varchar(20)    NOT NULL,
+    d_state     char(2)        NOT NULL,
+    d_zip       char(9)        NOT NULL,
+    FOREIGN KEY (d_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    PRIMARY KEY (d_w_id, d_id)
+);
+
+CREATE TABLE customer
+(
+    c_w_id         int            NOT NULL,
+    c_d_id         int            NOT NULL,
+    c_id           int            NOT NULL,
+    c_discount     decimal(4, 4)  NOT NULL,
+    c_credit       char(2)        NOT NULL,
+    c_last         varchar(16)    NOT NULL,
+    c_first        varchar(16)    NOT NULL,
+    c_credit_lim   decimal(12, 2) NOT NULL,
+    c_balance      decimal(12, 2) NOT NULL,
+    c_ytd_payment  float          NOT NULL,
+    c_payment_cnt  int            NOT NULL,
+    c_delivery_cnt int            NOT NULL,
+    c_street_1     varchar(20)    NOT NULL,
+    c_street_2     varchar(20)    NOT NULL,
+    c_city         varchar(20)    NOT NULL,
+    c_state        char(2)        NOT NULL,
+    c_zip          char(9)        NOT NULL,
+    c_phone        char(16)       NOT NULL,
+    c_since        timestamp      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    c_middle       char(2)        NOT NULL,
+    c_data         varchar(500)   NOT NULL,
+    FOREIGN KEY (c_w_id, c_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE,
+    PRIMARY KEY (c_w_id, c_d_id, c_id)
+);
+
+CREATE TABLE history
+(
+    h_c_id   int           NOT NULL,
+    h_c_d_id int           NOT NULL,
+    h_c_w_id int           NOT NULL,
+    h_d_id   int           NOT NULL,
+    h_w_id   int           NOT NULL,
+    h_date   timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    h_amount decimal(6, 2) NOT NULL,
+    h_data   varchar(24)   NOT NULL,
+    FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE,
+    FOREIGN KEY (h_w_id, h_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE
+);
+
+CREATE TABLE open_order
+(
+    o_w_id       int       NOT NULL,
+    o_d_id       int       NOT NULL,
+    o_id         int       NOT NULL,
+    o_c_id       int       NOT NULL,
+    o_carrier_id int                DEFAULT NULL,
+    o_ol_cnt     int       NOT NULL,
+    o_all_local  int       NOT NULL,
+    o_entry_d    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (o_w_id, o_d_id, o_id),
+    FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE
+);
+
+CREATE TABLE new_order
+(
+    no_w_id int NOT NULL,
+    no_d_id int NOT NULL,
+    no_o_id int NOT NULL,
+    FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES open_order (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    PRIMARY KEY (no_w_id, no_d_id, no_o_id)
+);
+
+CREATE TABLE order_line
+(
+    ol_w_id        int           NOT NULL,
+    ol_d_id        int           NOT NULL,
+    ol_o_id        int           NOT NULL,
+    ol_number      int           NOT NULL,
+    ol_i_id        int           NOT NULL,
+    ol_delivery_d  timestamp NULL DEFAULT NULL,
+    ol_amount      decimal(6, 2) NOT NULL,
+    ol_supply_w_id int           NOT NULL,
+    ol_quantity    int           NOT NULL,
+    ol_dist_info   char(24)      NOT NULL,
+    FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES open_order (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE,
+    PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
+);

--- a/bloviate-benchmarks/src/test/resources/create_wide.postgres.sql
+++ b/bloviate-benchmarks/src/test/resources/create_wide.postgres.sql
@@ -1,0 +1,32 @@
+--
+-- Copyright 2020 Tim Veil
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- A deliberately "wide" schema: many independent tables with no foreign keys between them.
+-- They all sit in a single topological level, so they are the target for the parallel
+-- table-fill optimization (#447, item #1). No primary keys: this is a raw-throughput fixture,
+-- not an integrity fixture, and unconstrained columns avoid random-value collisions on a
+-- generated key. Each table is filled with the configured default row count.
+
+CREATE TABLE wide_t01 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t02 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t03 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t04 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t05 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t06 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t07 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t08 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t09 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);
+CREATE TABLE wide_t10 (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);

--- a/bloviate-benchmarks/src/test/resources/mysql-conf/my.cnf
+++ b/bloviate-benchmarks/src/test/resources/mysql-conf/my.cnf
@@ -1,0 +1,12 @@
+# MySQL configuration override for TestContainers.
+#
+# TestContainers' bundled default my.cnf sets `innodb_log_file_size`, which was
+# deprecated in MySQL 8.0.30 and REMOVED in MySQL 9.x -- causing mysqld to abort
+# with "unknown variable 'innodb_log_file_size'". This override replaces it with
+# `innodb_redo_log_capacity` (the modern equivalent, available since 8.0.30) so
+# the tests run against current MySQL LTS releases (9.x).
+[mysqld]
+skip-name-resolve
+innodb_redo_log_capacity = 16777216
+innodb_buffer_pool_size = 33554432
+max_allowed_packet = 67108864

--- a/bloviate-benchmarks/src/test/resources/simplelogger.properties
+++ b/bloviate-benchmarks/src/test/resources/simplelogger.properties
@@ -1,0 +1,23 @@
+#
+# Copyright 2020 Tim Veil
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Benchmarks keep the engine at INFO: per-table StopWatch timings are useful, but the
+# per-fill DOT-graph dump (DEBUG) would flood the throughput output.
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.log.io.bloviate=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>bloviate-core</module>
         <module>bloviate-junit</module>
         <module>bloviate-testcontainers</module>
+        <module>bloviate-benchmarks</module>
     </modules>
 
     <properties>
@@ -72,7 +73,11 @@
         <postgresql.version>42.7.11</postgresql.version>
         <mysql.version>9.7.0</mysql.version>
 
+        <!-- benchmark dependency versions -->
+        <jmh.version>1.37</jmh.version>
+
         <!-- plugin versions -->
+        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
@@ -193,6 +198,18 @@
                 <version>${mysql.version}</version>
             </dependency>
 
+            <!-- benchmarks -->
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${jmh.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmh.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -208,6 +225,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## Summary

Establishes the performance **baseline** for #447 (performance optimizations for large datasets) *before* any optimization work, so future changes can be proven meaningful and regressions caught.

New non-published **`bloviate-benchmarks`** module with two complementary suites — matching the two regimes #447's optimizations span:

### CPU micro-benchmarks (JMH)
- `GeneratorBenchmark` — per-generator `generate()`/`generateAsString()` throughput across representative column types.
- `RowDispatchBenchmark` — models the `TableFiller.fill()` inner loop (the per-cell `generatorMap.get(column)` HashMap lookup); the clean baseline for the planned hot-loop array-indexing change.
- Both resolve generators via `DatabaseSupport.getDataGenerator` exactly as `TableFiller` does; packaged into a runnable `benchmarks.jar`.

### End-to-end fill (real database)
- Opt-in JUnit runners tagged `@Tag("benchmark")`, one per DB (Postgres/MySQL/CockroachDB), reusing the existing TestContainers stack.
- Each timed iteration truncates → fills → prints `rows/sec`; fixed seed for reproducible, comparable timings.
- Postgres covers TPC-C **and** a deliberately wide, FK-free schema (the parallel-table-fill target).
- **Skipped by a normal build**; run with `-Pbench`. Tunable via `bench.*` system properties.

See `BENCHMARKS.md` for how to run both suites and a results table to fill in.

## Not published
The module skips deploy/install/source/javadoc/JaCoCo, and `bloviate-core` does not depend on it.

## Verification
- Full reactor `package` — all 5 modules build; `benchmarks.jar` produced.
- JMH smoke: `RowDispatchBenchmark` and `GeneratorBenchmark` (enum `@Param`) run and emit throughput.
- E2E skipped by default; under `-Pbench`, `postgres/wide` (~139k rows/s) and `postgres/tpcc` (truncate→refill on the composite-key schema) run green.

## Out of scope
The actual optimizations (#1–#5 in the issue) — this PR is only the measurement baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)