### PR TITLE
feat(gen): migrate RNG to java.util.random.RandomGenerator (L64X128MixRandom)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,6 +180,13 @@ Two important properties fall out of this design:
 Every generator — built-in, registry-supplied, or per-column override — is constructed with this
 engine-managed seed, so reproducibility holds no matter how a column's generator was chosen.
 
+The per-column seed feeds a [`java.util.random.RandomGenerator`](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/random/package-summary.html)
+created by [`RandomGenerators.create(seed)`](bloviate-core/src/main/java/io/bloviate/util/RandomGenerators.java),
+which uses the JDK general-purpose default algorithm **`L64X128MixRandom`** rather than the legacy
+`java.util.Random` (a 48-bit LCG with a documented statistical defect and `synchronized` methods).
+The seeding architecture is unchanged — one isolated, deterministically-seeded generator per column —
+so output stays reproducible and order-independent; only the algorithm and statistical quality improve.
+
 ## 5. Database support — the Strategy pattern
 
 Different databases expose different types. [`DatabaseSupport`](bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java)
@@ -191,7 +198,7 @@ hook that subclasses override to add or replace entries for vendor-specific type
 classDiagram
     class DatabaseSupport {
         <<interface>>
-        +getDataGenerator(Column, Random) DataGenerator
+        +getDataGenerator(Column, RandomGenerator) DataGenerator
         +forConnection(Connection)$ DatabaseSupport
         +forProduct(String)$ DatabaseSupport
     }
@@ -256,14 +263,14 @@ GeneratorRegistry registry = new GeneratorRegistry.Builder()
 ```
 
 Crucially, registry- and plugin-supplied generators are still constructed with the engine's seeded
-`Random`, so they remain just as reproducible as the built-ins.
+`RandomGenerator`, so they remain just as reproducible as the built-ins.
 
 ## 7. The generator library — Builder pattern
 
 Every generator implements [`DataGenerator<T>`](bloviate-core/src/main/java/io/bloviate/gen/DataGenerator.java),
 which can `generate()` a typed value, `generateAsString()` for flat files, bind itself to a
 `PreparedStatement` (`generateAndSet`), and read a value back from a `ResultSet` (`get`). Each is
-constructed through a static inner `Builder` seeded with a `Random`:
+constructed through a static inner `Builder` seeded with a `RandomGenerator`:
 
 ```java
 new SimpleStringGenerator.Builder(random).size(100).build();
@@ -340,7 +347,7 @@ pattern lives and what it's doing for us.
 | **Builder** | Nearly everything: [`DatabaseFiller.Builder`](bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java), [`TableFiller.Builder`](bloviate-core/src/main/java/io/bloviate/db/TableFiller.java), every `*Generator.Builder`, [`GeneratorRegistry.Builder`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java), [`FlatFileGenerator.Builder`](bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java), [`BloviateContainers.Builder`](bloviate-testcontainers/src/main/java/io/bloviate/testcontainers/BloviateContainers.java) | Readable construction of objects with many optional, defaulted parameters; immutable results with no telescoping constructors |
 | **Strategy** | [`DatabaseSupport`](bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java) + per-database implementations | Database-specific behavior is swappable at runtime; adding a database means adding a class, not editing the engine |
 | **Template Method** | [`AbstractDatabaseSupport`](bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java) seeds defaults, then calls the `configure()` hook | Subclasses customize *only* the vendor-specific slice; the invariant default registry is defined once |
-| **Factory** (functional) | [`GeneratorFactory`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorFactory.java), [`ColumnGeneratorFactory`](bloviate-core/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java) | Defers generator creation until the engine can supply a column-seeded `Random`, preserving reproducibility |
+| **Factory** (functional) | [`GeneratorFactory`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorFactory.java), [`ColumnGeneratorFactory`](bloviate-core/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java) | Defers generator creation until the engine can supply a column-seeded `RandomGenerator`, preserving reproducibility |
 | **Registry** | [`GeneratorRegistry`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java) with documented precedence | Override generation by name/type without subclassing; rules resolved in a fixed, predictable order |
 | **Service Provider (SPI)** | [`GeneratorPlugin`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorPlugin.java) via `ServiceLoader` | Third-party jars contribute generators by dropping a file on the classpath — zero engine coupling |
 | **Strategy / polymorphism** | The [`DataGenerator<T>`](bloviate-core/src/main/java/io/bloviate/gen/DataGenerator.java) hierarchy | One uniform interface (`generate` / bind / read-back) over ~50 type-specific implementations |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -183,3 +183,56 @@ date/time/timestamp columns. `PostgresParallelFillTest` asserts a parallel fill 
 sequential fill byte-for-byte across a TPC-C schema, comparing every column except the few that use
 wall-clock time *by design* (e.g. the order-line delivery date), which are intentionally
 non-deterministic.
