### PR TITLE
docs: positioning + competitive landscape (#469, #470)

### DIFF
--- a/POSITIONING.md
+++ b/POSITIONING.md
@@ -1,0 +1,116 @@
+# Bloviate — Positioning & Competitive Landscape
+
+Where Bloviate sits in the test-data-generation landscape, who its real rivals are, and the lane it
+defensibly owns. If you just want to *use* it, start with the [README](README.md); this document is
+for evaluators deciding **whether Bloviate fits their problem**.
+
+> **A note on freshness.** The competitive facts below (licenses, maintenance status, ownership) were
+> verified mid-2026 and are cited. This space moves fast — treat the citations as the source of truth
+> and tell us if something has drifted.
+
+## The one axis that matters
+
+Test-data tools split on a single question: **do you generate from scratch, or derive from
+production?**
+
+- **Generate-from-scratch** — manufacture data from a schema/spec; production data is never touched.
+- **Derive-from-production** — copy real data, then mask, subset, or learn-and-resynthesize it.
+
+**Bloviate is firmly generate-from-scratch.** It reads your *schema* (not your data) and fills it.
+That single choice is why the privacy story is simple and why it shares almost nothing with the
+ML/masking platforms it's sometimes lumped in with.
+
+## The market map
+
+| Category | What it does | Representative tools | Same problem as Bloviate? |
+|---|---|---|---|
+| Value libraries | Emit realistic *values*; you wire up schema, DB, and FKs yourself | Datafaker, faker.js, Faker (Py) | Partial — a building block, not a filler |
+| Declarative / recipe | Describe rows in YAML/JSON/GUI; it manufactures them | Snowfakery, Mockaroo, Benerator | **Yes** |
+| **DB-native fillers** | Read a live schema and `INSERT` generated rows directly | **Bloviate**, DBeaver Mock Data, Redgate, dbForge | **Yes — home category** |
+| ML / AI synthetic | Learn real distributions and emit faithful copies | SDV, Gretel, MOSTLY AI, YData | No — needs real data, non-deterministic |
+| Subsetting / masking | Mask + subset *existing* production data | Tonic, Delphix, Neosync, Jailer | No — operates on production data |
+| Benchmark generators | Fixed-schema data for TPC-style load tests | pgbench, HammerDB, BenchBase | No — fixed schemas only |
+
+Bloviate's home category — **open-source, DB-native fillers that generate from the schema alone** — is
+unusually thin. The strong commercial entries are GUI/Windows/SQL-Server-leaning and proprietary, and
+the open-source schema-aware tools mostly *subset or mask existing data* rather than generate from
+types.
+
+## Closest functional rivals
+
+These are the tools that actually overlap Bloviate's job — generate relational test data from a
+schema — and how each differs (verified mid-2026):
+
+| Tool | Stack & license | Overlap | Where it diverges from Bloviate |
+|---|---|---|---|
+| **Benerator CE** | Java/JDBC, dual GPL-2.0-with-exceptions / commercial | Model-driven relational test-data generation on the JVM | Relationships are **declared in the descriptor** (e.g. `<reference>` selectors) — no automatic FK-graph + topological fill order. **CE is no longer actively maintained** — kept "for legacy usage" only; the vendor steers new work to the separate DATAMIMIC product. |
+| **Snowfakery** | Python, BSD-3-Clause | Generates related rows, deterministic-ish | Relations are **authored as YAML recipes** — it does **not** introspect a database schema; Salesforce-origin. Actively maintained (v4.2.1, Jan 2026). |
+| **synth** | Rust CLI, Apache-2.0 | *Can* introspect a DB and generate to Postgres/MySQL/Mongo with `--seed` | **Effectively dormant** — last release v0.6.9, **Nov 2022**; no CockroachDB. |
+| **DBeaver Mock Data** | Java/JDBC (GUI) | Schema-aware insert with an FK-aware generator and a seed | **Enterprise/Ultimate edition only** (not Community) and **GUI-bound**; oriented to filling tables whose parents already exist rather than ordering a whole schema from scratch. |
+
+The ML/privacy platforms (SDV, Gretel, MOSTLY AI, Tonic) solve a *different* problem: they need real
+seed data and are non-deterministic. They are not direct competitors — and several have notable
+license/ownership constraints (SDV is **BSL/BUSL-1.1**, source-available rather than OSI open-source;
+Gretel was **acquired by NVIDIA in March 2025**; MOSTLY AI now operates as "MOSTLY AI powered by
+Syntho").
+
+## Where Bloviate wins
+
+1. **An intersection few tools occupy.** Open-source **and** JVM/JDBC-native **and** automatic schema
+   introspection **and** automatic FK **topological** fill ordering **and** RNG-deterministic **and**
+   JUnit/Testcontainers-native **and** needs no production data. Each rival above is missing at least
+   one of these.
+2. **Zero-config foreign-key correctness.** Point it at a schema and it derives the fill order from
+   `DatabaseMetaData` (see [ARCHITECTURE.md §2](ARCHITECTURE.md#2-the-dependency-dag--fill-order-via-topological-sort)).
+   Benerator and Snowfakery make you hand-author relationships; DBeaver expects parents to pre-exist.
+3. **In-process, dependency-free, CI-native.** No cloud account, no Python/GPU runtime, no
+   per-row/per-GB pricing — just a library on your classpath, with first-class
+   [`@FillDatabase`/`@FillSource`](README.md#junit-5-bloviate-junit) and Testcontainers support.
+4. **Privacy-safe by construction.** Generates from schema/type and never reads production, so the
+   GDPR/CCPA exposure surface is structurally minimal — no masking or differential-privacy machinery
+   to configure or trust.
+5. **Determinism as a first-class contract.** Same seed + same schema ⇒ byte-identical data, even
+   under parallel and partitioned fills (see [ARCHITECTURE.md §4](ARCHITECTURE.md#4-reproducibility--deterministic-seeds-from-schema-identity)).
+   Most ML synthesizers cannot offer byte-identical reruns.
+6. **Maintained and multi-DB** — PostgreSQL, MySQL, and CockroachDB, actively released — while synth
+   is dormant and Benerator CE is frozen.
+
+## Where Bloviate loses
+
+Stated plainly, so the boundary is clear:
+
+1. **No statistical fidelity.** It does not learn real distributions or cross-column correlations —
+   SDV / Gretel / MOSTLY AI are the right tools for ML-training or analytics realism.
+2. **No PII masking / de-identification** of existing data — that's Tonic / Delphix / Neosync / Jailer.
+3. **Type-driven, not yet semantically aware.** An `email VARCHAR` gets random text, not a plausible
+   email. Tracked in [#472](https://github.com/timveil/bloviate/issues/472) (semantic/column-name
+   inference) and [#473](https://github.com/timveil/bloviate/issues/473) (correlated columns).
+4. **JVM-only reach** — invisible to the Python-centric data-science world.
+5. **No GUI / low-code surface** — it's a library and a CI dependency.
+
+## Recommended positioning
+
+Don't chase the ML/privacy platforms — different problem, different buyer. Bloviate's defensible lane:
+
+> **The maintained, open-source, JDBC-native, FK-aware, deterministic test-data filler for JVM
+> developers' CI pipelines.**
+
+Its true rivals each lose to it on at least one decisive axis today: Benerator (frozen, manual FK),
+synth (dormant), Snowfakery (Python, recipe-authored, no schema introspection), DBeaver Mock Data
+(paid, GUI-bound). That intersection — not statistical realism or data masking — is where Bloviate
+should compete and win.
+
+## Sources
+
+Verified 2026-06 via web survey + codebase analysis.
+
+- Benerator CE — <https://github.com/rapiddweller/rapiddweller-benerator-ce> · <https://benerator.de/faq/>
+- Snowfakery — <https://github.com/SFDO-Tooling/Snowfakery>
+- synth (releases) — <https://github.com/shuttle-hq/synth/releases>
+- DBeaver Mock Data — <https://dbeaver.com/docs/dbeaver/Mock-Data-Generation/>
+- SDV license (BSL) — <https://datacebo.com/blog/sdv-bsl-license/> · <https://github.com/sdv-dev/SDV/blob/main/LICENSE>
+- Gretel → NVIDIA — <https://techcrunch.com/2025/03/19/nvidia-reportedly-acquires-synthetic-data-startup-gretel/>
+- MOSTLY AI (powered by Syntho) — <https://mostly.ai/>
+- Datafaker — <https://github.com/datafaker-net/datafaker>
+- Jailer — <https://github.com/Wisser/Jailer>
+- pgbench — <https://www.postgresql.org/docs/current/pgbench.html>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,45 @@
 
 Hands-free test data generator for JDBC databases — Bloviate auto-discovers your schema, respects foreign keys, and fills tables (or CSV/TSV files) with realistic, reproducible data.
 
+## 🎯 Why Bloviate?
+
+> **Bloviate never touches production data, is deterministic by seed, and runs inside your JUnit/Testcontainers pipeline.**
+
+It generates *from your schema*, not from a copy of production — so the privacy story is simple and
+the data is reproducible by construction. Five structural strengths:
+
+1. **Zero-config foreign-key correctness.** It auto-introspects `DatabaseMetaData`, builds the FK
+   dependency graph, and topologically orders the fill — parents before children, no configuration.
+   Rivals make you hand-author relationships (Benerator `<reference>` selectors, Snowfakery YAML
+   recipes) or require parent rows to already exist (DBeaver).
+2. **Privacy-safe by construction.** Generated purely from schema and type — production data is never
+   read — so the GDPR/CCPA exposure surface is structurally minimal. No masking or
+   differential-privacy machinery to configure or trust.
+3. **Deterministic reproducibility as a contract.** The same seed and schema produce byte-identical
+   data on every run, including under parallel and partitioned fills. Most ML synthesizers can't offer
+   that.
+4. **CI-native, dependency-free core.** No cloud account, no Python/GPU runtime, no per-row/per-GB
+   pricing — just a library on your classpath, with first-class JUnit 5
+   (`@FillDatabase`/`@FillSource`) and Testcontainers integrations.
+5. **Maintained and multi-DB.** PostgreSQL, MySQL, and CockroachDB, actively released — while several
+   peers are dormant (synth) or feature-frozen (Benerator CE).
+
+**Where it fits.** Bloviate is an open-source, JDBC-native *filler* — it manufactures relational data
+from a schema. That's a different job from the **ML/privacy synthesizers** (SDV, Gretel, MOSTLY AI),
+which learn from real data and are non-deterministic, and from the **masking/subsetting** tools
+(Tonic, Delphix, Jailer), which operate on existing production data. Among its actual peers — Benerator
+(JVM, but FK is manually declared and the community edition is frozen), Snowfakery (Python,
+recipe-authored, no schema introspection), synth (dormant since 2022), and DBeaver Mock Data (paid,
+GUI-bound) — Bloviate is the maintained, deterministic, auto-FK option.
+
+**Honest limitations.** Bloviate is *not* a statistical/ML synthesizer (no learned distributions or
+correlations), *not* a masking/subsetting tool for existing data, JVM-only, and has no GUI. It is also
+type-driven rather than semantically aware today — an `email VARCHAR` gets random text, not a plausible
+email (tracked in [#472](https://github.com/timveil/bloviate/issues/472) and
+[#473](https://github.com/timveil/bloviate/issues/473)).
+
+See **[POSITIONING.md](POSITIONING.md)** for the full competitive landscape, with sources.
+
 ## 🚀 Features
 
 - **Automatic Schema Discovery**: Connects to existing databases and analyzes table structure, relationships, and constraints
@@ -23,6 +62,7 @@ Hands-free test data generator for JDBC databases — Bloviate auto-discovers yo
 
 ## 📋 Table of Contents
 
+- [Why Bloviate?](#-why-bloviate)
 - [Installation](#-installation)
 - [Quick Start](#-quick-start)
 - [Database Support](#-database-support)


### PR DESCRIPTION
Builds the "where Bloviate fits and where it wins" story. Closes #470, lands the docs deliverable for the #469 research.

## README — "Why Bloviate?" (#470)
A section right under the tagline:
- Lead one-liner: *never touches production data, deterministic by seed, runs inside your JUnit/Testcontainers pipeline.*
- Five structural pillars: zero-config FK correctness, privacy-by-construction, deterministic reproducibility, CI-native/dependency-free, maintained/multi-DB.
- **Where it fits** — framed against ML/privacy synthesizers (SDV, Gretel, MOSTLY AI) and masking/subsetting tools (Tonic, Delphix, Jailer), then its actual peers.
- **Honest limitations** stated plainly, with pointers to #472/#473.
- Links to the new POSITIONING.md. Added to the TOC.

## POSITIONING.md (#469)
The full landscape: the generate-from-scratch vs derive-from-production axis, a six-category market map, the closest functional rivals, where Bloviate wins/loses, the recommended lane, and cited sources.

## Claims were verified, not copied
The #469 issue flagged that this data is error-prone (it even corrected a false "Mostly.ai→Qlik" rumor). Every volatile claim was web-checked mid-2026 and cited:

| Claim | Verdict |
|---|---|
| Benerator CE no longer actively maintained; vendor steers to DATAMIMIC | ✅ |
| synth dormant — last release v0.6.9, Nov 2022 | ✅ |
| Snowfakery recipe-authored, no schema introspection (BSD-3, v4.2.1 Jan 2026) | ✅ |
| DBeaver Mock Data is Enterprise/Ultimate-only, GUI-bound | ✅ |
| SDV is BSL/BUSL-1.1 (source-available, not OSI) | ✅ |
| Gretel acquired by NVIDIA, Mar 2025 | ✅ |
| MOSTLY AI → Qlik | ❌ false — now "MOSTLY AI powered by Syntho"; kept minimal |

Volatile facts are dated ("verified mid-2026") and attributed, with a freshness caveat at the top of POSITIONING.md.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)