### PR TITLE
docs: document parallel fill, intra-table partitioning, and commit strategy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,10 @@ right place.
 - [The big picture](#the-big-picture)
 - [1. Schema introspection — reading the database](#1-schema-introspection--reading-the-database)
 - [2. The dependency DAG — fill order via topological sort](#2-the-dependency-dag--fill-order-via-topological-sort)
+  - [Parallel fill — topological levels](#parallel-fill--topological-levels)
 - [3. Filling a table — generators, batching, and FK fidelity](#3-filling-a-table--generators-batching-and-fk-fidelity)
+  - [Commit strategy](#commit-strategy)
+  - [Intra-table partitioning — seeking to a row range](#intra-table-partitioning--seeking-to-a-row-range)
 - [4. Reproducibility — deterministic seeds from schema identity](#4-reproducibility--deterministic-seeds-from-schema-identity)
 - [5. Database support — the Strategy pattern](#5-database-support--the-strategy-pattern)
 - [6. Pluggable generators — Registry + ServiceLoader](#6-pluggable-generators--registry--serviceloader)
@@ -119,6 +122,40 @@ link so you can *see* your schema's dependency graph rendered in the browser —
 ordered cleanly, so they're detected and logged with a warning rather than silently producing broken
 data.
 
+### Parallel fill — topological levels
+
+The loop above is sequential and runs on a single `Connection` — the default, and the only option
+when you hand `DatabaseFiller` a `Connection`. Construct it from a pooled `DataSource` instead and
+call `threads(n)`, and the fill runs **in parallel**.
+
+The key insight: tables in the *same* topological "level" have no foreign key between them, so they
+can fill concurrently. [`DatabaseFiller.fillLevels`](bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java)
+groups the graph into levels with Kahn's algorithm — level 0 is every table that references nothing,
+level 1 the tables whose parents are all in level 0, and so on:
+
+```mermaid
+flowchart TD
+    subgraph L0["level 0 — fill concurrently"]
+        warehouse & item
+    end
+    subgraph L1["level 1 — fill concurrently"]
+        district & stock
+    end
+    subgraph L2["level 2"]
+        customer
+    end
+    L0 -->|barrier| L1
+    L1 -->|barrier| L2
+```
+
+Each table is filled by a worker that borrows its own `Connection` from the pool (JDBC connections
+are not thread-safe) inside its own transaction, and a **barrier** between levels guarantees a child
+table never starts before its parents are committed. The fill stays **fully reproducible**: a table's
+data depends only on its own per-column seeds and row order, never on which tables fill alongside it,
+so a parallel fill is byte-for-byte identical to a sequential one
+([§4](#4-reproducibility--deterministic-seeds-from-schema-identity)). The win is largest for wide
+schemas of independent tables and small for deep, narrow FK chains (little fans out within a level).
+
 ## 3. Filling a table — generators, batching, and FK fidelity
 
 [`TableFiller`](bloviate-core/src/main/java/io/bloviate/db/TableFiller.java) handles one table. For
@@ -149,6 +186,51 @@ flowchart TD
     G -->|yes| H[executeBatch]
     G -->|no| A
 ```
+
+The inner loop is the hot path (it runs `rowCount × columnCount` times), so `TableFiller` resolves
+every column's generator, seed, and FK reseed-threshold *once* into positional arrays indexed by
+column ordinal — the loop then does array reads instead of hashing the `Column` on every cell.
+
+### Commit strategy
+
+By default the engine leaves the connection's autocommit state untouched — an autocommit connection
+commits per `executeBatch()`. A [`CommitStrategy`](bloviate-core/src/main/java/io/bloviate/db/CommitStrategy.java)
+on `DatabaseConfiguration` lets you cut that overhead: `perTable()` disables autocommit and commits
+once when the table is filled, and `everyNBatches(n)` commits every *n* batches to bound the open
+transaction. When a strategy is set, `TableFiller` owns the transaction (autocommit off, commit at the
+configured cadence, rollback on error, prior autocommit restored afterward); the default
+`connectionDefault()` preserves the original behavior. The parallel path's per-table commit is the
+same mechanism — its workers run with an effective `perTable()` strategy.
+
+### Intra-table partitioning — seeking to a row range
+
+Parallel fill ([§2](#parallel-fill--topological-levels)) parallelizes *across* tables, which doesn't
+help when a single huge table dominates — it fills alone in its level. Set `partitions` on that
+table's `TableConfiguration` and, on the parallel path, `DatabaseFiller` splits its `[0, rowCount)`
+rows into that many contiguous ranges filled concurrently, one `Connection` per range.
+
+The challenge is reproducibility: a worker starting at absolute row *N* must produce the value the
+sequential fill produces at row *N*, without replaying rows `0..N`. Counter/cursor generators solve
+this with [`IndexedDataGenerator`](bloviate-core/src/main/java/io/bloviate/gen/IndexedDataGenerator.java),
+whose `seek(rowIndex)` positions the generator directly (the composite/sequence/permutation generators
+are closed-form O(1); the variable-cardinality child-key generator locates the owning parent via the
+`ChildCardinality` cumulative). `TableFiller` seeks each column at the partition's first row with a
+three-way policy:
+
+| Column kind | Seek behavior | Result vs. sequential |
+| --- | --- | --- |
+| Positional (`IndexedDataGenerator` — keys, sequences, permutations, prefixes) | `seek(start)` | **byte-identical** |
+| Foreign-key random-replay (`maxInvocation > 0`) | reseed, then advance `start % maxInvocation` draws into the parent cycle | **byte-identical** (FK-valid) |
+| Plain non-key random | reseed from a partition-derived seed | deterministic per partition count |
+
+Because every column that participates in a cross-row or cross-table contract (keys and foreign keys)
+stays byte-identical, **foreign-key validity always holds** and the fill is reproducible *for a given
+configuration, including the partition count*. Only plain non-key random columns — which carry no such
+contract — take different values when you change the partition count. The default (unpartitioned) path
+never seeks and is byte-for-byte unchanged, so there is no per-cell cost for the common case. One edge
+is unsupported: partitioning a *parent* whose primary key is a plain random generator referenced by a
+foreign key (partition the child instead, or use the positional key generators). A custom generator
+with internal positional state must implement `IndexedDataGenerator` to stay aligned under partitioning.
 
 ## 4. Reproducibility — deterministic seeds from schema identity
 
@@ -186,6 +268,13 @@ which uses the JDK general-purpose default algorithm **`L64X128MixRandom`** rath
 `java.util.Random` (a 48-bit LCG with a documented statistical defect and `synchronized` methods).
 The seeding architecture is unchanged — one isolated, deterministically-seeded generator per column —
 so output stays reproducible and order-independent; only the algorithm and statistical quality improve.
+
+Because a value depends only on its column's seed and row index — never on timing or which tables fill
+alongside it — reproducibility survives concurrency. A **parallel table fill**
+([§2](#parallel-fill--topological-levels)) is byte-for-byte identical to a sequential one. An
+**intra-table partitioned fill** ([§3](#intra-table-partitioning--seeking-to-a-row-range)) is
+reproducible for a given configuration *including the partition count*: keys and foreign keys are
+byte-identical regardless of partitioning, and only plain non-key random columns vary with it.
 
 ## 5. Database support — the Strategy pattern
 
@@ -350,7 +439,8 @@ pattern lives and what it's doing for us.
 | **Factory** (functional) | [`GeneratorFactory`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorFactory.java), [`ColumnGeneratorFactory`](bloviate-core/src/main/java/io/bloviate/db/ColumnGeneratorFactory.java) | Defers generator creation until the engine can supply a column-seeded `RandomGenerator`, preserving reproducibility |
 | **Registry** | [`GeneratorRegistry`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java) with documented precedence | Override generation by name/type without subclassing; rules resolved in a fixed, predictable order |
 | **Service Provider (SPI)** | [`GeneratorPlugin`](bloviate-core/src/main/java/io/bloviate/ext/GeneratorPlugin.java) via `ServiceLoader` | Third-party jars contribute generators by dropping a file on the classpath — zero engine coupling |
-| **Strategy / polymorphism** | The [`DataGenerator<T>`](bloviate-core/src/main/java/io/bloviate/gen/DataGenerator.java) hierarchy | One uniform interface (`generate` / bind / read-back) over ~50 type-specific implementations |
+| **Strategy / polymorphism** | The [`DataGenerator<T>`](bloviate-core/src/main/java/io/bloviate/gen/DataGenerator.java) hierarchy; [`CommitStrategy`](bloviate-core/src/main/java/io/bloviate/db/CommitStrategy.java) for transaction cadence | One uniform interface (`generate` / bind / read-back) over ~50 type-specific implementations; swappable commit behavior |
+| **Seekable cursor** | [`IndexedDataGenerator.seek(long)`](bloviate-core/src/main/java/io/bloviate/gen/IndexedDataGenerator.java) on the positional generators | Position a generator at an absolute row index without replaying — the basis for intra-table partitioning |
 | **Iterator** | JGraphT's `TopologicalOrderIterator` in [`DatabaseFiller`](bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java) | Fill order is expressed as a traversal, decoupled from graph construction |
 | **Adapter** | [`bloviate-junit`](bloviate-junit/) and [`bloviate-testcontainers`](bloviate-testcontainers/) | Wrap the same core engine behind framework-native front-ends (`@FillDatabase`, `BloviateContainers`) |
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -245,3 +245,36 @@ xychart-beta
 
 **Bottom line:** ~2× faster per-row generation with better statistical quality, no new dependency,
 and unchanged reproducibility.
+
+## Recorded results — issue #466 (intra-table partitioning)
+
+Measured for the [issue #466](https://github.com/timveil/bloviate/issues/466) intra-table
+partitioning follow-up: a **single dominant table** (`create_single.postgres.sql`,
+`PostgresFillBenchmark#singleTable`), which between-table parallelism cannot speed up because it sits
+alone in its topological level. The baseline is the sequential single-`Connection` fill (`partitions`
+ignored); "partitioned" splits the one table into eight contiguous row ranges filled concurrently.
+
+**Environment**
+
+- Machine / CPU: Apple M5 (Mac17,3), 10 cores
+- JDK: Temurin 25.0.3+9 LTS
+- Docker / DB image: OrbStack (Docker 29.4.0); `postgres:18-alpine`
+- Harness: `bench.rows=1000000`, `bench.warmup=1`, `bench.iterations=3`, `bench.batch=1000`. Reported figure is **best of 3**.
+
+### End-to-end (rows/sec, best of 3 — higher is better)
+
+| Scenario | Rows | Baseline (1 thread) | Partitioned (8 threads / 8 partitions) | Speedup |
+|----------|-----:|--------------------:|---------------------------------------:|--------:|
+| `postgres/single` | 1,000,000 | 154,211 | **489,870** | **3.18×** |
+
+```mermaid
+xychart-beta
+    title "postgres/single throughput — 1,000,000 rows (higher is better)"
+    x-axis ["baseline (1 thread)", "partitioned (8 threads)"]
+    y-axis "rows / sec" 0 --> 520000
+    bar [154211, 489870]
+```
+
+**Bottom line:** a single large table — which the v2.9.0 between-table parallel fill leaves at
+sequential speed — fills **~3.2× faster** at 8 partitions, with foreign-key validity preserved and
+the data reproducible for the chosen partition count. The default (unpartitioned) path is unchanged.

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Hands-free test data generator for JDBC databases — Bloviate auto-discovers yo
 - **Foreign Key Support**: Handles complex table dependencies using topological sorting
 - **Per-Column Control**: Override generation for individual columns with custom, reproducible generators
 - **Composite Keys & Referential Fidelity**: Generate collision-free composite keys and variable parent/child cardinalities that keep foreign keys consistent
+- **Parallel & Partitioned Fills**: Fill independent tables concurrently, and split a single dominant table's rows across workers — reproducibly, with foreign-key validity preserved
 - **Benchmark-Ready**: Built-in TPC-C dataset configuration, with reusable building blocks for other benchmark schemas
 - **Multiple Database Support**: PostgreSQL, MySQL, CockroachDB with extensible architecture
 - **Flat File Generation**: Export data to CSV, TSV, and pipe-delimited formats
-- **Configurable Output**: Control batch sizes, record counts, and custom data generation rules
+- **Configurable Output**: Control batch sizes, record counts, commit cadence, and custom data generation rules
 - **Graph Visualization**: Generate DOT notation graphs of table relationships
 
 ## 📋 Table of Contents
@@ -33,6 +34,8 @@ Hands-free test data generator for JDBC databases — Bloviate auto-discovers yo
   - [Variable Parent/Child Cardinality](#variable-parentchild-cardinality)
   - [TPC-C Benchmark Data](#tpc-c-benchmark-data)
   - [Reproducible Data with Seeds](#reproducible-data-with-seeds)
+  - [Parallel Table Fill](#parallel-table-fill)
+  - [Commit Strategy](#commit-strategy)
   - [Testing Framework Integration](#testing-framework-integration)
   - [Flat File Formats](#flat-file-formats)
   - [Data Generator Types](#data-generator-types)
@@ -693,10 +696,16 @@ intervals). See the `io.bloviate.gen` package for the full set.
 - **Batch Size**: Number of records inserted in each batch operation
 - **Record Count**: Default number of records to generate per table
 - **Database Support**: Database-specific implementation for optimal compatibility
-- **Table Configurations**: Override the row count for specific tables
+- **Table Configurations**: Override the row count for specific tables, and the intra-table
+  `partitions` count for splitting a large table across workers on the parallel path
 - **Column Configurations**: Override the generator for specific columns (case-insensitive, reproducible)
 - **Seed**: Base seed for reproducible generation; the same schema and seed always produce the
   same data (defaults to `0`)
+- **Commit Strategy**: How the engine commits — leave autocommit alone (default), commit once per
+  table, or commit every N batches (see [Commit Strategy](#commit-strategy))
+
+Parallelism (worker threads for concurrent table fill) is configured on the `DatabaseFiller.Builder`
+via `threads(n)` with the `DataSource` constructor — see [Parallel Table Fill](#parallel-table-fill).
 
 ### File Generation Options
 
@@ -736,10 +745,10 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 ## 📈 Roadmap
 
 - [ ] [Additional database support (Oracle, SQL Server)](https://github.com/timveil/bloviate/issues/445)
-- [ ] [Custom data generation plugins](https://github.com/timveil/bloviate/issues/446)
-- [ ] [Performance optimizations for large datasets](https://github.com/timveil/bloviate/issues/447) — _in progress: parallel table fill, per-table commit, and hot-loop dispatch landed ([benchmarks](BENCHMARKS.md))_
+- [x] [Custom data generation plugins](https://github.com/timveil/bloviate/issues/446)
+- [x] [Performance optimizations for large datasets](https://github.com/timveil/bloviate/issues/447) — _parallel table fill, intra-table partitioning, configurable commit strategy, batch-rewrite surfacing, and hot-loop dispatch ([benchmarks](BENCHMARKS.md))_
 - [ ] GUI for configuration management
-- [ ] [Integration with popular testing frameworks](https://github.com/timveil/bloviate/issues/448)
+- [x] [Integration with popular testing frameworks](https://github.com/timveil/bloviate/issues/448) — _JUnit 5 (`bloviate-junit`) and Testcontainers (`bloviate-testcontainers`)_
 
 ---
 


### PR DESCRIPTION
Follow-up to #475. The architecture/usage docs were behind the engine — `ARCHITECTURE.md` had no coverage of parallel table fill (shipped v2.9.0) or the #466/#467/#468 follow-ups merged in #475. This brings the docs current and records the intra-table benchmark.

## ARCHITECTURE.md
- **§2 → "Parallel fill — topological levels"**: how `fillLevels` (Kahn) groups tables into levels, fills independent tables concurrently one connection per worker, barriers between levels, and stays byte-for-byte reproducible. (This was missing even for the v2.9.0 work.)
- **§3 → "Commit strategy"** and **"Intra-table partitioning — seeking to a row range"**: the `CommitStrategy` knob; the seek-based partitioning model with `IndexedDataGenerator`, the three-way seek policy (positional → byte-identical / FK random-replay → byte-identical / non-key random → per-partition), per-config determinism, FK validity, and the unsupported edge.
- **§4**: a note that reproducibility survives concurrency (parallel = byte-identical; partitioned = reproducible per partition count).
- Design-patterns table gains `IndexedDataGenerator` (seekable cursor) and `CommitStrategy`; TOC updated.

## README.md
- Features and Configuration options updated (`commitStrategy`, per-table `partitions`); TOC entries for Parallel Table Fill and Commit Strategy; Roadmap corrected (#446/#447/#448 now done).

## BENCHMARKS.md
- New **"Recorded results — issue #466"** section with the `postgres/single` measurement: a single 1M-row table fills **154,211 → 489,870 rows/s (best of 3, ~3.18×)** at 8 partitions — the case between-table parallelism leaves at sequential speed. Apple M5 / JDK 25 / postgres:18-alpine.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)