+
+## Recorded results — issue #471 (RNG migration)
+
+[Issue #471](https://github.com/timveil/bloviate/issues/471) replaced the legacy `java.util.Random`
+(a 48-bit LCG with a documented statistical defect and `synchronized` methods) with a
+`java.util.random.RandomGenerator` using the JDK general-purpose default **`L64X128MixRandom`**
+(`RandomGenerators.create(seed)`). The per-column seeding architecture is unchanged, so output stays
+reproducible; only the algorithm changes. These numbers compare the two RNGs on the identical
+benchmark harness — old jar built from `HEAD`, new jar from the migration branch.
+
+**Environment**
+
+- Machine / CPU: Apple M5 (Mac17,3), 10 cores
+- JDK: Temurin 25.0.3+9 LTS
+- Harness: `GeneratorBenchmark` / `RowDispatchBenchmark`, JMH `-f 1 -wi 3 -w 1 -i 5 -r 1` (quick settings; error bars on the clean `generate()` rows are <1%). Higher is better.
+
+### CPU (JMH, ops/us — higher is better)
+
+Raw value generation, old vs new RNG:
+
+| `generate()` | `java.util.Random` | `L64X128MixRandom` | Δ |
+|--------------|------------------:|-------------------:|---:|
+| INTEGER | 180.8 | 318.7 | **+76%** |
+| BIGINT | 91.4 | 320.5 | **+3.5×** |
+| DOUBLE | 91.6 | 344.9 | **+3.8×** |
+| VARCHAR_SHORT (16) | 9.5 | 17.2 | **+80%** |
+| VARCHAR_LONG (256) | 0.59 | 1.32 | **+2.2×** |
+| UUID | 9.4 | 9.8 | +4% |
+
+Integer/long/double draws benefit most — no lock and a better algorithm. UUID is dominated by the
+16-byte `nextBytes` copy, so it barely moves. Strings improved too: `SeededRandomUtils` no longer
+delegates to commons-lang3 `RandomStringUtils` (which only accepts a `java.util.Random`); the
+alphabetic/numeric paths now draw directly from a fixed character pool, which removes the
+draw-and-reject loop entirely.
+
+End-to-end per-row dispatch — `RowDispatchBenchmark` over a 16-column row, the real inner loop of
+`TableFiller.fill()`:
+
+| Benchmark | `java.util.Random` | `L64X128MixRandom` | Δ |
+|-----------|------------------:|-------------------:|---:|
+| `dispatchRow` (HashMap) | 0.313 | 0.607 | **+94%** |
+| `dispatchRowIndexed` (array) | 0.327 | 0.661 | **+102%** |
+
+```mermaid
+xychart-beta
+    title "Per-row generate() dispatch — 16-column row (ops/us, higher is better)"
+    x-axis ["Random (HashMap)", "L64X128 (HashMap)", "Random (array)", "L64X128 (array)"]
+    y-axis "ops / us" 0 --> 0.7
+    bar [0.313, 0.607, 0.327, 0.661]
+```
+
+**Bottom line:** ~2× faster per-row generation with better statistical quality, no new dependency,
+and unchanged reproducibility.

--- a/README.md
+++ b/README.md
@@ -130,8 +130,10 @@ Generate CSV files with custom column definitions:
 import io.bloviate.file.FlatFileGenerator;
 import io.bloviate.file.ColumnDefinition;
 import io.bloviate.gen.*;
+import io.bloviate.util.RandomGenerators;
+import java.util.random.RandomGenerator;
 
-Random random = new Random();
+RandomGenerator random = RandomGenerators.create(42L);
 List<ColumnDefinition> columns = Arrays.asList(
     new ColumnDefinition("id", new IntegerGenerator.Builder(random).build()),
     new ColumnDefinition("name", new SimpleStringGenerator.Builder(random).build()),
@@ -239,8 +241,8 @@ import io.bloviate.ext.PostgresSupport;
 import io.bloviate.gen.IntegerGenerator;
 import java.util.Set;
 
-// ColumnGeneratorFactory is a `Random -> DataGenerator<?>` lambda.
-// The engine supplies a column-seeded Random for reproducible output.
+// ColumnGeneratorFactory is a `RandomGenerator -> DataGenerator<?>` lambda.
+// The engine supplies a column-seeded RandomGenerator for reproducible output.
 Set<ColumnConfiguration> columnConfigs = Set.of(
     new ColumnConfiguration("status_code",
         random -> new IntegerGenerator.Builder(random).start(1).end(10).build())

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/GeneratorBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/GeneratorBenchmark.java
@@ -19,6 +19,7 @@ package io.bloviate.bench;
 import io.bloviate.db.Column;
 import io.bloviate.ext.PostgresSupport;
 import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -83,7 +84,7 @@ public class GeneratorBenchmark {
 
     @Setup
     public void setup() {
-        generator = new PostgresSupport().getDataGenerator(genCase.column, new java.util.Random(SEED));
+        generator = new PostgresSupport().getDataGenerator(genCase.column, RandomGenerators.create(SEED));
     }
 
     @Benchmark

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/RowDispatchBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/RowDispatchBenchmark.java
@@ -19,6 +19,7 @@ package io.bloviate.bench;
 import io.bloviate.db.Column;
 import io.bloviate.ext.PostgresSupport;
 import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -34,7 +35,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -70,7 +70,7 @@ public class RowDispatchBenchmark {
         long seed = 1L;
         for (int i = 0; i < filteredColumns.size(); i++) {
             Column column = filteredColumns.get(i);
-            DataGenerator<?> generator = support.getDataGenerator(column, new Random(seed++));
+            DataGenerator<?> generator = support.getDataGenerator(column, RandomGenerators.create(seed++));
             generatorMap.put(column, generator);
             generators[i] = generator;
         }

--- a/bloviate-core/src/main/java/io/bloviate/db/ColumnConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/ColumnConfiguration.java
@@ -21,8 +21,8 @@ package io.bloviate.db;
  * generator that would otherwise be auto-detected from the column's JDBC type.
  *
  * <p>The column name is matched case-insensitively. The generator is built lazily
- * by the fill engine via {@link ColumnGeneratorFactory#create(java.util.Random)},
- * using a column-seeded {@link java.util.Random} so overridden columns remain
+ * by the fill engine via {@link ColumnGeneratorFactory#create(java.util.random.RandomGenerator)},
+ * using a column-seeded {@link java.util.random.RandomGenerator} so overridden columns remain
  * reproducible.
  *
  * @param columnName the name of the column to override (matched case-insensitively)

--- a/bloviate-core/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java
@@ -18,12 +18,12 @@ package io.bloviate.db;
 
 import io.bloviate.gen.DataGenerator;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Builds the {@link DataGenerator} used to override generation for a single column.
  *
- * <p>The fill engine supplies a {@link Random} that is already seeded for the
+ * <p>The fill engine supplies a {@link RandomGenerator} that is already seeded for the
  * target column, so generators created here participate in the same
  * reproducible, per-column seeding (and foreign-key reseeding) as
  * auto-detected generators. Implementations should build their generator from
@@ -41,5 +41,5 @@ public interface ColumnGeneratorFactory {
      * @param random the column-seeded random source provided by the fill engine
      * @return the generator to use for the column
      */
-    DataGenerator<?> create(Random random);
+    DataGenerator<?> create(RandomGenerator random);
 }

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -20,6 +20,7 @@ import io.bloviate.ext.DatabaseSupport;
 import io.bloviate.ext.GeneratorRegistry;
 import io.bloviate.gen.DataGenerator;
 import io.bloviate.util.DatabaseUtils;
+import io.bloviate.util.RandomGenerators;
 import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Fills a database table with generated data.
@@ -83,6 +84,7 @@ public class TableFiller implements Fillable {
         long[] maxInvocations = new long[columnCount];
 
         DatabaseSupport databaseSupport = databaseConfiguration.databaseSupport();
+        GeneratorRegistry registry = databaseConfiguration.generatorRegistry();
 
         TableConfiguration tableConfiguration = databaseConfiguration.tableConfiguration(table.name());
 
@@ -116,7 +118,7 @@ public class TableFiller implements Fillable {
             // resolve the generator by precedence; the generator is always seeded by the engine
             // so it stays reproducible regardless of which path provides it:
             //   per-column config > custom registry (name > typeName > JDBCType) > support default
-            Random random = new Random(seed);
+            RandomGenerator random = RandomGenerators.create(seed);
 
             ColumnConfiguration columnConfiguration = tableConfiguration != null
                     ? tableConfiguration.columnConfiguration(column.name())
@@ -126,7 +128,6 @@ public class TableFiller implements Fillable {
             if (columnConfiguration != null) {
                 dataGenerator = columnConfiguration.generatorFactory().create(random);
             } else {
-                GeneratorRegistry registry = databaseConfiguration.generatorRegistry();
                 DataGenerator<?> custom = registry != null ? registry.resolve(column, random) : null;
                 dataGenerator = custom != null ? custom : databaseSupport.getDataGenerator(column, random);
             }
@@ -158,9 +159,10 @@ public class TableFiller implements Fillable {
 
                     long maxInvocation = maxInvocations[col];
                     if (maxInvocation > 0 && rowCounter != 0 && rowCounter % maxInvocation == 0) {
-                        // foreign-key generator has exhausted the parent key space; reseed so it
-                        // replays the same parent keys and never references a non-existent parent
-                        dataGenerator.setSeed(reseedSeeds[col]);
+                        // foreign-key generator has exhausted the parent key space; reseed its random
+                        // source so it replays the same parent keys and never references a non-existent
+                        // parent (generator counter/sequence state is preserved)
+                        dataGenerator.reseed(reseedSeeds[col]);
                     }
 
                     dataGenerator.generateAndSet(connection, ps, col + 1);

--- a/bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
@@ -22,7 +22,7 @@ import io.bloviate.gen.*;
 import java.sql.JDBCType;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Base {@link DatabaseSupport} that maps columns to generators through a
@@ -31,7 +31,7 @@ import java.util.Random;
  * <p>The constructor seeds the registry with cross-database defaults and then invokes
  * {@link #configure(Map)}, which database-specific subclasses override to add or replace
  * entries (for example, to handle driver-specific type names). Types absent from the
- * registry are unsupported and cause {@link #getDataGenerator(Column, Random)} to throw.
+ * registry are unsupported and cause {@link #getDataGenerator(Column, RandomGenerator)} to throw.
  *
  * @see GeneratorFactory
  */
@@ -47,7 +47,7 @@ public abstract class AbstractDatabaseSupport implements DatabaseSupport {
     }
 
     @Override
-    public final DataGenerator<?> getDataGenerator(Column column, Random random) {
+    public final DataGenerator<?> getDataGenerator(Column column, RandomGenerator random) {
         GeneratorFactory factory = registry.get(column.jdbcType());
         if (factory == null) {
             throw new UnsupportedOperationException("JDBCType [" + column.jdbcType() + "] not supported");

--- a/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java
@@ -22,7 +22,7 @@ import io.bloviate.gen.DataGenerator;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Locale;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Database-specific support interface for data generation and SQL handling.
@@ -53,7 +53,7 @@ public interface DatabaseSupport {
      * @return a data generator appropriate for the column type
      * @throws UnsupportedOperationException if the column type is not supported
      */
-    DataGenerator<?> getDataGenerator(Column column, Random random);
+    DataGenerator<?> getDataGenerator(Column column, RandomGenerator random);
 
     /**
      * Selects a {@link DatabaseSupport} for the given JDBC product name (as reported by

--- a/bloviate-core/src/main/java/io/bloviate/ext/GeneratorFactory.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/GeneratorFactory.java
@@ -19,7 +19,7 @@ package io.bloviate.ext;
 import io.bloviate.db.Column;
 import io.bloviate.gen.DataGenerator;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Builds the {@link DataGenerator} used for a column of a particular JDBC type.
@@ -42,5 +42,5 @@ public interface GeneratorFactory {
      * @param random the seeded random source supplied by the fill engine
      * @return the generator to use for the column
      */
-    DataGenerator<?> create(Column column, Random random);
+    DataGenerator<?> create(Column column, RandomGenerator random);
 }

--- a/bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.ServiceLoader;
 import java.util.regex.Pattern;
 
@@ -60,9 +60,9 @@ import java.util.regex.Pattern;
  *     &gt; built-in DatabaseSupport default
  * </pre>
  *
- * <p>If no rule matches, {@link #resolve(Column, Random)} returns {@code null} and the engine falls
+ * <p>If no rule matches, {@link #resolve(Column, RandomGenerator)} returns {@code null} and the engine falls
  * back to the {@link DatabaseSupport} default. Matched generators are constructed with the
- * engine-supplied, seeded {@link Random}, so they remain reproducible like every built-in generator.
+ * engine-supplied, seeded {@link RandomGenerator}, so they remain reproducible like every built-in generator.
  *
  * <p>Instances are immutable and built through the {@link Builder}. External jars can contribute
  * rules automatically by providing a {@link GeneratorPlugin} discovered via
@@ -98,7 +98,7 @@ public final class GeneratorRegistry {
      * @return the matching generator, or {@code null} if no rule applies (caller should fall back to
      * the {@link DatabaseSupport} default)
      */
-    public DataGenerator<?> resolve(Column column, Random random) {
+    public DataGenerator<?> resolve(Column column, RandomGenerator random) {
         String name = column.name();
         if (name != null) {
             for (NameRule rule : nameRules) {

--- a/bloviate-core/src/main/java/io/bloviate/gen/AbstractBuilder.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/AbstractBuilder.java
@@ -17,7 +17,7 @@
 package io.bloviate.gen;
 
 import java.time.Instant;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Abstract base class for data generator builders.
@@ -41,14 +41,14 @@ public abstract class AbstractBuilder<T> implements Builder<T> {
     /**
      * The random number generator used for creating data.
      */
-    protected final Random random;
+    protected final RandomGenerator random;
 
     /**
      * Constructs a new AbstractBuilder with the specified random number generator.
      *
      * @param random the random number generator to use for data generation
      */
-    public AbstractBuilder(Random random) {
+    public AbstractBuilder(RandomGenerator random) {
         this.random = random;
     }
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
@@ -16,6 +16,7 @@
 
 package io.bloviate.gen;
 
+import io.bloviate.util.RandomGenerators;
 import io.bloviate.util.SeededRandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Abstract base class providing common functionality for data generators.
@@ -51,24 +52,34 @@ public abstract class AbstractDataGenerator<T> implements DataGenerator<T> {
 
     final Logger logger = LoggerFactory.getLogger(getClass());
 
-    protected final Random random;
+    protected RandomGenerator random;
 
     /**
      * A reusable {@link SeededRandomUtils} view over {@link #random}, created once per
      * generator so subclasses don't allocate a fresh wrapper on every {@code generate()}
-     * call. Because it holds the same {@code random} reference, it observes any
-     * {@link #setSeed(long)} reseeding.
+     * call. It is rebuilt by {@link #reseed(long)} so it always wraps the current
+     * {@link #random}.
      */
-    protected final SeededRandomUtils randomUtils;
+    protected SeededRandomUtils randomUtils;
 
-    public AbstractDataGenerator(Random random) {
+    public AbstractDataGenerator(RandomGenerator random) {
         this.random = random;
         this.randomUtils = new SeededRandomUtils(random);
     }
 
+    /**
+     * Resets only the random source, replacing {@link #random} (and its {@link #randomUtils}
+     * view) with a freshly seeded {@link RandomGenerator}. Any counter or sequence state held by
+     * a subclass is intentionally left untouched, mirroring the legacy {@code Random.setSeed}
+     * behavior the engine relied on for foreign-key wraparound &mdash; only the random draws
+     * replay, not the generator's own progression.
+     *
+     * @param seed the seed for the replacement generator
+     */
     @Override
-    public void setSeed(long seed) {
-        random.setSeed(seed);
+    public void reseed(long seed) {
+        this.random = RandomGenerators.create(seed);
+        this.randomUtils = new SeededRandomUtils(random);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
@@ -23,7 +23,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
 
@@ -89,7 +89,7 @@ public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
         private Integer maxPrecision;
         private Integer maxDigits;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class BitGenerator extends AbstractDataGenerator<Integer> {
 
@@ -37,7 +37,7 @@ public class BitGenerator extends AbstractDataGenerator<Integer> {
 
     public static class Builder extends AbstractBuilder<Integer> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class BitStringGenerator extends AbstractDataGenerator<String> {
 
@@ -51,7 +51,7 @@ public class BitStringGenerator extends AbstractDataGenerator<String> {
     public static class Builder extends AbstractBuilder<String> {
         private int size = 1;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/BooleanGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BooleanGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generator for Boolean values.
@@ -56,7 +56,7 @@ public class BooleanGenerator extends AbstractDataGenerator<Boolean> {
          *
          * @param random the random number generator to use
          */
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/ByteGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ByteGenerator.java
@@ -23,7 +23,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class ByteGenerator extends AbstractDataGenerator<Byte[]> {
 
@@ -59,7 +59,7 @@ public class ByteGenerator extends AbstractDataGenerator<Byte[]> {
 
         private int size = 25;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class CharacterGenerator extends AbstractDataGenerator<Character> {
 
@@ -47,7 +47,7 @@ public class CharacterGenerator extends AbstractDataGenerator<Character> {
     }
 
     public static class Builder extends AbstractBuilder<Character> {
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -59,7 +59,7 @@ public class ChildCountGenerator extends AbstractDataGenerator<Integer> {
 
         private ChildCardinality cardinality;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Emits one component of a child table's composite key when each parent has a
@@ -101,7 +101,7 @@ public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> {
         private long repeat = 1;
         private int cycle = 1;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates IPv4 CIDR network specifications of the form {@code a.b.c.0/24}.
@@ -47,7 +47,7 @@ public class CidrGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -75,7 +75,7 @@ public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Intege
         private long repeat = 1;
         private int cycle = 1;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/CurrentSqlTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CurrentSqlTimestampGenerator.java
@@ -22,7 +22,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates the current timestamp at the moment of generation. The random
@@ -47,7 +47,7 @@ public class CurrentSqlTimestampGenerator extends AbstractDataGenerator<Timestam
 
     public static class Builder extends AbstractBuilder<Timestamp> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/DataGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DataGenerator.java
@@ -61,11 +61,15 @@ public interface DataGenerator<T> {
     String generateAsString();
 
     /**
-     * Sets the random seed for reproducible data generation.
-     * 
+     * Resets this generator's random source to the given seed for reproducible foreign-key
+     * wraparound. Implementations must replace the underlying {@link java.util.random.RandomGenerator}
+     * with a freshly seeded one (there is no in-place {@code setSeed} on
+     * {@link java.util.random.RandomGenerator}) while preserving any counter or sequence state the
+     * generator maintains, so that only random draws replay.
+     *
      * @param seed the random seed value
      */
-    void setSeed(long seed);
+    void reseed(long seed);
 
     /**
      * Generates a value and sets it on a PreparedStatement parameter.

--- a/bloviate-core/src/main/java/io/bloviate/gen/DateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DateGenerator.java
@@ -22,7 +22,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class DateGenerator extends AbstractDataGenerator<Date> {
 
@@ -48,7 +48,7 @@ public class DateGenerator extends AbstractDataGenerator<Date> {
         private Date startInclusive = Date.from(Instant.EPOCH);
         private Date endExclusive = Date.from(DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS));
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/DoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DoubleGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class DoubleGenerator extends AbstractDataGenerator<Double> {
 
@@ -48,7 +48,7 @@ public class DoubleGenerator extends AbstractDataGenerator<Double> {
         private double startInclusive = 0;
         private double endExclusive = Double.MAX_VALUE;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/FloatGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/FloatGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class FloatGenerator extends AbstractDataGenerator<Float> {
 
@@ -48,7 +48,7 @@ public class FloatGenerator extends AbstractDataGenerator<Float> {
         private float startInclusive = 0;
         private float endExclusive = Float.MAX_VALUE;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -101,7 +101,7 @@ public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> 
         private int start = 0;
         private long seed = 0;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -72,7 +72,7 @@ public class GroupedPrefixGenerator<T> extends AbstractDataGenerator<T> {
         private int prefixSize = 0;
         private DataGenerator<T> delegate;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class InetGenerator extends AbstractDataGenerator<String> {
 
@@ -41,7 +41,7 @@ public class InetGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/InstantGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InstantGenerator.java
@@ -21,7 +21,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class InstantGenerator extends AbstractDataGenerator<Instant> {
 
@@ -46,7 +46,7 @@ public class InstantGenerator extends AbstractDataGenerator<Instant> {
         private Instant startInclusive = Instant.EPOCH;
         private Instant endExclusive = DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS);
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
@@ -17,7 +17,7 @@
 package io.bloviate.gen;
 
 import java.sql.*;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
 
@@ -62,7 +62,7 @@ public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
 
         private int length = 3;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class IntegerGenerator extends AbstractDataGenerator<Integer> {
 
@@ -48,7 +48,7 @@ public class IntegerGenerator extends AbstractDataGenerator<Integer> {
         private int startInclusive = 0;
         private int endExclusive = Integer.MAX_VALUE;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class IntervalGenerator extends AbstractDataGenerator<String> {
 
@@ -48,7 +48,7 @@ public class IntervalGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/JsonbGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/JsonbGenerator.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generator for JSON / JSONB columns. Produces a JSON object literal (as a {@link String}) with a
@@ -71,7 +71,7 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
 
         private int fields = 3;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/LongGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/LongGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class LongGenerator extends AbstractDataGenerator<Long> {
 
@@ -48,7 +48,7 @@ public class LongGenerator extends AbstractDataGenerator<Long> {
         private long startInclusive = 0;
         private long endExclusive = Long.MAX_VALUE;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates MAC addresses as colon-separated hex octets, e.g. {@code 08:00:2b:01:02:03}.
@@ -57,7 +57,7 @@ public class MacAddressGenerator extends AbstractDataGenerator<String> {
 
         private int octets = 6;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
@@ -22,7 +22,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates a {@link BigDecimal} drawn uniformly from the half-open range
@@ -59,7 +59,7 @@ public class ScaledBigDecimalGenerator extends AbstractDataGenerator<BigDecimal>
         private double endExclusive = 1;
         private int scale = 2;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -59,7 +59,7 @@ public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> {
         private int startInclusive = 1;
         private int endInclusive = Integer.MAX_VALUE;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class ShortGenerator extends AbstractDataGenerator<Short> {
 
@@ -47,7 +47,7 @@ public class ShortGenerator extends AbstractDataGenerator<Short> {
         private int startInclusive = 0;
         private int endExclusive = Short.MAX_VALUE;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class SimpleStringGenerator extends AbstractDataGenerator<String> {
 
@@ -45,7 +45,7 @@ public class SimpleStringGenerator extends AbstractDataGenerator<String> {
 
         private boolean numbers = false;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlBlobGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlBlobGenerator.java
@@ -17,7 +17,7 @@
 package io.bloviate.gen;
 
 import java.sql.*;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class SqlBlobGenerator extends AbstractDataGenerator<Blob> {
     //todo
@@ -44,7 +44,7 @@ public class SqlBlobGenerator extends AbstractDataGenerator<Blob> {
 
     public static class Builder extends AbstractBuilder<Blob> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlClobGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlClobGenerator.java
@@ -17,7 +17,7 @@
 package io.bloviate.gen;
 
 import java.sql.*;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class SqlClobGenerator extends AbstractDataGenerator<Clob> {
     //todo
@@ -44,7 +44,7 @@ public class SqlClobGenerator extends AbstractDataGenerator<Clob> {
 
     public static class Builder extends AbstractBuilder<Clob> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlDateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlDateGenerator.java
@@ -19,7 +19,7 @@ package io.bloviate.gen;
 
 import java.sql.*;
 import java.time.temporal.ChronoUnit;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class SqlDateGenerator extends AbstractDataGenerator<Date> {
 
@@ -48,7 +48,7 @@ public class SqlDateGenerator extends AbstractDataGenerator<Date> {
         private Date startInclusive = new Date(DEFAULT_REFERENCE.minus(100, ChronoUnit.DAYS).toEpochMilli());
         private Date endExclusive = new Date(DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS).toEpochMilli());
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlStructGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlStructGenerator.java
@@ -19,7 +19,7 @@ package io.bloviate.gen;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Struct;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generator for SQL {@code STRUCT} (structured / user-defined type) columns.
@@ -61,7 +61,7 @@ public class SqlStructGenerator extends AbstractDataGenerator<Struct> {
 
     public static class Builder extends AbstractBuilder<Struct> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlTimeGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlTimeGenerator.java
@@ -19,7 +19,7 @@ package io.bloviate.gen;
 import java.sql.*;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class SqlTimeGenerator extends AbstractDataGenerator<Time> {
 
@@ -48,7 +48,7 @@ public class SqlTimeGenerator extends AbstractDataGenerator<Time> {
         private Time startInclusive = new Time(Instant.EPOCH.toEpochMilli());
         private Time endExclusive = new Time(DEFAULT_REFERENCE.plus(100, ChronoUnit.HOURS).toEpochMilli());
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlTimestampGenerator.java
@@ -19,7 +19,7 @@ package io.bloviate.gen;
 import java.sql.*;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class SqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
 
@@ -48,7 +48,7 @@ public class SqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
         private Timestamp startInclusive = Timestamp.from(DEFAULT_REFERENCE.minus(100, ChronoUnit.DAYS));
         private Timestamp endExclusive = Timestamp.from(DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS));
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
@@ -21,7 +21,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Always generates the same configured {@link BigDecimal} value. The random source is ignored.
@@ -49,7 +49,7 @@ public class StaticBigDecimalGenerator extends AbstractDataGenerator<BigDecimal>
 
         private BigDecimal value = BigDecimal.ZERO;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Always generates the same configured double value. The random source is ignored.
@@ -49,7 +49,7 @@ public class StaticDoubleGenerator extends AbstractDataGenerator<Double> {
 
         private Double value = 0d;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Always generates the same configured float value. The random source is ignored.
@@ -49,7 +49,7 @@ public class StaticFloatGenerator extends AbstractDataGenerator<Float> {
 
         private Float value = 0f;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
@@ -20,7 +20,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Always generates the same configured integer value. The random source is ignored.
@@ -49,7 +49,7 @@ public class StaticIntegerGenerator extends AbstractDataGenerator<Integer> {
 
         private Integer value = 0;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticStringGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Always generates the same configured string value. The random source is ignored.
@@ -41,7 +41,7 @@ public class StaticStringGenerator extends AbstractDataGenerator<String> {
 
         private String value = "";
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
@@ -17,7 +17,7 @@
 package io.bloviate.gen;
 
 import java.sql.*;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
 
@@ -69,7 +69,7 @@ public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
         private int length = 3;
         private int elementLength = 10;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/UUIDGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/UUIDGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.UUID;
 
 /**
@@ -58,7 +58,7 @@ public class UUIDGenerator extends AbstractDataGenerator<UUID> {
          *
          * @param random the random number generator to use
          */
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/VariableStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/VariableStringGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates strings whose length varies randomly within an inclusive
@@ -50,7 +50,7 @@ public class VariableStringGenerator extends AbstractDataGenerator<String> {
         private boolean letters = true;
         private boolean numbers = false;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
@@ -18,7 +18,7 @@ package io.bloviate.gen;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates small well-formed XML documents, e.g. {@code <bloviate>a1b2c3d4</bloviate>}.
@@ -47,7 +47,7 @@ public class XmlGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
@@ -21,7 +21,7 @@ import io.bloviate.gen.AbstractDataGenerator;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates the TPC-C customer credit rating (clause 4.3.2.7): "GC" (good credit)
@@ -44,7 +44,7 @@ public class CreditGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 
@@ -54,7 +54,7 @@ public class CreditGenerator extends AbstractDataGenerator<String> {
         }
     }
 
-    private CreditGenerator(Random random) {
+    private CreditGenerator(RandomGenerator random) {
         super(random);
     }
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
@@ -21,7 +21,7 @@ import io.bloviate.gen.AbstractDataGenerator;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -87,7 +87,7 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
         private int groupSize = 0;
         private int enumeratedCount = 0;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 
@@ -116,7 +116,7 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
         }
     }
 
-    private CustomerLastNameGenerator(Random random, int groupSize, int enumeratedCount) {
+    private CustomerLastNameGenerator(RandomGenerator random, int groupSize, int enumeratedCount) {
         super(random);
         if (enumeratedCount < 0 || enumeratedCount > MAX_ENUMERATED) {
             throw new IllegalArgumentException("enumeratedCount must be in [0, " + MAX_ENUMERATED + "]: " + enumeratedCount);

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
@@ -21,7 +21,7 @@ import io.bloviate.gen.AbstractDataGenerator;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates the TPC-C i_data / s_data values (clause 4.3.3.1): a random
@@ -53,7 +53,7 @@ public class DataColumnGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 
@@ -63,7 +63,7 @@ public class DataColumnGenerator extends AbstractDataGenerator<String> {
         }
     }
 
-    private DataColumnGenerator(Random random) {
+    private DataColumnGenerator(RandomGenerator random) {
         super(random);
     }
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/OrderLineDeliveryDateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/OrderLineDeliveryDateGenerator.java
@@ -27,7 +27,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates {@code ol_delivery_d} for the {@code order_line} table under variable order-line
@@ -71,7 +71,7 @@ public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timest
         private int ordersPerDistrict = 1;
         private int deliveredThreshold = 0;
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 
@@ -100,7 +100,7 @@ public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timest
         }
     }
 
-    private OrderLineDeliveryDateGenerator(Random random, Builder builder) {
+    private OrderLineDeliveryDateGenerator(RandomGenerator random, Builder builder) {
         super(random);
         if (builder.cardinality == null) {
             throw new IllegalStateException("cardinality is required");

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
  * Generates TPC-C zip codes (clause 4.3.2.7): four random digits followed by the
@@ -44,7 +44,7 @@ public class ZipCodeGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
-        public Builder(Random random) {
+        public Builder(RandomGenerator random) {
             super(random);
         }
 
@@ -54,7 +54,7 @@ public class ZipCodeGenerator extends AbstractDataGenerator<String> {
         }
     }
 
-    private ZipCodeGenerator(Random random) {
+    private ZipCodeGenerator(RandomGenerator random) {
         super(random);
     }
 }

--- a/bloviate-core/src/main/java/io/bloviate/util/RandomGenerators.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/RandomGenerators.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.util;
+
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+/**
+ * Central factory for the {@link RandomGenerator} used throughout the fill engine.
+ *
+ * <p>Bloviate seeds a fresh, isolated generator per column (see
+ * {@link DatabaseUtils#columnSeed(io.bloviate.db.Column, long)}), so reproducible parallel
+ * generation never depends on a shared, mutable RNG. The only thing this class fixes is the
+ * <em>algorithm</em>: {@value #ALGORITHM}, the JDK general-purpose default
+ * ({@link RandomGeneratorFactory#getDefault()}). Compared to the legacy {@link java.util.Random}
+ * (a 48-bit LCG with a documented statistical defect and {@code synchronized} methods), it offers a
+ * far longer period (2<sup>128</sup>&nbsp;&times;&nbsp;2<sup>64</sup>), better statistical quality,
+ * and no lock overhead &mdash; and it is explicitly recommended for multi-threaded use with a
+ * per-unit instance, exactly Bloviate's per-column model.
+ *
+ * <p>Because {@link java.util.Random} also implements {@link RandomGenerator}, callers that still
+ * hold a {@code java.util.Random} can pass it directly anywhere a {@link RandomGenerator} is
+ * expected; new code should obtain generators here so the whole engine shares one algorithm.
+ *
+ * @since 2.10.0
+ */
+public final class RandomGenerators {
+
+    /**
+     * The {@link RandomGenerator} algorithm used by the fill engine.
+     */
+    public static final String ALGORITHM = "L64X128MixRandom";
+
+    /**
+     * The factory is immutable and thread-safe, so a single shared instance backs every
+     * {@link #create(long)} call.
+     */
+    private static final RandomGeneratorFactory<RandomGenerator> FACTORY =
+            RandomGeneratorFactory.of(ALGORITHM);
+
+    private RandomGenerators() {
+    }
+
+    /**
+     * Creates a new, independent {@link RandomGenerator} seeded with the given value. The same seed
+     * always yields the same sequence, which is what makes Bloviate's per-column generation
+     * reproducible.
+     *
+     * @param seed the seed value
+     * @return a freshly seeded generator
+     */
+    public static RandomGenerator create(long seed) {
+        return FACTORY.create(seed);
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/util/SeededRandomUtils.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/SeededRandomUtils.java
@@ -16,16 +16,35 @@
 
 package io.bloviate.util;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.Validate;
 
-import java.util.Random;
+import java.util.random.RandomGenerator;
 
 /**
- * Borrowed from org.apache.commons.lang3.RandomUtils and org.apache.commons.lang3.RandomStringUtils
+ * Seeded numeric and string helpers built directly on a {@link RandomGenerator}.
+ *
+ * <p>The numeric range helpers are adapted from {@code org.apache.commons.lang3.RandomUtils}.
+ * The string helpers are reimplemented here (rather than delegating to
+ * {@code org.apache.commons.lang3.RandomStringUtils}) because that class accepts only a
+ * {@link java.util.Random}, whereas the engine now drives generation from a
+ * {@link RandomGenerator} ({@value RandomGenerators#ALGORITHM}). For the alphabetic/numeric
+ * cases the implementation draws directly from a fixed character pool &mdash; the same set of
+ * characters {@code RandomStringUtils} would yield for those flags &mdash; which avoids the
+ * draw-and-reject loop entirely. The general {@code [start, end)} code-point path is retained for
+ * completeness and mirrors the classic {@code RandomStringUtils.random(...)} rejection algorithm.
  */
 
-public record SeededRandomUtils(Random random) {
+public record SeededRandomUtils(RandomGenerator random) {
+
+    /** Pool for {@code numbers}-only requests: the ASCII digits {@code RandomStringUtils} keeps. */
+    private static final char[] DIGITS = "0123456789".toCharArray();
+
+    /** Pool for {@code letters}-only requests: the ASCII letters {@code RandomStringUtils} keeps. */
+    private static final char[] LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".toCharArray();
+
+    /** Pool for {@code letters && numbers} requests. */
+    private static final char[] ALPHANUMERIC =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
 
     public String randomNumeric(int minLengthInclusive, int maxLengthExclusive) {
         return randomNumeric(nextInt(minLengthInclusive, maxLengthExclusive));
@@ -36,11 +55,107 @@ public record SeededRandomUtils(Random random) {
     }
 
     public String random(final int count, final boolean letters, final boolean numbers) {
-        return random(count, 0, 0, letters, numbers);
+        if (count < 0) {
+            throw new IllegalArgumentException("Requested random string length " + count + " is less than 0.");
+        }
+        if (count == 0) {
+            return "";
+        }
+
+        // fast path for the only cases the engine uses: pick from a fixed pool with no rejection
+        char[] pool = null;
+        if (letters && numbers) {
+            pool = ALPHANUMERIC;
+        } else if (letters) {
+            pool = LETTERS;
+        } else if (numbers) {
+            pool = DIGITS;
+        }
+        if (pool != null) {
+            final char[] out = new char[count];
+            for (int i = 0; i < count; i++) {
+                out[i] = pool[random.nextInt(pool.length)];
+            }
+            return new String(out);
+        }
+
+        // !letters && !numbers: any code point — fall back to the general range path
+        return random(count, 0, 0, false, false);
     }
 
+    /**
+     * Generates a random string of the requested length, drawing code points from the
+     * {@code [start, end)} range and keeping only letters and/or digits as requested. This mirrors
+     * the classic {@code RandomStringUtils.random(count, start, end, letters, numbers, null, random)}
+     * rejection algorithm, sourcing randomness from this record's {@link RandomGenerator}. The
+     * common alphabetic/numeric requests are served by {@link #random(int, boolean, boolean)}'s
+     * pool fast path instead.
+     *
+     * @param count   the length of the string to create
+     * @param start   the inclusive lower bound of code points to draw from (0 selects a default)
+     * @param end     the exclusive upper bound of code points to draw from (0 selects a default)
+     * @param letters whether letters are allowed
+     * @param numbers whether digits are allowed
+     * @return the generated random string
+     */
     public String random(final int count, final int start, final int end, final boolean letters, final boolean numbers) {
-        return RandomStringUtils.random(count, start, end, letters, numbers, null, random);
+        if (count == 0) {
+            return "";
+        }
+        if (count < 0) {
+            throw new IllegalArgumentException("Requested random string length " + count + " is less than 0.");
+        }
+
+        int lower = start;
+        int upper = end;
+        if (lower == 0 && upper == 0) {
+            if (!letters && !numbers) {
+                upper = Character.MAX_CODE_POINT;
+            } else {
+                upper = 'z' + 1;
+                lower = ' ';
+            }
+        } else if (upper <= lower) {
+            throw new IllegalArgumentException("Parameter end (" + upper + ") must be greater than start (" + lower + ")");
+        } else if (lower < 0) {
+            throw new IllegalArgumentException("Character positions MUST be >= 0");
+        }
+
+        if (upper > Character.MAX_CODE_POINT) {
+            upper = Character.MAX_CODE_POINT;
+        }
+
+        final StringBuilder builder = new StringBuilder(count);
+        final int gap = upper - lower;
+
+        int remaining = count;
+        while (remaining-- != 0) {
+            final int codePoint = random.nextInt(gap) + lower;
+            switch (Character.getType(codePoint)) {
+                case Character.UNASSIGNED, Character.PRIVATE_USE, Character.SURROGATE -> {
+                    remaining++;
+                    continue;
+                }
+            }
+
+            final int numberOfChars = Character.charCount(codePoint);
+            if (remaining == 0 && numberOfChars > 1) {
+                remaining++;
+                continue;
+            }
+
+            if (letters && Character.isLetter(codePoint)
+                    || numbers && Character.isDigit(codePoint)
+                    || !letters && !numbers) {
+                builder.appendCodePoint(codePoint);
+                if (numberOfChars == 2) {
+                    remaining--;
+                }
+            } else {
+                remaining++;
+            }
+        }
+        return builder.toString();
     }
 
     public String randomAlphabetic(final int count) {

--- a/bloviate-core/src/test/java/io/bloviate/gen/JsonbGeneratorTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/JsonbGeneratorTest.java
@@ -18,6 +18,7 @@ package io.bloviate.gen;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.bloviate.util.RandomGenerators;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
@@ -54,10 +55,8 @@ class JsonbGeneratorTest {
 
     @Test
     void isDeterministicForAGivenSeed() {
-        JsonbGenerator a = new JsonbGenerator.Builder(new Random()).fields(4).build();
-        JsonbGenerator b = new JsonbGenerator.Builder(new Random()).fields(4).build();
-        a.setSeed(42L);
-        b.setSeed(42L);
+        JsonbGenerator a = new JsonbGenerator.Builder(RandomGenerators.create(42L)).fields(4).build();
+        JsonbGenerator b = new JsonbGenerator.Builder(RandomGenerators.create(42L)).fields(4).build();
 
         assertEquals(a.generate(), b.generate());
     }


### PR DESCRIPTION
## Summary

Closes #471. Replaces the legacy `java.util.Random` (48-bit LCG, `synchronized`, documented statistical defect) with `java.util.random.RandomGenerator` using the JDK general-purpose default **`L64X128MixRandom`**. The per-column seeding architecture is unchanged, so generation stays **reproducible and order-independent** — only the algorithm and statistical quality improve. **No new dependency.**

## Changes

- **`RandomGenerators.create(seed)`** — single factory fixing the algorithm (`L64X128MixRandom`).
- **SPI converted** `java.util.Random` → `RandomGenerator` across `GeneratorFactory`, `ColumnGeneratorFactory`, `DatabaseSupport`, `GeneratorRegistry`, `AbstractBuilder`, `AbstractDataGenerator`, and all generators.
- **FK reseed without `setSeed`** — `RandomGenerator` has no `setSeed`. Removed `DataGenerator.setSeed(long)`, added `reseed(long)` which swaps in a freshly-seeded generator **in place**, preserving generator counter/sequence state (so composite/sequential keys stay correct on FK wraparound — a naïve "recreate the generator" approach broke the TPC-C composite-key tests).
- **`SeededRandomUtils`** reimplemented over `RandomGenerator` (commons-lang3 `RandomStringUtils` only accepts `java.util.Random`). The alphabetic/numeric paths now draw from a fixed character pool — same character set, no draw-and-reject loop.
- Updated benchmarks, README, ARCHITECTURE, and BENCHMARKS.

> **Breaking change to the pluggable-generator SPI** — but the SPI is newly released with no users yet, so versioned as a normal `feat`.

## Performance (issue #471 results, recorded in `BENCHMARKS.md`)

`generate()`, old `java.util.Random` → new `L64X128MixRandom` (ops/µs, higher is better):

| type | old | new | Δ |
|---|--:|--:|--:|
| INTEGER | 180.8 | 318.7 | +76% |
| BIGINT | 91.4 | 320.5 | +3.5× |
| DOUBLE | 91.6 | 344.9 | +3.8× |
| VARCHAR_SHORT | 9.5 | 17.2 | +80% |
| VARCHAR_LONG | 0.59 | 1.32 | +2.2× |
| UUID | 9.4 | 9.8 | +4% |

End-to-end `RowDispatchBenchmark` (16-column row, real `TableFiller` inner loop): **0.31 → 0.61 ops/µs (~2×)**.

## Testing

- All **148 `bloviate-core` tests pass**, including `PostgresParallelFillTest` (parallel == sequential, byte-for-byte) and the seed/temporal reproducibility tests.
- Full reactor (`junit`, `testcontainers`) builds and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)