### PR TITLE
feat(perf): intra-table partitioning, commit strategy, batch-rewrite warning (#466, #467, #468)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -59,8 +59,9 @@ Each measured iteration truncates the schema, times a full `DatabaseFiller.fill(
 fetch included), and prints `rows/sec`. A fixed seed makes every iteration generate identical
 data, so timings are comparable across runs and across optimization branches.
 
-- `PostgresFillBenchmark` — TPC-C schema **and** a deliberately wide, FK-free schema
-  (`create_wide.postgres.sql`); the wide one is the parallel-table-fill target.
+- `PostgresFillBenchmark` — TPC-C schema, a deliberately wide FK-free schema
+  (`create_wide.postgres.sql`, the between-table parallel-fill target), **and** a single dominant
+  table (`create_single.postgres.sql`, the intra-table partitioning target for issue #466).
 - `MySqlFillBenchmark`, `CockroachFillBenchmark` — TPC-C schema.
 
 ```bash
@@ -70,6 +71,12 @@ data, so timings are comparable across runs and across optimization branches.
 # just Postgres, just the wide schema, larger dataset
 ./mvnw -pl bloviate-benchmarks -am -Pbench test \
     -Dtest='PostgresFillBenchmark#wide' -Dbench.rows=500000
+
+# intra-table partitioning (#466): one big table, sequential baseline vs 8-way partitioned
+./mvnw -pl bloviate-benchmarks -am -Pbench test \
+    -Dtest='PostgresFillBenchmark#singleTable' -Dbench.rows=2000000 -Dbench.threads=1
+./mvnw -pl bloviate-benchmarks -am -Pbench test \
+    -Dtest='PostgresFillBenchmark#singleTable' -Dbench.rows=2000000 -Dbench.threads=8
 ```
 
 Output lines look like:
@@ -87,7 +94,9 @@ Output lines look like:
 | `bench.warmup` | 1 | untimed warmup fills (JIT / pool / cache priming) |
 | `bench.iterations` | 3 | timed fills; best and mean are reported |
 | `bench.batch` | 1000 | JDBC batch size (`DatabaseConfiguration.batchSize`) |
-| `bench.rows` | 50000 | default row count for the **wide** schema (per table) |
+| `bench.threads` | 1 | worker threads; `1` = sequential baseline, `>1` = parallel `DataSource` path |
+| `bench.partitions` | `max(2, threads)` | intra-table partitions for the **single** schema (#466) |
+| `bench.rows` | 50000 | default row count for the **wide**/**single** schema (per table) |
 | `bench.warehouses` | 1 | TPC-C scale factor (W) |
 | `bench.items` | 10000 | TPC-C items (I) |
 | `bench.districts` | 10 | TPC-C districts per warehouse (D) |

--- a/README.md
+++ b/README.md
@@ -506,10 +506,67 @@ depending on the previous) has little to parallelize. See [BENCHMARKS.md](BENCHM
 The single-`Connection` constructor is unchanged and remains the default sequential path — `threads`
 only applies to the `DataSource` form.
 
+#### Intra-table partitioning
+
+When a **single large table dominates** the fill, between-table parallelism can't help it — it sits
+alone in its topological level. Set `partitions` on that table's `TableConfiguration` to split its
+rows into that many contiguous ranges filled concurrently, one connection per range, on the parallel
+(`DataSource` + `threads`) path:
+
+```java
+// split the one big table into 8 row ranges; ignored on the single-Connection path
+Set<TableConfiguration> tables = Set.of(
+    new TableConfiguration("events", 50_000_000L, 8 /* partitions */));
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    1000, 0, new PostgresSupport(), tables, 42L);
+
+new DatabaseFiller.Builder(dataSource, config).threads(8).build().fill();
+```
+
+Partitioning is reproducible **for a given configuration, including the partition count**: key
+columns and the columns correlated with them (foreign keys, sequences, permutations) are generated
+positionally, so they are byte-for-byte identical to a sequential fill and **foreign-key validity
+always holds**. Only plain non-key random columns take different (but still deterministic) values
+when you change the partition count — they carry no cross-row contract, so this is by design and
+keeps the default path free of any per-cell cost.
+
+Size the connection pool for the total concurrent demand (`threads`, where a partitioned table counts
+as `partitions` units). One case is unsupported: partitioning a **parent** table whose primary key is
+a plain *random* generator referenced by a foreign key can orphan those references — partition the
+child table instead, or use the positional key generators (as the bundled TPC-C/TPC-H configurations
+do). A custom generator with internal positional state must implement
+`io.bloviate.gen.IndexedDataGenerator` to stay aligned under partitioning.
+
+### Commit Strategy
+
+By default the engine leaves the connection's autocommit untouched (a typical autocommit connection
+commits per `executeBatch()`). Disabling autocommit and committing less often cuts overhead. Pass a
+`CommitStrategy` to `DatabaseConfiguration` for the sequential path:
+
+```java
+import io.bloviate.db.*;
+
+// commit once per table (autocommit off for the fill, restored afterward)
+DatabaseConfiguration perTable = new DatabaseConfiguration(
+    1000, 100_000, new PostgresSupport(), null, 42L, CommitStrategy.perTable());
+
+// or bound the open transaction: commit every 50 JDBC batches
+DatabaseConfiguration everyN = new DatabaseConfiguration(
+    1000, 100_000, new PostgresSupport(), null, 42L, CommitStrategy.everyNBatches(50));
+```
+
+The default, `CommitStrategy.connectionDefault()`, preserves today's behavior (the engine never
+touches autocommit). The parallel path already commits once per table; a configured strategy applies
+there too.
+
 > **Tip — driver batch rewrite.** Bloviate inserts in JDBC batches, but most drivers only collapse a
 > batch into a single multi-row `INSERT` when you opt in via the JDBC URL: PostgreSQL
 > `reWriteBatchedInserts=true`, MySQL `rewriteBatchedStatements=true`. Enabling it is often the
-> single biggest fill speedup, sequential or parallel.
+> single biggest fill speedup, sequential or parallel. Bloviate **logs a warning** at fill time when
+> the parameter is missing, and `io.bloviate.util.JdbcUrls.withBatchRewrite(url, support.batchRewriteUrlParameter())`
+> builds a correctly-parameterized URL if you construct the `DataSource` yourself. CockroachDB ignores
+> the parameter, so no warning is emitted there.
 
 ### Testing Framework Integration
 

--- a/bloviate-benchmarks/src/test/java/io/bloviate/bench/PostgresFillBenchmark.java
+++ b/bloviate-benchmarks/src/test/java/io/bloviate/bench/PostgresFillBenchmark.java
@@ -17,6 +17,7 @@
 package io.bloviate.bench;
 
 import io.bloviate.db.DatabaseConfiguration;
+import io.bloviate.db.TableConfiguration;
 import io.bloviate.ext.PostgresSupport;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * End-to-end fill throughput on PostgreSQL: a realistic TPC-C schema and a deliberately wide,
@@ -72,6 +74,26 @@ class PostgresFillBenchmark extends AbstractFillBenchmark {
         try (PostgreSQLContainer<?> database = container("create_wide.postgres.sql")) {
             database.start();
             runBenchmark("postgres/wide", database, configuration);
+        }
+    }
+
+    /**
+     * Single dominant table: between-table parallelism cannot help (one table, one level), so only
+     * intra-table partitioning (issue #466) speeds it up. Compare {@code -Dbench.threads=1} (baseline,
+     * partitions ignored on the sequential path) against {@code -Dbench.threads=N} (the one table is
+     * split into {@code bench.partitions} ranges, default {@code N}). Reproducibility is per
+     * configuration: the partitioned non-key values differ from the sequential ones by design.
+     */
+    @Test
+    void singleTable() throws SQLException {
+        int partitions = Integer.getInteger("bench.partitions", Math.max(2, THREADS));
+        Set<TableConfiguration> tables = Set.of(new TableConfiguration("big_t", ROWS, partitions));
+        DatabaseConfiguration configuration = new DatabaseConfiguration(
+                BATCH_SIZE, ROWS, new PostgresSupport(), tables, SEED);
+
+        try (PostgreSQLContainer<?> database = container("create_single.postgres.sql")) {
+            database.start();
+            runBenchmark("postgres/single", database, configuration);
         }
     }
 }

--- a/bloviate-benchmarks/src/test/resources/create_single.postgres.sql
+++ b/bloviate-benchmarks/src/test/resources/create_single.postgres.sql
@@ -1,0 +1,22 @@
+--
+-- Copyright 2020 Tim Veil
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- A single, wide table: the target for intra-table parallelism (#447 item #2, issue #466).
+-- One table sits alone in its topological level, so between-table parallelism cannot help; only
+-- partitioning its rows across workers does. No primary key (a raw-throughput fixture, not an
+-- integrity one) so unconstrained columns avoid random-value collisions.
+
+CREATE TABLE big_t (c_int int, c_bigint bigint, c_name varchar(64), c_desc varchar(128), c_amount numeric(12, 2), c_score double precision, c_flag boolean, c_ts timestamp);

--- a/bloviate-core/src/main/java/io/bloviate/db/CommitStrategy.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/CommitStrategy.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+/**
+ * How a {@link TableFiller} commits the rows it inserts.
+ *
+ * <p>By default ({@link #connectionDefault()}) the fill engine does not touch the connection's
+ * transaction state at all — it relies on whatever autocommit the caller's connection has, which for
+ * a typical autocommit connection means a commit per {@code executeBatch()}. Disabling autocommit and
+ * committing less often cuts commit overhead and is usually faster.
+ *
+ * <ul>
+ *   <li>{@link #connectionDefault()} — the engine leaves autocommit alone (back-compatible default).</li>
+ *   <li>{@link #perTable()} — autocommit off, a single commit once the table is fully filled.</li>
+ *   <li>{@link #everyNBatches(int)} — autocommit off, commit after every {@code n} JDBC batches
+ *       (and once more for the trailing partial batch), bounding the size of an open transaction.</li>
+ * </ul>
+ *
+ * <p>For anything other than {@link #connectionDefault()} the engine sets autocommit off for the fill,
+ * rolls back on error, and restores the connection's prior autocommit setting when done.
+ *
+ * @param mode    the commit mode
+ * @param batches the batch cadence for {@link Mode#EVERY_N_BATCHES} (ignored otherwise)
+ * @since 2.10.0
+ * @see DatabaseConfiguration
+ */
+public record CommitStrategy(Mode mode, int batches) {
+
+    /** The available commit modes. */
+    public enum Mode {
+        /** Leave the connection's autocommit state untouched (the default, back-compatible behavior). */
+        CONNECTION_DEFAULT,
+        /** Autocommit off; commit once when the table is fully filled. */
+        PER_TABLE,
+        /** Autocommit off; commit after every {@code n} JDBC batches. */
+        EVERY_N_BATCHES
+    }
+
+    /**
+     * @throws IllegalArgumentException if {@code mode} is null, or {@code batches < 1} for
+     *                                  {@link Mode#EVERY_N_BATCHES}
+     */
+    public CommitStrategy {
+        if (mode == null) {
+            throw new IllegalArgumentException("mode must not be null");
+        }
+        if (mode == Mode.EVERY_N_BATCHES && batches < 1) {
+            throw new IllegalArgumentException("batches must be >= 1 for EVERY_N_BATCHES: " + batches);
+        }
+    }
+
+    /** The back-compatible default: the engine never changes the connection's autocommit state. */
+    public static CommitStrategy connectionDefault() {
+        return new CommitStrategy(Mode.CONNECTION_DEFAULT, 0);
+    }
+
+    /** Autocommit off, a single commit once the table is fully filled. */
+    public static CommitStrategy perTable() {
+        return new CommitStrategy(Mode.PER_TABLE, 0);
+    }
+
+    /**
+     * Autocommit off, commit after every {@code n} JDBC batches.
+     *
+     * @param n the number of batches between commits; must be {@code >= 1}
+     * @return the strategy
+     */
+    public static CommitStrategy everyNBatches(int n) {
+        return new CommitStrategy(Mode.EVERY_N_BATCHES, n);
+    }
+
+    /** Whether the engine manages the transaction (i.e. anything other than {@link Mode#CONNECTION_DEFAULT}). */
+    public boolean managesTransaction() {
+        return mode != Mode.CONNECTION_DEFAULT;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseConfiguration.java
@@ -52,14 +52,27 @@ import java.util.Set;
  *        vendor type name, or JDBCType), consulted between per-column overrides and the
  *        {@code databaseSupport} defaults; may be null
  * @param seed the base seed for reproducible generation; vary it for a different dataset
+ * @param commitStrategy how the engine commits inserted rows; defaults to
+ *        {@link CommitStrategy#connectionDefault()} (autocommit untouched) when null
  *
  * @author Tim Veil
  * @see DatabaseSupport
  * @see TableConfiguration
  * @see GeneratorRegistry
+ * @see CommitStrategy
  * @see DatabaseFiller
  */
-public record DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed) {
+public record DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed, CommitStrategy commitStrategy) {
+
+    /**
+     * Normalizes a null {@code commitStrategy} to {@link CommitStrategy#connectionDefault()} so the
+     * back-compatible behavior applies whenever a caller does not specify one.
+     */
+    public DatabaseConfiguration {
+        if (commitStrategy == null) {
+            commitStrategy = CommitStrategy.connectionDefault();
+        }
+    }
 
     /**
      * Creates a configuration with no custom {@link GeneratorRegistry} and a base {@code seed}
@@ -71,7 +84,7 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param tableConfigurations optional per-table configuration overrides
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, 0L);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, 0L, null);
     }
 
     /**
@@ -85,7 +98,7 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param generatorRegistry optional registry of custom generator rules; may be null
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, 0L);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, 0L, null);
     }
 
     /**
@@ -99,7 +112,37 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param seed the base seed for reproducible generation
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, long seed) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, null);
+    }
+
+    /**
+     * Creates a configuration with the given base {@code seed} and {@link CommitStrategy}, and no
+     * custom {@link GeneratorRegistry}.
+     *
+     * @param batchSize the number of rows to include in each batch INSERT operation
+     * @param defaultRowCount the default number of rows to generate for each table
+     * @param databaseSupport the database-specific support implementation
+     * @param tableConfigurations optional per-table configuration overrides
+     * @param seed the base seed for reproducible generation
+     * @param commitStrategy how the engine commits inserted rows; may be null for the default
+     */
+    public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, long seed, CommitStrategy commitStrategy) {
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, commitStrategy);
+    }
+
+    /**
+     * Creates a configuration with a custom {@link GeneratorRegistry} and base {@code seed}, and the
+     * default {@link CommitStrategy} (preserves the original six-argument signature).
+     *
+     * @param batchSize the number of rows to include in each batch INSERT operation
+     * @param defaultRowCount the default number of rows to generate for each table
+     * @param databaseSupport the database-specific support implementation
+     * @param tableConfigurations optional per-table configuration overrides
+     * @param generatorRegistry optional registry of custom generator rules; may be null
+     * @param seed the base seed for reproducible generation
+     */
+    public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed) {
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, seed, null);
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -17,6 +17,7 @@
 package io.bloviate.db;
 
 import io.bloviate.util.DatabaseUtils;
+import io.bloviate.util.JdbcUrls;
 import org.apache.commons.lang3.time.StopWatch;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultDirectedGraph;
@@ -41,6 +42,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -127,14 +129,25 @@ public class DatabaseFiller implements Fillable {
 
         visualizeGraph(reversedGraph, database.catalog());
 
+        // recommend the driver batch-rewrite URL parameter once per fill if it is missing
+        if (connection != null) {
+            warnIfBatchRewriteMissing(connection);
+        } else {
+            try (Connection conn = dataSource.getConnection()) {
+                warnIfBatchRewriteMissing(conn);
+            }
+        }
+
         if (connection != null) {
             // back-compat path: fill sequentially on the caller's single connection (unchanged)
+            warnIfPartitionsIgnored();
             fillSequential(connection, database, reversedGraph);
         } else if (threads > 1) {
             // parallel path: fill independent tables within each topological level concurrently
             fillParallel(database, reversedGraph);
         } else {
             // DataSource supplied but no parallelism requested: borrow one connection, fill in order
+            warnIfPartitionsIgnored();
             try (Connection conn = dataSource.getConnection()) {
                 fillSequential(conn, database, reversedGraph);
             }
@@ -184,8 +197,11 @@ public class DatabaseFiller implements Fillable {
     private void fillParallel(Database database, Graph<Table, DefaultEdge> reversedGraph) throws SQLException {
         List<List<Table>> levels = fillLevels(reversedGraph);
 
-        // never spin up more workers than the widest level can use
-        int widest = levels.stream().mapToInt(List::size).max().orElse(1);
+        // never spin up more workers than the widest level can use; a partitioned table contributes
+        // one unit of work per partition, so a single large partitioned table can use all threads
+        int widest = levels.stream()
+                .mapToInt(level -> level.stream().mapToInt(this::partitionsFor).sum())
+                .max().orElse(1);
         int poolSize = Math.max(1, Math.min(threads, widest));
 
         logger.info("filling {} tables across {} topological level(s) with {} worker thread(s)",
@@ -196,10 +212,7 @@ public class DatabaseFiller implements Fillable {
             for (List<Table> level : levels) {
                 List<Callable<Void>> tasks = new ArrayList<>(level.size());
                 for (Table table : level) {
-                    tasks.add(() -> {
-                        fillTableInOwnTransaction(database, table);
-                        return null;
-                    });
+                    addTableTasks(tasks, database, table);
                 }
 
                 // barrier: every table in this level must finish before the next level may start
@@ -213,6 +226,29 @@ public class DatabaseFiller implements Fillable {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    /**
+     * Logs a one-time recommendation to enable the driver's batch-rewrite URL parameter when the
+     * connection's URL does not already set it to {@code true}. Bloviate fills through a connection
+     * it does not own, so it cannot add the parameter itself; enabling it (e.g. with
+     * {@link io.bloviate.util.JdbcUrls#withBatchRewrite(String, String)}) is often the single biggest
+     * fill speedup. No-op for databases without such a parameter (e.g. CockroachDB).
+     *
+     * @param conn a connection whose URL is inspected; never modified
+     * @throws SQLException if the connection metadata cannot be read
+     */
+    private void warnIfBatchRewriteMissing(Connection conn) throws SQLException {
+        String parameter = configuration.databaseSupport().batchRewriteUrlParameter();
+        if (parameter == null) {
+            return;
+        }
+        String url = conn.getMetaData().getURL();
+        if (url != null && JdbcUrls.parameterEquals(url, parameter, "true")) {
+            return;
+        }
+        logger.warn("JDBC driver batch rewrite is not enabled; add '{}=true' to the JDBC URL for a "
+                + "potentially large fill speedup (see io.bloviate.util.JdbcUrls#withBatchRewrite)", parameter);
     }
 
     /** Unwraps a worker future, re-throwing the underlying {@link SQLException} or runtime failure. */
@@ -232,26 +268,114 @@ public class DatabaseFiller implements Fillable {
     }
 
     /**
-     * Fills one table on its own pooled connection inside a single transaction: autocommit is
-     * disabled and the work is committed once when the table is complete (rolled back on failure).
-     * Committing once per table — rather than once per JDBC batch — also cuts commit overhead.
+     * Adds the worker task(s) for one table to {@code tasks}. A table with the default single
+     * partition contributes one whole-table task; a table configured with {@code partitions > 1}
+     * contributes one task per contiguous row range, so the ranges fill concurrently (intra-table
+     * parallelism) alongside the other tables in the same topological level.
+     */
+    private void addTableTasks(List<Callable<Void>> tasks, Database database, Table table) {
+        int partitions = partitionsFor(table);
+        if (partitions <= 1) {
+            tasks.add(() -> {
+                fillTableInOwnTransaction(database, table);
+                return null;
+            });
+            return;
+        }
+
+        long rowCount = rowCountFor(table);
+        long base = rowCount / partitions;
+        long remainder = rowCount % partitions;
+        long start = 0;
+        for (int p = 0; p < partitions; p++) {
+            long size = base + (p < remainder ? 1 : 0);
+            long end = start + size;
+            if (size > 0) {
+                long rangeStart = start;
+                long rangeEnd = end;
+                tasks.add(() -> {
+                    fillTablePartition(database, table, rangeStart, rangeEnd);
+                    return null;
+                });
+            }
+            start = end;
+        }
+    }
+
+    /**
+     * Fills a whole table on its own pooled connection inside a single transaction — the original,
+     * proven per-table parallel path (no row range, so generation is byte-for-byte identical to a
+     * sequential fill). The transaction is managed by {@link TableFiller} via the effective commit
+     * strategy (see {@link #effectiveParallelCommitStrategy()}).
      */
     private void fillTableInOwnTransaction(Database database, Table table) throws SQLException {
         try (Connection conn = dataSource.getConnection()) {
-            boolean previousAutoCommit = conn.getAutoCommit();
-            conn.setAutoCommit(false);
-            try {
-                new TableFiller.Builder(conn, database, configuration)
-                        .table(table)
-                        .build().fill();
-                conn.commit();
-            } catch (SQLException e) {
-                conn.rollback();
-                throw e;
-            } finally {
-                conn.setAutoCommit(previousAutoCommit);
+            new TableFiller.Builder(conn, database, configuration)
+                    .table(table)
+                    .commitStrategy(effectiveParallelCommitStrategy())
+                    .build().fill();
+        }
+    }
+
+    /**
+     * Fills one contiguous row range of a table on its own pooled connection inside a single
+     * transaction. The transaction is managed by {@link TableFiller} via the effective commit
+     * strategy (see {@link #effectiveParallelCommitStrategy()}): autocommit off, committed when the
+     * range is complete (or every N batches), and rolled back on failure.
+     */
+    private void fillTablePartition(Database database, Table table, long startInclusive, long endExclusive) throws SQLException {
+        try (Connection conn = dataSource.getConnection()) {
+            new TableFiller.Builder(conn, database, configuration)
+                    .table(table)
+                    .commitStrategy(effectiveParallelCommitStrategy())
+                    .rowRange(startInclusive, endExclusive)
+                    .build().fill();
+        }
+    }
+
+    /** The configured intra-table partition count for a table, or {@code 1} when not configured. */
+    private int partitionsFor(Table table) {
+        TableConfiguration tableConfiguration = configuration.tableConfiguration(table.name());
+        return tableConfiguration != null ? tableConfiguration.partitions() : 1;
+    }
+
+    /** The row count for a table: its per-table override if present, otherwise the default. */
+    private long rowCountFor(Table table) {
+        TableConfiguration tableConfiguration = configuration.tableConfiguration(table.name());
+        return tableConfiguration != null ? tableConfiguration.rowCount() : configuration.defaultRowCount();
+    }
+
+    /**
+     * Logs a warning for any table configured with intra-table {@code partitions > 1} when the fill
+     * will not run on the parallel path, since partitioning has no effect there (mirrors the
+     * {@code threads(...)} warning). Intra-table parallelism requires the {@link DataSource}
+     * constructor with {@code threads > 1}.
+     */
+    private void warnIfPartitionsIgnored() {
+        Set<TableConfiguration> tableConfigurations = configuration.tableConfigurations();
+        if (tableConfigurations == null) {
+            return;
+        }
+        for (TableConfiguration tableConfiguration : tableConfigurations) {
+            if (tableConfiguration.partitions() > 1) {
+                logger.warn("intra-table partitions ({}) for table [{}] are ignored on the sequential fill path; "
+                                + "use the DataSource constructor with threads(n) > 1 for intra-table parallelism",
+                        tableConfiguration.partitions(), tableConfiguration.tableName());
             }
         }
+    }
+
+    /**
+     * The commit strategy used by parallel workers. A pooled worker connection must not be left on
+     * the connection's autocommit (that would commit per batch and lose the per-table transaction),
+     * so {@link CommitStrategy.Mode#CONNECTION_DEFAULT} maps to {@link CommitStrategy#perTable()};
+     * any explicitly configured strategy (e.g. {@link CommitStrategy#everyNBatches(int)}) is honored.
+     */
+    private CommitStrategy effectiveParallelCommitStrategy() {
+        CommitStrategy configured = configuration.commitStrategy();
+        return configured.mode() == CommitStrategy.Mode.CONNECTION_DEFAULT
+                ? CommitStrategy.perTable()
+                : configured;
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/db/TableConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableConfiguration.java
@@ -21,24 +21,72 @@ import java.util.Set;
 /**
  * Configuration for customizing how a specific table should be filled with data.
  * This record allows users to specify a custom row count for an individual table
- * (overriding the default row count specified in the DatabaseConfiguration) and,
- * optionally, per-column generator overrides.
+ * (overriding the default row count specified in the DatabaseConfiguration), an optional
+ * intra-table partition count for parallel fills, and optional per-column generator overrides.
+ *
+ * <p><strong>Intra-table partitioning.</strong> When {@code partitions > 1} <em>and</em> the fill
+ * runs on the parallel ({@code DataSource} + {@code threads}) path, this table's rows are split into
+ * that many contiguous ranges filled concurrently, one connection per range — useful when a single
+ * large table dominates the fill. It is ignored on the sequential (single-{@code Connection}) path.
+ *
+ * <p>Partitioning is reproducible <em>for a given configuration, including the partition count</em>:
+ * key columns and the columns correlated with them (foreign keys, sequences, permutations) are
+ * byte-for-byte identical to a sequential fill, so foreign-key validity always holds; only plain
+ * non-key random columns take different (but still deterministic) values when the partition count
+ * changes. One case is unsupported: partitioning a parent table whose primary key is a plain
+ * <em>random</em> generator referenced by a foreign key can orphan those references — partition the
+ * child table instead, or use the positional key generators (as the bundled TPC-C/TPC-H
+ * configurations do).
  *
  * @param tableName the name of the table to configure
  * @param rowCount the number of rows to generate for this table
  * @param columnConfigurations optional per-column generator overrides; may be null or empty
+ * @param partitions the number of intra-table partitions for parallel fills; {@code 1} (the default)
+ *        disables intra-table partitioning. Must be {@code >= 1}.
  * @since 1.0.0
  */
-public record TableConfiguration(String tableName, long rowCount, Set<ColumnConfiguration> columnConfigurations) {
+public record TableConfiguration(String tableName, long rowCount, Set<ColumnConfiguration> columnConfigurations, int partitions) {
 
     /**
-     * Creates a table configuration with no per-column overrides.
+     * Validates and normalizes the partition count: a non-positive value defaults to {@code 1}
+     * (no intra-table partitioning).
+     */
+    public TableConfiguration {
+        if (partitions < 1) {
+            partitions = 1;
+        }
+    }
+
+    /**
+     * Creates a table configuration with no per-column overrides and no intra-table partitioning.
      *
      * @param tableName the name of the table to configure
      * @param rowCount the number of rows to generate for this table
      */
     public TableConfiguration(String tableName, long rowCount) {
-        this(tableName, rowCount, null);
+        this(tableName, rowCount, null, 1);
+    }
+
+    /**
+     * Creates a table configuration with per-column overrides and no intra-table partitioning.
+     *
+     * @param tableName the name of the table to configure
+     * @param rowCount the number of rows to generate for this table
+     * @param columnConfigurations optional per-column generator overrides; may be null or empty
+     */
+    public TableConfiguration(String tableName, long rowCount, Set<ColumnConfiguration> columnConfigurations) {
+        this(tableName, rowCount, columnConfigurations, 1);
+    }
+
+    /**
+     * Creates a table configuration with an intra-table partition count and no per-column overrides.
+     *
+     * @param tableName the name of the table to configure
+     * @param rowCount the number of rows to generate for this table
+     * @param partitions the number of intra-table partitions for parallel fills ({@code >= 1})
+     */
+    public TableConfiguration(String tableName, long rowCount, int partitions) {
+        this(tableName, rowCount, null, partitions);
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -19,7 +19,9 @@ package io.bloviate.db;
 import io.bloviate.ext.DatabaseSupport;
 import io.bloviate.ext.GeneratorRegistry;
 import io.bloviate.gen.DataGenerator;
+import io.bloviate.gen.IndexedDataGenerator;
 import io.bloviate.util.DatabaseUtils;
+import io.bloviate.util.Mixers;
 import io.bloviate.util.RandomGenerators;
 import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
@@ -48,8 +50,16 @@ public class TableFiller implements Fillable {
     private final DatabaseConfiguration databaseConfiguration;
     private final Table table;
 
+    /** How this filler commits; resolved from the builder override or {@link DatabaseConfiguration}. */
+    private final CommitStrategy commitStrategy;
+
+    /** True when this filler handles a sub-range (one partition) of the table rather than all rows. */
+    private final boolean partitioned;
+    private final long rangeStartInclusive;
+    private final long rangeEndExclusive;
+
     /**
-     * Constructs a new TableFiller.
+     * Constructs a new TableFiller using the configuration's {@link CommitStrategy}.
      *
      * @param connection the database connection to use for filling the table
      * @param database the database metadata containing table relationships
@@ -57,10 +67,27 @@ public class TableFiller implements Fillable {
      * @param table the table to be filled with data
      */
     public TableFiller(Connection connection, Database database, DatabaseConfiguration databaseConfiguration, Table table) {
+        this(connection, database, databaseConfiguration, table, databaseConfiguration.commitStrategy());
+    }
+
+    /**
+     * Constructs a new TableFiller with an explicit {@link CommitStrategy} override.
+     *
+     * @param connection the database connection to use for filling the table
+     * @param database the database metadata containing table relationships
+     * @param databaseConfiguration the configuration settings for the fill operation
+     * @param table the table to be filled with data
+     * @param commitStrategy the commit strategy to use; falls back to the configuration's when null
+     */
+    public TableFiller(Connection connection, Database database, DatabaseConfiguration databaseConfiguration, Table table, CommitStrategy commitStrategy) {
         this.connection = connection;
         this.database = database;
         this.databaseConfiguration = databaseConfiguration;
         this.table = table;
+        this.commitStrategy = commitStrategy != null ? commitStrategy : databaseConfiguration.commitStrategy();
+        this.partitioned = false;
+        this.rangeStartInclusive = 0;
+        this.rangeEndExclusive = 0;
     }
 
     @Override
@@ -138,30 +165,58 @@ public class TableFiller implements Fillable {
 
         int batchSize = databaseConfiguration.batchSize();
 
-        long rowCount = databaseConfiguration.defaultRowCount();
+        long totalRowCount = databaseConfiguration.defaultRowCount();
         if (tableConfiguration != null) {
-            rowCount = tableConfiguration.rowCount();
+            totalRowCount = tableConfiguration.rowCount();
         }
 
-        logger.info("filling table [{}] with [{}] rows", table.name(), rowCount);
+        // when a sub-range is configured this filler handles one partition of the table; otherwise
+        // it fills the whole table on the original, byte-for-byte-unchanged path
+        long startRow = partitioned ? rangeStartInclusive : 0;
+        long endRow = partitioned ? Math.min(rangeEndExclusive, totalRowCount) : totalRowCount;
+
+        if (partitioned) {
+            logger.info("filling table [{}] rows [{}, {}) of [{}]", table.name(), startRow, endRow, totalRowCount);
+        } else {
+            logger.info("filling table [{}] with [{}] rows", table.name(), totalRowCount);
+        }
 
         StopWatch tableWatch = new StopWatch(String.format("filled table [%s] in", table.name()));
         tableWatch.start();
 
+        // For anything other than CONNECTION_DEFAULT the engine owns the transaction: autocommit off
+        // for the fill, commit at the configured cadence, roll back on error, and restore the prior
+        // autocommit in the finally. CONNECTION_DEFAULT leaves the connection exactly as the caller
+        // (or pool) configured it — the original, back-compatible behavior.
+        boolean manageTransaction = commitStrategy.managesTransaction();
+        boolean previousAutoCommit = manageTransaction && connection.getAutoCommit();
+        if (manageTransaction) {
+            connection.setAutoCommit(false);
+        }
+
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
 
-            int rowCounter = 0;
-            for (long i = 0; i < rowCount; i++) {
+            if (partitioned) {
+                // position every generator at the partition's first absolute row so its values match
+                // the sequential fill: keys/foreign keys stay byte-identical, while non-key random
+                // columns are reseeded per partition (deterministic for the chosen partition count)
+                seekGeneratorsTo(generators, reseedSeeds, maxInvocations, startRow);
+            }
+
+            int batchesSinceCommit = 0;
+            long produced = 0;
+            for (long i = startRow; i < endRow; i++) {
 
                 for (int col = 0; col < columnCount; col++) {
 
                     DataGenerator<?> dataGenerator = generators[col];
 
                     long maxInvocation = maxInvocations[col];
-                    if (maxInvocation > 0 && rowCounter != 0 && rowCounter % maxInvocation == 0) {
+                    if (maxInvocation > 0 && i != 0 && i % maxInvocation == 0) {
                         // foreign-key generator has exhausted the parent key space; reseed its random
                         // source so it replays the same parent keys and never references a non-existent
-                        // parent (generator counter/sequence state is preserved)
+                        // parent (positional generators ignore the unused RNG, so this is a no-op for
+                        // them; the index drives their wraparound by formula)
                         dataGenerator.reseed(reseedSeeds[col]);
                     }
 
@@ -170,18 +225,69 @@ public class TableFiller implements Fillable {
 
                 ps.addBatch();
 
-                if (++rowCounter % batchSize == 0) {
+                if (++produced % batchSize == 0) {
                     ps.executeBatch();
+                    if (commitStrategy.mode() == CommitStrategy.Mode.EVERY_N_BATCHES
+                            && ++batchesSinceCommit % commitStrategy.batches() == 0) {
+                        connection.commit();
+                    }
                 }
             }
 
             ps.executeBatch();
+
+            if (manageTransaction) {
+                // commit the final partial batch (and any whole batches not yet committed under EVERY_N_BATCHES)
+                connection.commit();
+            }
+        } catch (SQLException e) {
+            if (manageTransaction) {
+                connection.rollback();
+            }
+            throw e;
+        } finally {
+            if (manageTransaction) {
+                connection.setAutoCommit(previousAutoCommit);
+            }
         }
 
         tableWatch.stop();
 
         logger.info(tableWatch.toString());
 
+    }
+
+    /**
+     * Positions every column generator so the next value produced is the one for absolute row
+     * {@code startRow}, using a three-way policy that keeps a partitioned fill consistent with a
+     * sequential one:
+     * <ul>
+     *   <li><b>Positional generators</b> ({@link IndexedDataGenerator} — keys, sequences,
+     *       permutations, prefixes) seek directly to the absolute index, so they are byte-identical
+     *       to the sequential fill regardless of partition count.</li>
+     *   <li><b>Foreign-key random-replay columns</b> ({@code maxInvocations[col] > 0}) reseed and
+     *       advance {@code startRow % maxInvocation} draws into the parent key cycle, so the partition
+     *       continues the exact parent-key sequence and never references a missing parent.</li>
+     *   <li><b>Plain non-key random columns</b> are reseeded from a partition-derived seed; their
+     *       values are deterministic for the chosen partition count but (by design) need not match a
+     *       different partitioning, as they carry no cross-row contract.</li>
+     * </ul>
+     */
+    private void seekGeneratorsTo(DataGenerator<?>[] generators, long[] reseedSeeds, long[] maxInvocations, long startRow) {
+        for (int col = 0; col < generators.length; col++) {
+            DataGenerator<?> generator = generators[col];
+            if (generator instanceof IndexedDataGenerator indexed) {
+                indexed.seek(startRow);
+            } else if (maxInvocations[col] > 0) {
+                generator.reseed(reseedSeeds[col]);
+                long advance = startRow % maxInvocations[col];
+                for (long k = 0; k < advance; k++) {
+                    generator.generate();
+                }
+            } else {
+                generator.reseed(Mixers.splitmix64(reseedSeeds[col] + startRow));
+            }
+        }
     }
 
 
@@ -192,6 +298,10 @@ public class TableFiller implements Fillable {
         private final DatabaseConfiguration databaseConfiguration;
 
         private Table table;
+        private CommitStrategy commitStrategy;
+        private boolean partitioned;
+        private long rangeStartInclusive;
+        private long rangeEndExclusive;
 
         public Builder(Connection connection, Database database, DatabaseConfiguration databaseConfiguration) {
             this.connection = connection;
@@ -209,6 +319,39 @@ public class TableFiller implements Fillable {
             return this;
         }
 
+        /**
+         * Overrides the {@link CommitStrategy} for this table fill. When unset (or null), the
+         * configuration's strategy is used.
+         *
+         * @param commitStrategy the commit strategy to use, or null for the configuration default
+         * @return this builder
+         */
+        public Builder commitStrategy(CommitStrategy commitStrategy) {
+            this.commitStrategy = commitStrategy;
+            return this;
+        }
+
+        /**
+         * Restricts this filler to a contiguous sub-range of the table's rows — one partition of an
+         * intra-table parallel fill. Generators are positioned to {@code startInclusive} so the
+         * produced values match the sequential fill for the corresponding rows (see
+         * {@link TableFiller#seekGeneratorsTo}). When unset, the whole table is filled.
+         *
+         * @param startInclusive the first absolute (0-based) row to fill, inclusive
+         * @param endExclusive the row to stop at, exclusive
+         * @return this builder
+         * @throws IllegalArgumentException if the range is negative or empty/inverted
+         */
+        public Builder rowRange(long startInclusive, long endExclusive) {
+            if (startInclusive < 0 || endExclusive < startInclusive) {
+                throw new IllegalArgumentException("invalid row range [" + startInclusive + ", " + endExclusive + ")");
+            }
+            this.rangeStartInclusive = startInclusive;
+            this.rangeEndExclusive = endExclusive;
+            this.partitioned = true;
+            return this;
+        }
+
         public TableFiller build() {
             return new TableFiller(this);
         }
@@ -219,5 +362,9 @@ public class TableFiller implements Fillable {
         this.table = builder.table;
         this.database = builder.database;
         this.databaseConfiguration = builder.databaseConfiguration;
+        this.commitStrategy = builder.commitStrategy != null ? builder.commitStrategy : builder.databaseConfiguration.commitStrategy();
+        this.partitioned = builder.partitioned;
+        this.rangeStartInclusive = builder.rangeStartInclusive;
+        this.rangeEndExclusive = builder.rangeEndExclusive;
     }
 }

--- a/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java
@@ -31,4 +31,16 @@ package io.bloviate.ext;
  */
 public class CockroachDBSupport extends PostgresSupport {
 
+    /**
+     * CockroachDB ignores the PostgreSQL driver's {@code reWriteBatchedInserts} parameter, so
+     * there is nothing to recommend; overrides {@link PostgresSupport#batchRewriteUrlParameter()}
+     * back to {@code null}.
+     *
+     * @return {@code null}
+     * @since 2.10.0
+     */
+    @Override
+    public String batchRewriteUrlParameter() {
+        return null;
+    }
 }

--- a/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java
@@ -56,6 +56,27 @@ public interface DatabaseSupport {
     DataGenerator<?> getDataGenerator(Column column, RandomGenerator random);
 
     /**
+     * Returns the JDBC-URL parameter name that enables this driver's <em>batch rewrite</em>
+     * optimization &mdash; collapsing a JDBC batch into a single multi-row {@code INSERT} &mdash;
+     * or {@code null} if the database has no such parameter.
+     *
+     * <p>Bloviate fills through a {@link Connection}/{@link javax.sql.DataSource} it does not own,
+     * so it cannot add this parameter to the URL after the fact. Instead, the fill engine reads it
+     * to warn when the parameter is absent (it is often the single biggest fill speedup), and
+     * {@link io.bloviate.util.JdbcUrls} uses it to help callers build a correctly-parameterized URL.
+     *
+     * <p>Known values: PostgreSQL {@code reWriteBatchedInserts}, MySQL
+     * {@code rewriteBatchedStatements}. CockroachDB ignores batch rewrite, so it returns
+     * {@code null}; the generic {@link DefaultSupport} also returns {@code null}.
+     *
+     * @return the batch-rewrite URL parameter name, or {@code null} if not applicable
+     * @since 2.10.0
+     */
+    default String batchRewriteUrlParameter() {
+        return null;
+    }
+
+    /**
      * Selects a {@link DatabaseSupport} for the given JDBC product name (as reported by
      * {@link java.sql.DatabaseMetaData#getDatabaseProductName()}), so callers don't have
      * to hardcode a specific implementation.

--- a/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
@@ -42,6 +42,11 @@ import java.util.Map;
 public class MySQLSupport extends AbstractDatabaseSupport {
 
     @Override
+    public String batchRewriteUrlParameter() {
+        return "rewriteBatchedStatements";
+    }
+
+    @Override
     protected void configure(Map<JDBCType, GeneratorFactory> registry) {
 
         // MySQL JSON columns report as LONGVARCHAR with type name "JSON". Generate valid JSON

--- a/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
@@ -68,6 +68,11 @@ import java.util.Map;
 public class PostgresSupport extends AbstractDatabaseSupport {
 
     @Override
+    public String batchRewriteUrlParameter() {
+        return "reWriteBatchedInserts";
+    }
+
+    @Override
     protected void configure(Map<JDBCType, GeneratorFactory> registry) {
 
         // PostgreSQL reports both bit/bit(n) and boolean as JDBCType.BIT, distinguished by

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p>The produced values do not depend on the random source; counter state is held by
  * the generator instance and advances on every {@link #generate()}.
  */
-public class ChildCountGenerator extends AbstractDataGenerator<Integer> {
+public class ChildCountGenerator extends AbstractDataGenerator<Integer> implements IndexedDataGenerator {
 
     private final ChildCardinality cardinality;
     private final AtomicLong counter = new AtomicLong(0);
@@ -42,6 +42,20 @@ public class ChildCountGenerator extends AbstractDataGenerator<Integer> {
     @Override
     public Integer generate() {
         return cardinality.count(counter.getAndIncrement());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The value is {@code cardinality.count(rowIndex)}, a pure function of the row index, so
+     * seeking is O(1): the counter is set to {@code rowIndex}.
+     */
+    @Override
+    public void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+        counter.set(rowIndex);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
@@ -50,7 +50,7 @@ import java.util.random.RandomGenerator;
  *
  * <p>The produced values do not depend on the random source.
  */
-public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> {
+public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> implements IndexedDataGenerator {
 
     private final ChildCardinality cardinality;
     private final boolean sequence;
@@ -80,6 +80,48 @@ public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> {
             return start + currentPosition;
         }
         return start + (int) ((parentIndex / repeat) % cycle);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Positions the cursor on the parent that owns the {@code rowIndex}-th child and the offset
+     * within it, so the next {@link #generate()} returns exactly what a sequential walk would. When
+     * the cardinality is fixed this is O(1); otherwise it is a single O(parentCount) scan that
+     * accumulates child counts (done once per partition, then generation walks sequentially).
+     */
+    @Override
+    public synchronized void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+
+        long owningParent;
+        long positionInParent;
+
+        if (cardinality.minChildren() == cardinality.maxChildren() && cardinality.minChildren() > 0) {
+            // fixed cardinality: closed form
+            int childrenPerParent = cardinality.minChildren();
+            owningParent = rowIndex / childrenPerParent;
+            positionInParent = rowIndex % childrenPerParent;
+        } else {
+            // variable cardinality: walk parents (skipping empty ones) until the target child is owned
+            long cumulative = 0;
+            owningParent = 0;
+            while (true) {
+                int childCount = cardinality.count(owningParent);
+                if (cumulative + childCount > rowIndex) {
+                    positionInParent = rowIndex - cumulative;
+                    break;
+                }
+                cumulative += childCount;
+                owningParent++;
+            }
+        }
+
+        this.parentIndex = owningParent;
+        this.position = (int) positionInParent;
+        this.childrenRemaining = cardinality.count(owningParent) - (int) positionInParent;
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p>The produced values do not depend on the random source; counter state is
  * held by the generator instance and advances on every {@link #generate()}.
  */
-public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Integer> {
+public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Integer> implements IndexedDataGenerator {
 
     private final int start;
     private final long repeat;
@@ -56,6 +56,20 @@ public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Intege
     public Integer generate() {
         long n = counter.getAndIncrement();
         return start + (int) ((n / repeat) % cycle);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The value is a closed form of the row index ({@code start + ((rowIndex / repeat) % cycle)}),
+     * so seeking is O(1): the counter is simply set to {@code rowIndex}.
+     */
+    @Override
+    public void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+        counter.set(rowIndex);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <p>Supports group sizes up to {@code 2^30}.
  */
-public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> {
+public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> implements IndexedDataGenerator {
 
     private static final int ROUNDS = 4;
 
@@ -60,6 +60,21 @@ public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> 
         int position = (int) (n % groupSize);
         long key = mix(seed + group);
         return start + permute(position, key);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The value is a pure function of the row index (the permutation is keyed by
+     * {@code rowIndex / groupSize} and applied to {@code rowIndex % groupSize}), so seeking is O(1):
+     * the counter is set to {@code rowIndex}.
+     */
+    @Override
+    public void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+        counter.set(rowIndex);
     }
 
     // cycle-walking: a Feistel permutation on [0, 2^(2*halfBits)) restricted to [0, groupSize)

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
@@ -16,6 +16,8 @@
 
 package io.bloviate.gen;
 
+import io.bloviate.util.Mixers;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -39,7 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @param <T> the Java type produced by the wrapped generator
  */
-public class GroupedPrefixGenerator<T> extends AbstractDataGenerator<T> {
+public class GroupedPrefixGenerator<T> extends AbstractDataGenerator<T> implements IndexedDataGenerator {
 
     private final int groupSize;
     private final int prefixSize;
@@ -50,6 +52,31 @@ public class GroupedPrefixGenerator<T> extends AbstractDataGenerator<T> {
     public T generate() {
         int position = (int) (counter.getAndIncrement() % groupSize);
         return position < prefixSize ? delegate.generate() : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Setting the counter to {@code rowIndex} restores the null/non-null pattern exactly (it is a
+     * pure function of the absolute position). The wrapped delegate is consulted only on prefix rows,
+     * so it is advanced to the matching delegate-call index: a positional delegate is itself
+     * {@link #seek(long) sought} (byte-identical), while a plain random delegate is reseeded
+     * deterministically for the partition (its non-key values may differ from a sequential fill).
+     */
+    @Override
+    public void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+        counter.set(rowIndex);
+        // number of delegate.generate() calls made for rows [0, rowIndex): prefixSize per full group
+        // plus the prefix rows of the partial group
+        long delegateIndex = (rowIndex / groupSize) * prefixSize + Math.min(rowIndex % groupSize, prefixSize);
+        if (delegate instanceof IndexedDataGenerator indexedDelegate) {
+            indexedDelegate.seek(delegateIndex);
+        } else {
+            delegate.reseed(Mixers.splitmix64(delegateIndex));
+        }
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/IndexedDataGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IndexedDataGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+/**
+ * A {@link DataGenerator} whose value for a row is a deterministic function of that row's
+ * <em>absolute</em> (0-based) index, so it can be positioned to any row without replaying every
+ * preceding {@code generate()} call.
+ *
+ * <p>This is what lets the fill engine partition a single table's rows across workers (intra-table
+ * parallelism): a worker filling the range {@code [start, end)} calls {@link #seek(long) seek(start)}
+ * once and then iterates {@code generate()} as usual, producing exactly the values the sequential
+ * fill produces at those rows. Implemented by the counter/cursor-based generators whose output is
+ * positional &mdash; the key, sequence, child-count, permutation, and prefix generators &mdash; so
+ * that key columns and the columns correlated with them stay byte-for-byte identical regardless of
+ * how the rows are partitioned (preserving foreign-key validity).
+ *
+ * <p>Plain random generators are intentionally <em>not</em> indexed: their values carry no cross-row
+ * contract, so the engine reseeds them per partition instead.
+ *
+ * @since 2.10.0
+ * @see DataGenerator
+ */
+public interface IndexedDataGenerator {
+
+    /**
+     * Positions this generator so the next {@link DataGenerator#generate()} returns the value for
+     * the given absolute (0-based) row index.
+     *
+     * @param rowIndex the absolute, 0-based row index to seek to; must be {@code >= 0}
+     */
+    void seek(long rowIndex);
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * source; the counter state is held by the generator instance and advances on
  * every call to {@link #generate()}.
  */
-public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> {
+public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> implements IndexedDataGenerator {
 
     private final int startInclusive;
     private final int endInclusive;
@@ -41,6 +41,21 @@ public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> {
     @Override
     public Integer generate() {
         return counter.getAndUpdate(current -> current >= endInclusive ? startInclusive : current + 1);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The value at call index {@code n} is {@code start + (n % range)} where
+     * {@code range = end - start + 1}, so seeking is O(1).
+     */
+    @Override
+    public void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+        long range = (long) endInclusive - startInclusive + 1;
+        counter.set((int) (startInclusive + rowIndex % range));
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/OrderLineDeliveryDateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/OrderLineDeliveryDateGenerator.java
@@ -20,6 +20,7 @@ import io.bloviate.gen.AbstractBuilder;
 import io.bloviate.gen.AbstractDataGenerator;
 import io.bloviate.gen.ChildCardinality;
 import io.bloviate.gen.ChildKeyComponentGenerator;
+import io.bloviate.gen.IndexedDataGenerator;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -44,7 +45,7 @@ import java.util.random.RandomGenerator;
  * <p>The delivery timestamp approximates the spec's {@code ol_delivery_d = o_entry_d}; the
  * fidelity that matters is that undelivered orders' lines are NULL.
  */
-public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timestamp> {
+public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timestamp> implements IndexedDataGenerator {
 
     private final ChildKeyComponentGenerator orderId;
     private final int deliveredThreshold;
@@ -53,6 +54,18 @@ public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timest
     public Timestamp generate() {
         int oId = orderId.generate();
         return oId <= deliveredThreshold ? Timestamp.from(Instant.now()) : null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The delivered/undelivered (timestamp-vs-NULL) decision is positional — it comes entirely
+     * from the wrapped {@link ChildKeyComponentGenerator} walker — so seeking delegates to it,
+     * keeping the column aligned with the {@code order_line} keys under intra-table partitioning.
+     */
+    @Override
+    public void seek(long rowIndex) {
+        orderId.seek(rowIndex);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/util/JdbcUrls.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/JdbcUrls.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.util;
+
+/**
+ * Small helpers for inspecting and extending JDBC connection URLs.
+ *
+ * <p>Bloviate fills through a {@link java.sql.Connection}/{@link javax.sql.DataSource} it does not
+ * own, so it cannot change the URL after the fact. These helpers let a caller who <em>does</em> build
+ * the URL (or {@code DataSource}) add the driver's batch-rewrite parameter programmatically &mdash;
+ * the optimization that is often the single biggest fill speedup. The matching parameter name comes
+ * from {@code io.bloviate.ext.DatabaseSupport#batchRewriteUrlParameter()} (PostgreSQL
+ * {@code reWriteBatchedInserts}, MySQL {@code rewriteBatchedStatements}).
+ *
+ * <p>All methods treat the query string in the simple {@code key=value} form drivers use and compare
+ * parameter names case-insensitively. They do no URL decoding; they are intended for the
+ * straightforward JDBC URLs the supported drivers accept.
+ *
+ * @since 2.10.0
+ */
+public final class JdbcUrls {
+
+    private JdbcUrls() {
+    }
+
+    /**
+     * Returns whether the URL already carries a query parameter with the given name (any value).
+     *
+     * @param url  the JDBC URL, may be null
+     * @param name the parameter name (case-insensitive)
+     * @return {@code true} if the parameter is present
+     */
+    public static boolean hasParameter(String url, String name) {
+        return rawValue(url, name) != null;
+    }
+
+    /**
+     * Returns whether the URL carries the given parameter set to the given value
+     * (both name and value compared case-insensitively).
+     *
+     * @param url   the JDBC URL, may be null
+     * @param name  the parameter name (case-insensitive)
+     * @param value the expected value (case-insensitive)
+     * @return {@code true} if present and equal
+     */
+    public static boolean parameterEquals(String url, String name, String value) {
+        String actual = rawValue(url, name);
+        return actual != null && actual.equalsIgnoreCase(value);
+    }
+
+    /**
+     * Appends {@code name=value} to the URL's query string, choosing {@code ?} or {@code &} as the
+     * separator. Does not check for or replace an existing parameter of the same name &mdash; use
+     * {@link #hasParameter(String, String)} first if that matters.
+     *
+     * @param url   the JDBC URL
+     * @param name  the parameter name
+     * @param value the parameter value
+     * @return the URL with the parameter appended
+     * @throws IllegalArgumentException if any argument is null/blank
+     */
+    public static String appendParameter(String url, String name, String value) {
+        if (url == null || url.isBlank()) {
+            throw new IllegalArgumentException("url must not be blank");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("value must not be null");
+        }
+        String separator = url.indexOf('?') < 0 ? "?" : "&";
+        return url + separator + name + "=" + value;
+    }
+
+    /**
+     * Returns the URL with the driver's batch-rewrite parameter set to {@code true}, or the URL
+     * unchanged if {@code parameterName} is null/blank (the database has no such parameter) or the
+     * URL already specifies the parameter (the caller's explicit value is preserved).
+     *
+     * <pre>{@code
+     * String url = JdbcUrls.withBatchRewrite(baseUrl, support.batchRewriteUrlParameter());
+     * }</pre>
+     *
+     * @param url           the JDBC URL
+     * @param parameterName the batch-rewrite parameter name, or null if not applicable
+     * @return the URL, with the parameter appended when applicable and absent
+     */
+    public static String withBatchRewrite(String url, String parameterName) {
+        if (parameterName == null || parameterName.isBlank()) {
+            return url;
+        }
+        if (hasParameter(url, parameterName)) {
+            return url;
+        }
+        return appendParameter(url, parameterName, "true");
+    }
+
+    /** Returns the raw (un-decoded) value of the named query parameter, or null if absent. */
+    private static String rawValue(String url, String name) {
+        if (url == null) {
+            return null;
+        }
+        int question = url.indexOf('?');
+        if (question < 0 || question == url.length() - 1) {
+            return null;
+        }
+        for (String pair : url.substring(question + 1).split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int equals = pair.indexOf('=');
+            String key = equals < 0 ? pair : pair.substring(0, equals);
+            if (key.equalsIgnoreCase(name)) {
+                return equals < 0 ? "" : pair.substring(equals + 1);
+            }
+        }
+        return null;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/util/Mixers.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/Mixers.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.util;
+
+/**
+ * Deterministic integer mixing functions shared across the engine.
+ *
+ * <p>{@link #splitmix64(long)} is the splitmix64 finalizer: a fast, well-distributed bijection on
+ * 64-bit values with no state. The fill engine uses it to derive one reproducible value from another
+ * &mdash; for example a per-partition seed from a column seed and a starting row offset, or a child
+ * count from a parent index &mdash; without pulling from a stateful random source.
+ *
+ * @since 2.10.0
+ */
+public final class Mixers {
+
+    private Mixers() {
+    }
+
+    /**
+     * The splitmix64 finalizer applied to {@code value}.
+     *
+     * @param value the input
+     * @return a well-distributed, deterministic mix of {@code value}
+     */
+    public static long splitmix64(long value) {
+        long z = value + 0x9E3779B97F4A7C15L;
+        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
+        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
+        return z ^ (z >>> 31);
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/CommitStrategyTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/CommitStrategyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.ext.DefaultSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CommitStrategyTest {
+
+    @Test
+    void factoriesProduceExpectedModes() {
+        assertEquals(CommitStrategy.Mode.CONNECTION_DEFAULT, CommitStrategy.connectionDefault().mode());
+        assertEquals(CommitStrategy.Mode.PER_TABLE, CommitStrategy.perTable().mode());
+
+        CommitStrategy everyFive = CommitStrategy.everyNBatches(5);
+        assertEquals(CommitStrategy.Mode.EVERY_N_BATCHES, everyFive.mode());
+        assertEquals(5, everyFive.batches());
+    }
+
+    @Test
+    void onlyConnectionDefaultLeavesTransactionToTheConnection() {
+        assertFalse(CommitStrategy.connectionDefault().managesTransaction());
+        assertTrue(CommitStrategy.perTable().managesTransaction());
+        assertTrue(CommitStrategy.everyNBatches(2).managesTransaction());
+    }
+
+    @Test
+    void everyNBatchesRejectsNonPositiveCadence() {
+        assertThrows(IllegalArgumentException.class, () -> CommitStrategy.everyNBatches(0));
+        assertThrows(IllegalArgumentException.class, () -> CommitStrategy.everyNBatches(-1));
+    }
+
+    @Test
+    void databaseConfigurationDefaultsToConnectionDefaultWhenUnset() {
+        // the four-arg convenience constructor must normalize the (absent) strategy
+        DatabaseConfiguration configuration =
+                new DatabaseConfiguration(100, 10, new DefaultSupport(), Set.of());
+        assertEquals(CommitStrategy.connectionDefault(), configuration.commitStrategy());
+    }
+
+    @Test
+    void databaseConfigurationNormalizesNullStrategy() {
+        DatabaseConfiguration configuration =
+                new DatabaseConfiguration(100, 10, new DefaultSupport(), Set.of(), 42L, null);
+        assertEquals(CommitStrategy.connectionDefault(), configuration.commitStrategy());
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresCommitStrategyTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresCommitStrategyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Set;
+
+/**
+ * Verifies issue #467: an explicit {@link CommitStrategy} on the sequential (single-{@code Connection})
+ * fill path produces correct data. The engine takes over the transaction (autocommit off, commit at the
+ * configured cadence) and must leave a complete, valid dataset.
+ */
+class PostgresCommitStrategyTest extends BaseDatabaseTestCase {
+
+    private static final int W = 1;
+    private static final int I = 100;
+    private static final int D = 10;
+    private static final int C = 20;
+    private static final int MIN_LINES = 5;
+    private static final int MAX_LINES = 15;
+    private static final int NEW_ORDERS = 8;
+
+    @Test
+    void perTableAndEveryNBatchesCommitStrategiesFillCorrectly() throws SQLException {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+
+        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
+                .withDatabaseName("bloviate")
+                .withUrlParam("rewriteBatchedInserts", "true")
+                .withUrlParam("stringtype", "unspecified")
+                .withInitScript("create_tpcc.postgres.sql")) {
+
+            database.start();
+
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
+
+                // commit once per table on the sequential path (autocommit off, single commit per table)
+                fillAndVerify(dataSource, new DatabaseConfiguration(64, 0, new PostgresSupport(), tables, 7L, CommitStrategy.perTable()));
+
+                // commit every N batches: bounds the open transaction while filling
+                fillAndVerify(dataSource, new DatabaseConfiguration(64, 0, new PostgresSupport(), tables, 7L, CommitStrategy.everyNBatches(3)));
+            }
+        }
+    }
+
+    private void fillAndVerify(HikariDataSource dataSource, DatabaseConfiguration configuration) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            new DatabaseFiller.Builder(connection, configuration).build().fill();
+
+            assertRowCount(connection, "warehouse", W);
+            assertRowCount(connection, "stock", (long) W * I);
+            assertRowCount(connection, "customer", (long) W * D * C);
+            assertTpccColumnFidelity(connection, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+
+            truncateAll(connection);
+        }
+    }
+
+    private static void truncateAll(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("TRUNCATE warehouse, item, stock, district, customer, history, open_order, new_order, order_line CASCADE");
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresIntraTableFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresIntraTableFillTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
+import io.bloviate.util.DatabaseUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies issue #466 intra-table parallelism: partitioning a single table's rows across workers
+ * (configured via {@link TableConfiguration#partitions()} on the parallel
+ * {@link DatabaseFiller.Builder#Builder(javax.sql.DataSource, DatabaseConfiguration)} +
+ * {@link DatabaseFiller.Builder#threads(int)} path).
+ *
+ * <p>A TPC-C schema is used because it carries real foreign-key constraints and rich positional
+ * correlations (composite keys, per-order line counts, the per-district {@code o_c_id} permutation,
+ * the delivery-state prefix), so a partitioned fill that completes and passes
+ * {@link #assertTpccColumnFidelity} proves the key and key-correlated columns stayed coherent — i.e.
+ * partitioning preserved foreign-key validity and reproducibility.
+ */
+class PostgresIntraTableFillTest extends BaseDatabaseTestCase {
+
+    private static final int W = 2;
+    private static final int I = 200;
+    private static final int D = 10;
+    private static final int C = 30;
+    private static final int MIN_LINES = 5;
+    private static final int MAX_LINES = 15;
+    private static final int NEW_ORDERS = 10;
+
+    // partition a mix of an early parent (stock), a mid parent (customer) and the largest leaf
+    // (order_line); all use positional key generators, so foreign keys stay valid under partitioning
+    private static final Set<String> PARTITIONED_TABLES = Set.of("stock", "customer", "order_line");
+    private static final int PARTITIONS = 4;
+
+    @Test
+    void intraTablePartitionedFillIsValidAndReproducible() throws SQLException {
+        Set<TableConfiguration> tables = withPartitions(
+                TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS), PARTITIONS, PARTITIONED_TABLES);
+        DatabaseConfiguration configuration =
+                new DatabaseConfiguration(256, 0, new PostgresSupport(), tables, 42L);
+
+        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
+                .withDatabaseName("bloviate")
+                .withUrlParam("rewriteBatchedInserts", "true")
+                .withUrlParam("stringtype", "unspecified")
+                .withInitScript("create_tpcc.postgres.sql")) {
+
+            database.start();
+
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
+
+                List<String> tableNames;
+                Map<String, List<String>> firstDump;
+
+                // first partitioned fill: four workers, three tables split into four row ranges each.
+                // Completing at all means every foreign key resolved (the schema enforces them).
+                new DatabaseFiller.Builder(dataSource, configuration).threads(4).build().fill();
+
+                try (Connection connection = dataSource.getConnection()) {
+                    tableNames = tableNames(connection);
+
+                    // row counts are exactly what a sequential fill would produce (no rows lost or duplicated)
+                    assertRowCount(connection, "warehouse", W);
+                    assertRowCount(connection, "item", I);
+                    assertRowCount(connection, "stock", (long) W * I);
+                    assertRowCount(connection, "district", (long) W * D);
+                    assertRowCount(connection, "customer", (long) W * D * C);
+                    assertRowCount(connection, "open_order", (long) W * D * C);
+                    assertRowCount(connection, "new_order", (long) W * D * NEW_ORDERS);
+
+                    // positional / key-correlated columns stayed coherent across the partition boundaries
+                    assertTpccColumnFidelity(connection, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+
+                    firstDump = dump(connection, tableNames);
+                    truncateAll(connection, tableNames);
+                }
+
+                // second partitioned fill with the same configuration must reproduce the first exactly
+                new DatabaseFiller.Builder(dataSource, configuration).threads(4).build().fill();
+
+                try (Connection connection = dataSource.getConnection()) {
+                    Map<String, List<String>> secondDump = dump(connection, tableNames);
+                    for (String table : tableNames) {
+                        assertEquals(firstDump.get(table), secondDump.get(table),
+                                "table [" + table + "] must be identical across two partitioned fills of the same config");
+                    }
+                }
+            }
+        }
+    }
+
+    /** Returns a copy of the table set with {@code partitions} applied to the named tables. */
+    private static Set<TableConfiguration> withPartitions(Set<TableConfiguration> tables, int partitions, Set<String> names) {
+        Set<TableConfiguration> result = new HashSet<>();
+        for (TableConfiguration table : tables) {
+            if (names.contains(table.tableName().toLowerCase())) {
+                result.add(new TableConfiguration(table.tableName(), table.rowCount(), table.columnConfigurations(), partitions));
+            } else {
+                result.add(table);
+            }
+        }
+        return result;
+    }
+
+    private static List<String> tableNames(Connection connection) throws SQLException {
+        List<String> names = new ArrayList<>();
+        for (Table table : DatabaseUtils.getMetadata(connection).tables()) {
+            names.add(table.name());
+        }
+        return names;
+    }
+
+    /**
+     * Dumps each table ordered by every (non-temporal) column, producing a canonical row multiset
+     * independent of physical insert order (which a partitioned fill may legitimately change).
+     */
+    private static Map<String, List<String>> dump(Connection connection, List<String> tables) throws SQLException {
+        Map<String, List<String>> dump = new LinkedHashMap<>();
+        try (Statement statement = connection.createStatement()) {
+            for (String table : tables) {
+                List<Integer> columns = deterministicColumns(statement, table);
+                if (columns.isEmpty()) {
+                    dump.put(table, List.of());
+                    continue;
+                }
+
+                StringJoiner order = new StringJoiner(",");
+                for (int column : columns) {
+                    order.add(String.valueOf(column));
+                }
+
+                List<String> rows = new ArrayList<>();
+                try (ResultSet resultSet = statement.executeQuery("select * from " + table + " order by " + order)) {
+                    while (resultSet.next()) {
+                        StringJoiner row = new StringJoiner("|");
+                        for (int column : columns) {
+                            row.add(String.valueOf(resultSet.getString(column)));
+                        }
+                        rows.add(row.toString());
+                    }
+                }
+                dump.put(table, rows);
+            }
+        }
+        return dump;
+    }
+
+    /** The 1-based indexes of a table's columns, excluding temporal types (which may use wall-clock time). */
+    private static List<Integer> deterministicColumns(Statement statement, String table) throws SQLException {
+        List<Integer> columns = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("select * from " + table + " where false")) {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                if (!isTemporal(metaData.getColumnType(i))) {
+                    columns.add(i);
+                }
+            }
+        }
+        return columns;
+    }
+
+    private static boolean isTemporal(int sqlType) {
+        return sqlType == Types.DATE
+                || sqlType == Types.TIME
+                || sqlType == Types.TIME_WITH_TIMEZONE
+                || sqlType == Types.TIMESTAMP
+                || sqlType == Types.TIMESTAMP_WITH_TIMEZONE;
+    }
+
+    private static void truncateAll(Connection connection, List<String> tables) throws SQLException {
+        if (tables.isEmpty()) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("TRUNCATE " + String.join(", ", tables) + " CASCADE");
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/ext/BatchRewriteParameterTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/ext/BatchRewriteParameterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BatchRewriteParameterTest {
+
+    @Test
+    void postgresAdvertisesReWriteBatchedInserts() {
+        assertEquals("reWriteBatchedInserts", new PostgresSupport().batchRewriteUrlParameter());
+    }
+
+    @Test
+    void mySqlAdvertisesRewriteBatchedStatements() {
+        assertEquals("rewriteBatchedStatements", new MySQLSupport().batchRewriteUrlParameter());
+    }
+
+    @Test
+    void cockroachDbHasNoBatchRewriteParameter() {
+        // CockroachDB extends PostgresSupport but ignores the parameter, so it overrides back to null
+        assertNull(new CockroachDBSupport().batchRewriteUrlParameter());
+    }
+
+    @Test
+    void defaultSupportHasNoBatchRewriteParameter() {
+        assertNull(new DefaultSupport().batchRewriteUrlParameter());
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/gen/IndexedGeneratorSeekTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/IndexedGeneratorSeekTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the issue #466 contract for {@link IndexedDataGenerator}: for every positional generator,
+ * {@code seek(k)} followed by {@code generate()} reproduces exactly the value the plain sequential
+ * {@code generate()} stream yields at index {@code k} — the property intra-table partitioning relies
+ * on for key columns to stay byte-for-byte identical regardless of how rows are partitioned.
+ */
+class IndexedGeneratorSeekTest {
+
+    private static final int TOTAL = 60;
+    private static final long[] SEEK_POINTS = {0, 1, 2, 7, 11, 12, 23, 24, 35, 59};
+
+    /**
+     * Asserts that for each seek point {@code k}, a freshly built generator seeked to {@code k} and
+     * then run to the end produces the same values as the reference sequential stream from {@code k}.
+     */
+    private static void assertSeekMatchesSequential(Supplier<DataGenerator<Integer>> factory) {
+        DataGenerator<Integer> reference = factory.get();
+        Integer[] expected = new Integer[TOTAL];
+        for (int i = 0; i < TOTAL; i++) {
+            expected[i] = reference.generate();
+        }
+
+        for (long k : SEEK_POINTS) {
+            DataGenerator<Integer> seeker = factory.get();
+            ((IndexedDataGenerator) seeker).seek(k);
+            for (int i = (int) k; i < TOTAL; i++) {
+                int row = i;
+                assertEquals(expected[i], seeker.generate(),
+                        () -> "seek(" + k + ") then generating to the end must match the sequential value at row " + row);
+            }
+        }
+    }
+
+    @Test
+    void compositeKeyComponentSeekMatchesSequential() {
+        assertSeekMatchesSequential(() ->
+                new CompositeKeyComponentGenerator.Builder(new Random()).start(1).repeat(3).cycle(4).build());
+    }
+
+    @Test
+    void sequentialIntegerSeekMatchesSequential() {
+        assertSeekMatchesSequential(() ->
+                new SequentialIntegerGenerator.Builder(new Random()).start(5).end(9).build());
+    }
+
+    @Test
+    void childCountSeekMatchesSequential() {
+        ChildCardinality cardinality = new ChildCardinality(1, 5, 42L);
+        assertSeekMatchesSequential(() ->
+                new ChildCountGenerator.Builder(new Random()).cardinality(cardinality).build());
+    }
+
+    @Test
+    void groupedPermutationSeekMatchesSequential() {
+        assertSeekMatchesSequential(() ->
+                new GroupedPermutationGenerator.Builder(new Random()).groupSize(7).start(1).seed(99L).build());
+    }
+
+    @Test
+    void childKeySequenceSeekMatchesSequential_fixedCardinality() {
+        ChildCardinality cardinality = new ChildCardinality(3, 3, 7L);
+        assertSeekMatchesSequential(() ->
+                new ChildKeyComponentGenerator.Builder(new Random()).cardinality(cardinality).sequence().start(1).build());
+    }
+
+    @Test
+    void childKeySequenceSeekMatchesSequential_variableCardinality() {
+        ChildCardinality cardinality = new ChildCardinality(1, 4, 123L);
+        assertSeekMatchesSequential(() ->
+                new ChildKeyComponentGenerator.Builder(new Random()).cardinality(cardinality).sequence().start(1).build());
+    }
+
+    @Test
+    void childKeyParentComponentSeekMatchesSequential_variableCardinality() {
+        ChildCardinality cardinality = new ChildCardinality(0, 4, 55L);
+        assertSeekMatchesSequential(() ->
+                new ChildKeyComponentGenerator.Builder(new Random()).cardinality(cardinality).start(1).repeat(1).cycle(6).build());
+    }
+
+    @Test
+    void groupedPrefixSeekMatchesSequential_staticDelegate() {
+        // a non-positional (static) delegate: the null/non-null pattern and the constant value are
+        // both a function of the absolute position, so seek is byte-identical
+        assertSeekMatchesSequential(() ->
+                new GroupedPrefixGenerator.Builder<Integer>(new Random())
+                        .groupSize(10).prefixSize(3)
+                        .delegate(new StaticIntegerGenerator.Builder(new Random()).value(7).build())
+                        .build());
+    }
+
+    @Test
+    void groupedPrefixSeekMatchesSequential_positionalDelegate() {
+        // a positional delegate is itself sought, so the emitted prefix values track absolute position
+        assertSeekMatchesSequential(() ->
+                new GroupedPrefixGenerator.Builder<Integer>(new Random())
+                        .groupSize(8).prefixSize(5)
+                        .delegate(new SequentialIntegerGenerator.Builder(new Random()).start(100).end(199).build())
+                        .build());
+    }
+
+    @Test
+    void seekRejectsNegativeRowIndex() {
+        IndexedDataGenerator generator =
+                new CompositeKeyComponentGenerator.Builder(new Random()).start(1).repeat(1).cycle(3).build();
+        assertThrows(IllegalArgumentException.class, () -> generator.seek(-1));
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/util/JdbcUrlsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/util/JdbcUrlsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JdbcUrlsTest {
+
+    @Test
+    void hasParameterIsCaseInsensitiveAndValueAgnostic() {
+        String url = "jdbc:postgresql://host:5432/db?reWriteBatchedInserts=true&stringtype=unspecified";
+        assertTrue(JdbcUrls.hasParameter(url, "rewritebatchedinserts"));
+        assertTrue(JdbcUrls.hasParameter(url, "stringtype"));
+        assertFalse(JdbcUrls.hasParameter(url, "rewriteBatchedStatements"));
+        assertFalse(JdbcUrls.hasParameter("jdbc:postgresql://host/db", "anything"));
+        assertFalse(JdbcUrls.hasParameter(null, "anything"));
+    }
+
+    @Test
+    void parameterEqualsComparesNameAndValueCaseInsensitively() {
+        String url = "jdbc:postgresql://host/db?reWriteBatchedInserts=TRUE";
+        assertTrue(JdbcUrls.parameterEquals(url, "rewritebatchedinserts", "true"));
+        assertFalse(JdbcUrls.parameterEquals(url, "rewritebatchedinserts", "false"));
+        assertFalse(JdbcUrls.parameterEquals("jdbc:mysql://host/db", "rewriteBatchedStatements", "true"));
+    }
+
+    @Test
+    void appendParameterChoosesCorrectSeparator() {
+        assertEquals("jdbc:postgresql://host/db?a=b",
+                JdbcUrls.appendParameter("jdbc:postgresql://host/db", "a", "b"));
+        assertEquals("jdbc:postgresql://host/db?x=1&a=b",
+                JdbcUrls.appendParameter("jdbc:postgresql://host/db?x=1", "a", "b"));
+    }
+
+    @Test
+    void withBatchRewriteAppendsWhenAbsent() {
+        assertEquals("jdbc:postgresql://host/db?reWriteBatchedInserts=true",
+                JdbcUrls.withBatchRewrite("jdbc:postgresql://host/db", "reWriteBatchedInserts"));
+        assertEquals("jdbc:mysql://host/db?useSSL=false&rewriteBatchedStatements=true",
+                JdbcUrls.withBatchRewrite("jdbc:mysql://host/db?useSSL=false", "rewriteBatchedStatements"));
+    }
+
+    @Test
+    void withBatchRewriteIsNoOpWhenPresentOrUnsupported() {
+        String already = "jdbc:postgresql://host/db?reWriteBatchedInserts=false";
+        // preserves the caller's explicit value rather than overriding it
+        assertEquals(already, JdbcUrls.withBatchRewrite(already, "reWriteBatchedInserts"));
+        // null/blank parameter name (database has no such parameter) leaves the URL untouched
+        assertEquals("jdbc:foo://host/db", JdbcUrls.withBatchRewrite("jdbc:foo://host/db", null));
+        assertEquals("jdbc:foo://host/db", JdbcUrls.withBatchRewrite("jdbc:foo://host/db", "  "));
+    }
+}


### PR DESCRIPTION
Closes the three #447 follow-up issues in a single change: **#466**, **#467**, **#468**.

## #466 — Intra-table parallelism (seek-based)
Partition a single large table's rows across workers via `TableConfiguration.partitions` on the parallel (`DataSource` + `threads`) path — for when one table dominates the fill and between-table parallelism can't help it.

- New `IndexedDataGenerator.seek(long)`, implemented by the positional generators (`CompositeKeyComponentGenerator`, `ChildKeyComponentGenerator`, `ChildCountGenerator`, `SequentialIntegerGenerator`, `GroupedPermutationGenerator`, `GroupedPrefixGenerator`, and TPC-C's `OrderLineDeliveryDateGenerator`).
- `TableFiller.rowRange(start, end)` + a three-way seek-to-partition-start: positional generators seek to the absolute index (**byte-identical** to a sequential fill); foreign-key random-replay columns reseed and advance into the parent key cycle (FK-valid); plain non-key random columns are reseeded per partition.
- **Reproducibility = per-configuration determinism (including partition count).** Keys and key-correlated columns are byte-for-byte identical to a sequential fill, so **foreign-key validity always holds**; only non-key random columns take different (but deterministic) values when the partition count changes. The default/sequential path is byte-for-byte unchanged and pays no per-cell cost.
- Unsupported edge (documented in javadoc + README): partitioning a *parent* whose primary key is a plain random generator referenced by a foreign key.

`L64X128MixRandom` is splittable but not jumpable, so O(1) absolute-index seeking of arbitrary random columns isn't possible — hence the seek-to-start design rather than per-cell indexing.

## #467 — Configurable commit strategy
`CommitStrategy` on `DatabaseConfiguration` — `connectionDefault()` (default, behavior unchanged), `perTable()`, `everyNBatches(n)`. The engine manages the transaction on the sequential path; the parallel path's existing per-table commit is unified through the same knob.

## #468 — Driver batch-rewrite
`DatabaseSupport.batchRewriteUrlParameter()` (PostgreSQL `reWriteBatchedInserts`, MySQL `rewriteBatchedStatements`; CockroachDB/Default `null`), a one-time WARN at fill time when the JDBC URL lacks it, and `io.bloviate.util.JdbcUrls.withBatchRewrite(...)` for callers who build their own URL/`DataSource`.

## Testing
- `IndexedGeneratorSeekTest` — proves `seek(k)` then `generate()` reproduces the sequential stream at index `k` for every positional generator (the core #466 invariant).
- `PostgresIntraTableFillTest` — fills a TPC-C schema with `stock`/`customer`/`order_line` each split into 4 partitions and asserts foreign-key validity, row counts, full TPC-C column fidelity, and reproducibility across two partitioned runs.
- `PostgresCommitStrategyTest` — `perTable()` and `everyNBatches(n)` on the sequential path.
- `JdbcUrlsTest`, `BatchRewriteParameterTest`, `CommitStrategyTest`.
- Existing `PostgresParallelFillTest` (parallel == sequential byte-for-byte) and seed/temporal reproducibility tests still pass — the default and proven parallel paths are unchanged.
- Benchmark: new `postgres/single` single-dominant-table scenario (`create_single.postgres.sql`) for measuring intra-table partitioning.

All 174 `bloviate-core` tests plus the `bloviate-junit` and `bloviate-testcontainers` suites pass (Postgres, MySQL, CockroachDB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)