### PR TITLE
chore: remove personal email from docs and pom

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,4 +138,3 @@ git commit -m "docs: update installation instructions"
 
 - **Issues**: [GitHub Issues](https://github.com/timveil/bloviate/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/timveil/bloviate/discussions)
-- **Email**: tjveil@gmail.com

--- a/README.md
+++ b/README.md
@@ -780,7 +780,6 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 - **Issues**: [GitHub Issues](https://github.com/timveil/bloviate/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/timveil/bloviate/discussions)
-- **Email**: tjveil@gmail.com
 
 ## 📈 Roadmap
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <developer>
             <id>timveil</id>
             <name>Tim Veil</name>
-            <email>tjveil@gmail.com</email>
             <url>https://github.com/timveil</url>
         </developer>
     </developers>


### PR DESCRIPTION
Removes the maintainer's personal email address from public-facing locations:

- README "Support" section
- CONTRIBUTING "Getting Help" section
- `pom.xml` `<developer>` metadata (this one is published to **Maven Central**, so it was the more exposed of the three)

GitHub Issues, Discussions, and the developer GitHub URL remain as contact points. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)