### PR TITLE
feat(gen): non-uniform value distributions (#479 Part A)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -378,6 +378,12 @@ intervals, arrays, and XML. A few are worth calling out:
   permutation in O(1) memory without materializing or shuffling an array.
 - **TPC-C generators** — [`io.bloviate.gen.tpcc`](bloviate-core/src/main/java/io/bloviate/gen/tpcc/)
   provides benchmark-faithful fields (customer last names, zip codes, credit, delivery dates).
+- **Distribution generators** — `WeightedCategoricalGenerator`, `NormalDoubleGenerator`/`NormalIntegerGenerator`,
+  `ZipfianIntegerGenerator`, and `SkewedTimestampGenerator` emit non-uniform values (categorical,
+  bounded-Gaussian, power-law, recency-skewed). A column opts in through the
+  [`Distributions`](bloviate-core/src/main/java/io/bloviate/db/Distributions.java) convenience without
+  writing a factory. These are *specified* distributions, not learned from data — so they stay
+  deterministic by seed and compose with FK reseeding and parallel fills like any other generator.
 
 ## 8. Flat-file generation
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See **[POSITIONING.md](POSITIONING.md)** for the full competitive landscape, wit
 - [Usage Examples](#-usage-examples)
   - [Per-Table Row Counts](#per-table-row-counts)
   - [Per-Column Generation Overrides](#per-column-generation-overrides)
+  - [Value Distributions](#value-distributions)
   - [Custom Generator Registry](#custom-generator-registry)
   - [Composite Keys & Foreign Key Fidelity](#composite-keys--foreign-key-fidelity)
   - [Variable Parent/Child Cardinality](#variable-parentchild-cardinality)
@@ -306,6 +307,41 @@ new DatabaseFiller.Builder(connection, config)
 
 Column names are matched **case-insensitively**. Any column without an override keeps
 its default, type-based generator.
+
+### Value Distributions
+
+Real columns are rarely uniform — a `status` is mostly `ACTIVE`, a `rating` clusters around its
+mean, a referenced `product_id` follows a popularity curve, and a `created_at` bunches toward the
+present. The `Distributions` helper returns ready-made `ColumnGeneratorFactory` values so a column can
+opt into a **non-uniform distribution** without writing a factory:
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.ext.PostgresSupport;
+import java.util.Map;
+import java.util.Set;
+
+Set<ColumnConfiguration> columnConfigs = Set.of(
+    // 70% NEW, 25% SHIPPED, 5% CANCELLED (weights need not sum to 1)
+    new ColumnConfiguration("status",     Distributions.weighted(Map.of("NEW", 0.7, "SHIPPED", 0.25, "CANCELLED", 0.05))),
+    // normal(mean=4, sd=1) rounded and clamped to [1, 5]
+    new ColumnConfiguration("rating",     Distributions.normalInt(4, 1, 1, 5)),
+    // Zipfian (power-law) over [1, 10000] — a few hot ids, a long thin tail
+    new ColumnConfiguration("product_id", Distributions.zipfian(10_000)),
+    // timestamps skewed toward the recent end of the window
+    new ColumnConfiguration("created_at", Distributions.recentTimestamps())
+);
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    128, 100, new PostgresSupport(),
+    Set.of(new TableConfiguration("orders", 100_000, columnConfigs)));
+```
+
+Available shapes: `weighted(...)` (categorical), `normal(...)` / `normalInt(...)` (bounded Gaussian),
+`zipfian(...)` (power-law), and `recentTimestamps(...)` (recency-skewed). Each is built from the
+engine's column seed, so output stays **reproducible** and composes with foreign-key reseeding and
+parallel fills like any other generator. These are *specified* distributions, not distributions
+learned from real data.
 
 ### Custom Generator Registry
 

--- a/bloviate-core/src/main/java/io/bloviate/db/Distributions.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/Distributions.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.gen.NormalDoubleGenerator;
+import io.bloviate.gen.NormalIntegerGenerator;
+import io.bloviate.gen.SkewedTimestampGenerator;
+import io.bloviate.gen.WeightedCategoricalGenerator;
+import io.bloviate.gen.ZipfianIntegerGenerator;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Ready-made {@link ColumnGeneratorFactory ColumnGeneratorFactories} for non-uniform value
+ * distributions, so a column can opt into a distribution without writing a generator factory:
+ *
+ * <pre>{@code
+ * new TableConfiguration("orders", 100_000, Set.of(
+ *     new ColumnConfiguration("status",     Distributions.weighted(Map.of("NEW", 0.7, "SHIPPED", 0.25, "CANCELLED", 0.05))),
+ *     new ColumnConfiguration("rating",     Distributions.normalInt(4, 1, 1, 5)),
+ *     new ColumnConfiguration("product_id", Distributions.zipfian(10_000)),
+ *     new ColumnConfiguration("created_at", Distributions.recentTimestamps())));
+ * }</pre>
+ *
+ * <p>Each factory builds its generator from the engine-supplied, column-seeded {@code random}, so the
+ * output is reproducible (same seed ⇒ same data) and composes with foreign-key reseeding and parallel
+ * fills exactly like any other generator. These are <em>specified</em> distributions, not distributions
+ * learned from real data.
+ *
+ * @see io.bloviate.gen.WeightedCategoricalGenerator
+ * @see io.bloviate.gen.NormalDoubleGenerator
+ * @see io.bloviate.gen.NormalIntegerGenerator
+ * @see io.bloviate.gen.ZipfianIntegerGenerator
+ * @see io.bloviate.gen.SkewedTimestampGenerator
+ * @since 2.11.0
+ */
+public final class Distributions {
+
+    private Distributions() {
+    }
+
+    /**
+     * A categorical distribution over the given values, each weighted by its (relative) probability.
+     *
+     * @param weights value → weight; weights need not sum to 1
+     * @param <T> the value type (matched to the column, e.g. String or Integer)
+     * @return a factory for a {@link WeightedCategoricalGenerator}
+     */
+    public static <T> ColumnGeneratorFactory weighted(Map<? extends T, ? extends Number> weights) {
+        return random -> new WeightedCategoricalGenerator.Builder<T>(random).weights(weights).build();
+    }
+
+    /**
+     * A normal (Gaussian) {@code double} distribution clamped to {@code [min, max]}.
+     *
+     * @return a factory for a {@link NormalDoubleGenerator}
+     */
+    public static ColumnGeneratorFactory normal(double mean, double standardDeviation, double min, double max) {
+        return random -> new NormalDoubleGenerator.Builder(random)
+                .mean(mean).standardDeviation(standardDeviation).min(min).max(max).build();
+    }
+
+    /**
+     * A normal (Gaussian) {@code int} distribution, rounded and clamped to {@code [min, max]}.
+     *
+     * @return a factory for a {@link NormalIntegerGenerator}
+     */
+    public static ColumnGeneratorFactory normalInt(double mean, double standardDeviation, int min, int max) {
+        return random -> new NormalIntegerGenerator.Builder(random)
+                .mean(mean).standardDeviation(standardDeviation).min(min).max(max).build();
+    }
+
+    /**
+     * A Zipfian (power-law) distribution over {@code [1, size]} with the classic exponent {@code 1.0}.
+     *
+     * @return a factory for a {@link ZipfianIntegerGenerator}
+     */
+    public static ColumnGeneratorFactory zipfian(int size) {
+        return zipfian(1, size, 1.0);
+    }
+
+    /**
+     * A Zipfian (power-law) distribution over {@code [start, start + size)} with the given exponent.
+     *
+     * @return a factory for a {@link ZipfianIntegerGenerator}
+     */
+    public static ColumnGeneratorFactory zipfian(int start, int size, double exponent) {
+        return random -> new ZipfianIntegerGenerator.Builder(random)
+                .start(start).size(size).exponent(exponent).build();
+    }
+
+    /**
+     * Recency-skewed timestamps over the generator's default five-year window.
+     *
+     * @return a factory for a {@link SkewedTimestampGenerator}
+     */
+    public static ColumnGeneratorFactory recentTimestamps() {
+        return random -> new SkewedTimestampGenerator.Builder(random).build();
+    }
+
+    /**
+     * Recency-skewed timestamps over {@code [start, end]} with the given skew ({@code 1.0} = uniform).
+     *
+     * @return a factory for a {@link SkewedTimestampGenerator}
+     */
+    public static ColumnGeneratorFactory recentTimestamps(Instant start, Instant end, double skew) {
+        return random -> new SkewedTimestampGenerator.Builder(random)
+                .start(start).end(end).skew(skew).build();
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/NormalDoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/NormalDoubleGenerator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.random.RandomGenerator;
+
+/**
+ * Generates {@code double} values from a <em>normal (Gaussian)</em> distribution with the configured
+ * mean and standard deviation, clamped to the inclusive range {@code [min, max]}. Useful when a
+ * numeric column should cluster around a central value rather than spread uniformly (prices, scores,
+ * measurements).
+ *
+ * <p>Clamping (rather than re-drawing) keeps generation O(1) and reproducible; values beyond the
+ * bounds pile up slightly at {@code min}/{@code max}, so choose a range a few standard deviations wide
+ * to keep that mass negligible.
+ *
+ * @since 2.11.0
+ */
+public class NormalDoubleGenerator extends AbstractDataGenerator<Double> {
+
+    private final double mean;
+    private final double standardDeviation;
+    private final double min;
+    private final double max;
+
+    @Override
+    public Double generate() {
+        double value = random.nextGaussian(mean, standardDeviation);
+        return Math.min(max, Math.max(min, value));
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Double value) throws SQLException {
+        statement.setDouble(parameterIndex, value);
+    }
+
+    @Override
+    public Double get(ResultSet resultSet, int columnIndex) throws SQLException {
+        double value = resultSet.getDouble(columnIndex);
+        return resultSet.wasNull() ? null : value;
+    }
+
+    public static class Builder extends AbstractBuilder<Double> {
+
+        private double mean = 0.0;
+        private double standardDeviation = 1.0;
+        private double min = -Double.MAX_VALUE;
+        private double max = Double.MAX_VALUE;
+
+        public Builder(RandomGenerator random) {
+            super(random);
+        }
+
+        public Builder mean(double mean) {
+            this.mean = mean;
+            return this;
+        }
+
+        public Builder standardDeviation(double standardDeviation) {
+            this.standardDeviation = standardDeviation;
+            return this;
+        }
+
+        public Builder min(double min) {
+            this.min = min;
+            return this;
+        }
+
+        public Builder max(double max) {
+            this.max = max;
+            return this;
+        }
+
+        @Override
+        public NormalDoubleGenerator build() {
+            if (standardDeviation < 0) {
+                throw new IllegalArgumentException("standardDeviation must be non-negative: " + standardDeviation);
+            }
+            if (max < min) {
+                throw new IllegalArgumentException("max (" + max + ") must be >= min (" + min + ")");
+            }
+            return new NormalDoubleGenerator(this);
+        }
+    }
+
+    private NormalDoubleGenerator(Builder builder) {
+        super(builder.random);
+        this.mean = builder.mean;
+        this.standardDeviation = builder.standardDeviation;
+        this.min = builder.min;
+        this.max = builder.max;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/NormalIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/NormalIntegerGenerator.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.random.RandomGenerator;
+
+/**
+ * Generates {@code int} values from a <em>normal (Gaussian)</em> distribution with the configured
+ * mean and standard deviation, rounded to the nearest integer and clamped to the inclusive range
+ * {@code [min, max]}. The integer analogue of {@link NormalDoubleGenerator} — for counts, ages,
+ * ratings, and other whole-number columns that should cluster around a center.
+ *
+ * @since 2.11.0
+ */
+public class NormalIntegerGenerator extends AbstractDataGenerator<Integer> {
+
+    private final double mean;
+    private final double standardDeviation;
+    private final int min;
+    private final int max;
+
+    @Override
+    public Integer generate() {
+        long rounded = Math.round(random.nextGaussian(mean, standardDeviation));
+        return (int) Math.min(max, Math.max(min, rounded));
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private double mean = 0.0;
+        private double standardDeviation = 1.0;
+        private int min = Integer.MIN_VALUE;
+        private int max = Integer.MAX_VALUE;
+
+        public Builder(RandomGenerator random) {
+            super(random);
+        }
+
+        public Builder mean(double mean) {
+            this.mean = mean;
+            return this;
+        }
+
+        public Builder standardDeviation(double standardDeviation) {
+            this.standardDeviation = standardDeviation;
+            return this;
+        }
+
+        public Builder min(int min) {
+            this.min = min;
+            return this;
+        }
+
+        public Builder max(int max) {
+            this.max = max;
+            return this;
+        }
+
+        @Override
+        public NormalIntegerGenerator build() {
+            if (standardDeviation < 0) {
+                throw new IllegalArgumentException("standardDeviation must be non-negative: " + standardDeviation);
+            }
+            if (max < min) {
+                throw new IllegalArgumentException("max (" + max + ") must be >= min (" + min + ")");
+            }
+            return new NormalIntegerGenerator(this);
+        }
+    }
+
+    private NormalIntegerGenerator(Builder builder) {
+        super(builder.random);
+        this.mean = builder.mean;
+        this.standardDeviation = builder.standardDeviation;
+        this.min = builder.min;
+        this.max = builder.max;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/SkewedTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SkewedTimestampGenerator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.random.RandomGenerator;
+
+/**
+ * Generates {@link Timestamp} values in the window {@code [start, end]} skewed toward {@code end} —
+ * i.e. <em>recent</em> timestamps are more likely than old ones. Real event/audit columns
+ * (created_at, last_login, order_date) are rarely uniform across history; they bunch toward the
+ * present.
+ *
+ * <p>A uniform draw {@code u} is reshaped to {@code u^(1/skew)}: {@code skew == 1} is uniform, and
+ * larger {@code skew} pulls more mass toward {@code end}. Bounds default to a deterministic five-year
+ * window anchored at {@link AbstractBuilder#DEFAULT_REFERENCE}, so output stays reproducible (it is
+ * never anchored to wall-clock {@code now()}); set explicit bounds for a different window.
+ *
+ * @since 2.11.0
+ */
+public class SkewedTimestampGenerator extends AbstractDataGenerator<Timestamp> {
+
+    private final long startMillis;
+    private final long rangeMillis;
+    private final double skew;
+
+    @Override
+    public Timestamp generate() {
+        double u = randomUtils.nextDouble(0.0, 1.0);
+        double fraction = Math.pow(u, 1.0 / skew);
+        return new Timestamp(startMillis + (long) (fraction * rangeMillis));
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Timestamp value) throws SQLException {
+        statement.setTimestamp(parameterIndex, value);
+    }
+
+    @Override
+    public Timestamp get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getTimestamp(columnIndex);
+    }
+
+    public static class Builder extends AbstractBuilder<Timestamp> {
+
+        private Instant start = DEFAULT_REFERENCE;
+        private Instant end = DEFAULT_REFERENCE.plus(Duration.ofDays(5 * 365));
+        private double skew = 3.0;
+
+        public Builder(RandomGenerator random) {
+            super(random);
+        }
+
+        public Builder start(Instant start) {
+            this.start = start;
+            return this;
+        }
+
+        public Builder end(Instant end) {
+            this.end = end;
+            return this;
+        }
+
+        /** Recency skew; {@code 1.0} is uniform, larger pulls mass toward {@code end}. Must be {@code > 0}. */
+        public Builder skew(double skew) {
+            this.skew = skew;
+            return this;
+        }
+
+        @Override
+        public SkewedTimestampGenerator build() {
+            if (skew <= 0) {
+                throw new IllegalArgumentException("skew must be positive: " + skew);
+            }
+            if (end.isBefore(start)) {
+                throw new IllegalArgumentException("end must be >= start");
+            }
+            return new SkewedTimestampGenerator(this);
+        }
+    }
+
+    private SkewedTimestampGenerator(Builder builder) {
+        super(builder.random);
+        this.startMillis = builder.start.toEpochMilli();
+        this.rangeMillis = builder.end.toEpochMilli() - builder.start.toEpochMilli();
+        this.skew = builder.skew;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/WeightedCategoricalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/WeightedCategoricalGenerator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.random.RandomGenerator;
+
+/**
+ * Draws from a fixed set of values according to per-value <em>weights</em> — a categorical
+ * distribution. For example a {@code status} column that should be 80% {@code ACTIVE}, 15%
+ * {@code CHURNED}, 5% {@code BANNED} instead of three equally-likely codes.
+ *
+ * <p>Weights need not sum to 1; each value's probability is its weight divided by the total. The
+ * value is bound with {@code setObject}, so this works for any column type whose values you supply
+ * as the matching Java type (strings, integers, etc.).
+ *
+ * <p><strong>Reproducibility.</strong> The candidate values are arranged in a stable canonical order
+ * (by {@code String.valueOf(value)}) before the cumulative weights are built, so the value returned
+ * for a given draw is independent of how the weight map was constructed (e.g. an unordered
+ * {@link Map#of()} ). Same seed ⇒ same sequence.
+ *
+ * @param <T> the value type
+ * @since 2.11.0
+ */
+public class WeightedCategoricalGenerator<T> extends AbstractDataGenerator<T> {
+
+    private final Object[] values;
+    private final double[] cumulativeWeights;
+    private final double totalWeight;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T generate() {
+        double draw = randomUtils.nextDouble(0.0, totalWeight);
+        int index = indexFor(draw);
+        return (T) values[index];
+    }
+
+    /** Binary search for the first cumulative-weight bucket strictly greater than {@code draw}. */
+    private int indexFor(double draw) {
+        int low = 0;
+        int high = cumulativeWeights.length - 1;
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (draw < cumulativeWeights[mid]) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+        return low;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return (T) resultSet.getObject(columnIndex);
+    }
+
+    public static class Builder<T> extends AbstractBuilder<T> {
+
+        private record Entry<T>(T value, double weight) {
+        }
+
+        private final List<Entry<T>> entries = new ArrayList<>();
+
+        public Builder(RandomGenerator random) {
+            super(random);
+        }
+
+        /**
+         * Adds one value with its (positive) weight. Calls accumulate, so this can be chained.
+         */
+        public Builder<T> add(T value, double weight) {
+            if (weight <= 0) {
+                throw new IllegalArgumentException("weight must be positive: " + weight);
+            }
+            entries.add(new Entry<>(value, weight));
+            return this;
+        }
+
+        /**
+         * Adds every value/weight pair from the map. Order is irrelevant — the generator imposes a
+         * stable canonical order so output is reproducible regardless of the map's iteration order.
+         */
+        public Builder<T> weights(Map<? extends T, ? extends Number> weights) {
+            for (Map.Entry<? extends T, ? extends Number> entry : weights.entrySet()) {
+                add(entry.getKey(), entry.getValue().doubleValue());
+            }
+            return this;
+        }
+
+        @Override
+        public WeightedCategoricalGenerator<T> build() {
+            if (entries.isEmpty()) {
+                throw new IllegalStateException("at least one weighted value is required");
+            }
+            return new WeightedCategoricalGenerator<>(this);
+        }
+    }
+
+    private WeightedCategoricalGenerator(Builder<T> builder) {
+        super(builder.random);
+
+        // stable canonical order (by string form) so the value for a given draw never depends on the
+        // iteration order of the source map — the key to reproducibility across JVMs
+        List<Builder.Entry<T>> sorted = new ArrayList<>(builder.entries);
+        sorted.sort((a, b) -> String.valueOf(a.value()).compareTo(String.valueOf(b.value())));
+
+        this.values = new Object[sorted.size()];
+        this.cumulativeWeights = new double[sorted.size()];
+        double running = 0.0;
+        for (int i = 0; i < sorted.size(); i++) {
+            values[i] = sorted.get(i).value();
+            running += sorted.get(i).weight();
+            cumulativeWeights[i] = running;
+        }
+        this.totalWeight = running;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.random.RandomGenerator;
+
+/**
+ * Generates integers from a <em>Zipfian</em> (power-law) distribution over {@code size} consecutive
+ * values starting at {@code start}: rank <em>k</em> (1-based) has probability proportional to
+ * {@code 1 / k^exponent}, so the lowest values are by far the most frequent and the tail is long and
+ * thin. This is the shape of "popularity" columns — a few hot keys, many rare ones (referenced
+ * products, authors, tags) — that uniform random generation never reproduces.
+ *
+ * <p>A cumulative table of {@code size} doubles is precomputed once, so keep {@code size} modest
+ * (thousands to low millions). {@code exponent} defaults to {@code 1.0} (classic Zipf); higher values
+ * concentrate mass even harder on the head.
+ *
+ * @since 2.11.0
+ */
+public class ZipfianIntegerGenerator extends AbstractDataGenerator<Integer> {
+
+    private final int start;
+    private final double[] cumulativeWeights;
+    private final double totalWeight;
+
+    @Override
+    public Integer generate() {
+        double draw = randomUtils.nextDouble(0.0, totalWeight);
+        int low = 0;
+        int high = cumulativeWeights.length - 1;
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (draw < cumulativeWeights[mid]) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+        return start + low;
+    }
+
+    @Override
+    public void set(Connection connection, PreparedStatement statement, int parameterIndex, Integer value) throws SQLException {
+        statement.setInt(parameterIndex, value);
+    }
+
+    @Override
+    public Integer get(ResultSet resultSet, int columnIndex) throws SQLException {
+        int value = resultSet.getInt(columnIndex);
+        return resultSet.wasNull() ? null : value;
+    }
+
+    public static class Builder extends AbstractBuilder<Integer> {
+
+        private int start = 1;
+        private int size = 0;
+        private double exponent = 1.0;
+
+        public Builder(RandomGenerator random) {
+            super(random);
+        }
+
+        /** The first (most frequent) value; ranks run {@code [start, start + size)}. Default {@code 1}. */
+        public Builder start(int start) {
+            this.start = start;
+            return this;
+        }
+
+        /** The number of distinct values; required and must be {@code >= 1}. */
+        public Builder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        /** The skew exponent; {@code 1.0} is classic Zipf, higher concentrates more on the head. */
+        public Builder exponent(double exponent) {
+            this.exponent = exponent;
+            return this;
+        }
+
+        @Override
+        public ZipfianIntegerGenerator build() {
+            if (size < 1) {
+                throw new IllegalArgumentException("size must be >= 1: " + size);
+            }
+            if (exponent < 0) {
+                throw new IllegalArgumentException("exponent must be non-negative: " + exponent);
+            }
+            return new ZipfianIntegerGenerator(this);
+        }
+    }
+
+    private ZipfianIntegerGenerator(Builder builder) {
+        super(builder.random);
+        this.start = builder.start;
+        this.cumulativeWeights = new double[builder.size];
+        double running = 0.0;
+        for (int k = 1; k <= builder.size; k++) {
+            running += 1.0 / Math.pow(k, builder.exponent);
+            cumulativeWeights[k - 1] = running;
+        }
+        this.totalWeight = running;
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/DistributionsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/DistributionsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.gen.NormalIntegerGenerator;
+import io.bloviate.gen.SkewedTimestampGenerator;
+import io.bloviate.gen.WeightedCategoricalGenerator;
+import io.bloviate.gen.ZipfianIntegerGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies the {@link Distributions} convenience factories build the expected generators from the
+ * engine-supplied seeded {@link java.util.random.RandomGenerator}, exactly as a per-column override
+ * does — so a column can opt into a distribution without writing a factory.
+ */
+class DistributionsTest {
+
+    @Test
+    void factoriesBuildTheExpectedGeneratorTypes() {
+        var random = RandomGenerators.create(1L);
+        assertInstanceOf(WeightedCategoricalGenerator.class, Distributions.weighted(Map.of("A", 0.9, "B", 0.1)).create(random));
+        assertInstanceOf(NormalIntegerGenerator.class, Distributions.normalInt(5, 1, 1, 10).create(random));
+        assertInstanceOf(ZipfianIntegerGenerator.class, Distributions.zipfian(1000).create(random));
+        assertInstanceOf(SkewedTimestampGenerator.class, Distributions.recentTimestamps().create(random));
+        assertNotNull(Distributions.normal(0, 1, -1, 1).create(random));
+    }
+
+    @Test
+    void wiredFactoryIsSeededByTheEngineAndReproducible() {
+        ColumnGeneratorFactory factory = Distributions.zipfian(1000);
+        DataGenerator<?> a = factory.create(RandomGenerators.create(7L));
+        DataGenerator<?> b = factory.create(RandomGenerators.create(7L));
+        for (int i = 0; i < 500; i++) {
+            assertEquals(a.generate(), b.generate(), "engine-seeded factory must be reproducible at draw " + i);
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/gen/DistributionGeneratorsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/DistributionGeneratorsTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import io.bloviate.util.RandomGenerators;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the issue #479 (Part A) distribution generators: each produces the intended
+ * <em>shape</em>, stays within bounds, and is reproducible (same seed ⇒ identical sequence).
+ */
+class DistributionGeneratorsTest {
+
+    private static final long SEED = 42L;
+    private static final int N = 50_000;
+
+    /** Same seed ⇒ identical sequence, for any generator factory. */
+    private static <T> void assertReproducible(Supplier<DataGenerator<T>> factory) {
+        DataGenerator<T> a = factory.get();
+        DataGenerator<T> b = factory.get();
+        for (int i = 0; i < 1_000; i++) {
+            assertEquals(a.generate(), b.generate(), "same seed must produce the same value at draw " + i);
+        }
+    }
+
+    @Test
+    void weightedCategoricalMatchesWeightsAndIsReproducible() {
+        Map<String, Double> weights = Map.of("ACTIVE", 0.8, "CHURNED", 0.15, "BANNED", 0.05);
+        assertReproducible(() -> new WeightedCategoricalGenerator.Builder<String>(RandomGenerators.create(SEED))
+                .weights(weights).build());
+
+        WeightedCategoricalGenerator<String> generator =
+                new WeightedCategoricalGenerator.Builder<String>(RandomGenerators.create(SEED)).weights(weights).build();
+        Map<String, Integer> counts = new HashMap<>();
+        for (int i = 0; i < N; i++) {
+            counts.merge(generator.generate(), 1, Integer::sum);
+        }
+        // every category appears, and observed frequencies track the configured weights (loose bounds)
+        assertEquals(3, counts.size());
+        assertTrue(counts.get("ACTIVE") > counts.get("CHURNED"), "ACTIVE (0.8) should dominate CHURNED (0.15)");
+        assertTrue(counts.get("CHURNED") > counts.get("BANNED"), "CHURNED (0.15) should beat BANNED (0.05)");
+        double activeShare = counts.get("ACTIVE") / (double) N;
+        assertTrue(activeShare > 0.75 && activeShare < 0.85, "ACTIVE share ~0.80 but was " + activeShare);
+    }
+
+    @Test
+    void weightedCategoricalOrderIndependentOfMapType() {
+        // a LinkedHashMap in a different insertion order must yield the SAME sequence as Map.of,
+        // because the generator imposes a stable canonical order — the reproducibility guarantee
+        Map<String, Double> reversed = new java.util.LinkedHashMap<>();
+        reversed.put("BANNED", 0.05);
+        reversed.put("CHURNED", 0.15);
+        reversed.put("ACTIVE", 0.8);
+
+        WeightedCategoricalGenerator<String> fromOrdered =
+                new WeightedCategoricalGenerator.Builder<String>(RandomGenerators.create(SEED))
+                        .weights(Map.of("ACTIVE", 0.8, "CHURNED", 0.15, "BANNED", 0.05)).build();
+        WeightedCategoricalGenerator<String> fromReversed =
+                new WeightedCategoricalGenerator.Builder<String>(RandomGenerators.create(SEED))
+                        .weights(reversed).build();
+
+        for (int i = 0; i < 1_000; i++) {
+            assertEquals(fromOrdered.generate(), fromReversed.generate(), "map order must not affect output");
+        }
+    }
+
+    @Test
+    void normalIntegerStaysInRangeAndCentersOnMean() {
+        assertReproducible(() -> new NormalIntegerGenerator.Builder(RandomGenerators.create(SEED))
+                .mean(50).standardDeviation(10).min(0).max(100).build());
+
+        NormalIntegerGenerator generator = new NormalIntegerGenerator.Builder(RandomGenerators.create(SEED))
+                .mean(50).standardDeviation(10).min(0).max(100).build();
+        long sum = 0;
+        for (int i = 0; i < N; i++) {
+            int value = generator.generate();
+            assertTrue(value >= 0 && value <= 100, "value out of [0,100]: " + value);
+            sum += value;
+        }
+        double mean = sum / (double) N;
+        assertTrue(mean > 48 && mean < 52, "sample mean ~50 but was " + mean);
+    }
+
+    @Test
+    void normalDoubleStaysInRange() {
+        NormalDoubleGenerator generator = new NormalDoubleGenerator.Builder(RandomGenerators.create(SEED))
+                .mean(0).standardDeviation(1).min(-2).max(2).build();
+        for (int i = 0; i < N; i++) {
+            double value = generator.generate();
+            assertTrue(value >= -2.0 && value <= 2.0, "value out of [-2,2]: " + value);
+        }
+    }
+
+    @Test
+    void zipfianConcentratesOnTheHeadAndIsReproducible() {
+        assertReproducible(() -> new ZipfianIntegerGenerator.Builder(RandomGenerators.create(SEED))
+                .start(1).size(100).exponent(1.0).build());
+
+        ZipfianIntegerGenerator generator = new ZipfianIntegerGenerator.Builder(RandomGenerators.create(SEED))
+                .start(1).size(100).exponent(1.0).build();
+        int[] counts = new int[101];
+        for (int i = 0; i < N; i++) {
+            int value = generator.generate();
+            assertTrue(value >= 1 && value <= 100, "value out of [1,100]: " + value);
+            counts[value]++;
+        }
+        assertTrue(counts[1] > counts[2], "rank 1 should beat rank 2");
+        assertTrue(counts[1] > counts[100] * 10, "the head should dwarf the tail");
+    }
+
+    @Test
+    void skewedTimestampStaysInWindowAndLeansRecent() {
+        Instant start = Instant.parse("2020-01-01T00:00:00Z");
+        Instant end = Instant.parse("2025-01-01T00:00:00Z");
+        assertReproducible(() -> new SkewedTimestampGenerator.Builder(RandomGenerators.create(SEED))
+                .start(start).end(end).skew(3.0).build());
+
+        SkewedTimestampGenerator generator = new SkewedTimestampGenerator.Builder(RandomGenerators.create(SEED))
+                .start(start).end(end).skew(3.0).build();
+        long startMs = start.toEpochMilli();
+        long rangeMs = end.toEpochMilli() - startMs;
+        double fractionSum = 0;
+        List<Timestamp> samples = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            Timestamp ts = generator.generate();
+            long ms = ts.getTime();
+            assertTrue(ms >= startMs && ms <= end.toEpochMilli(), "timestamp out of window: " + ts);
+            fractionSum += (ms - startMs) / (double) rangeMs;
+            if (i < 5) {
+                samples.add(ts);
+            }
+        }
+        // with skew 3.0 the average position should sit well past the midpoint (recent-weighted)
+        double meanFraction = fractionSum / N;
+        assertTrue(meanFraction > 0.6, "recency-skewed mean fraction should exceed 0.6 but was " + meanFraction);
+    }
+
+    @Test
+    void buildersRejectInvalidArguments() {
+        var random = RandomGenerators.create(SEED);
+        assertThrows(IllegalStateException.class,
+                () -> new WeightedCategoricalGenerator.Builder<String>(random).build());
+        assertThrows(IllegalArgumentException.class,
+                () -> new NormalIntegerGenerator.Builder(random).min(10).max(0).build());
+        assertThrows(IllegalArgumentException.class,
+                () -> new ZipfianIntegerGenerator.Builder(random).size(0).build());
+        assertThrows(IllegalArgumentException.class,
+                () -> new SkewedTimestampGenerator.Builder(random).skew(0).build());
+    }
+}


### PR DESCRIPTION
First half of #479 — **value distributions** (the realism gap). Specified, deterministic distributions, *not* learned-from-data ML synthesis, so Bloviate stays in its lane.

## What's new
New generators in `io.bloviate.gen`, each built from the engine's column seed (reproducible):

| Generator | Shape | Example use |
|---|---|---|
| `WeightedCategoricalGenerator<T>` | categorical by weight | `status` 70% NEW / 25% SHIPPED / 5% CANCELLED |
| `NormalDoubleGenerator` / `NormalIntegerGenerator` | bounded Gaussian | `rating` ~ N(4,1) clamped to [1,5] |
| `ZipfianIntegerGenerator` | power-law | hot `product_id`s, long thin tail |
| `SkewedTimestampGenerator` | recency-skewed | `created_at` bunched toward now |

Plus **`Distributions`** — a convenience returning `ColumnGeneratorFactory` so a column opts in **declaratively**, no factory class required:

```java
new ColumnConfiguration("status",     Distributions.weighted(Map.of("NEW", 0.7, "SHIPPED", 0.25, "CANCELLED", 0.05))),
new ColumnConfiguration("rating",     Distributions.normalInt(4, 1, 1, 5)),
new ColumnConfiguration("product_id", Distributions.zipfian(10_000)),
new ColumnConfiguration("created_at", Distributions.recentTimestamps())
```

## Properties
- **Reproducible** — same seed ⇒ identical sequence; the weighted generator imposes a stable canonical value order so output doesn't depend on map iteration order.
- **Additive** — no engine change; the default (no distribution configured) path is byte-for-byte unchanged; composes with FK reseeding and parallel/partitioned fills.

## Tests
`DistributionGeneratorsTest` (shape, bounds, reproducibility, map-order independence, validation) and `DistributionsTest` (factory wiring + engine-seeded reproducibility) — 9 tests, all green. Documented in README ("Value Distributions") and ARCHITECTURE.md.

**Part B of #479** — `CHECK`/enum-domain constraint conformance — stays open and is tracked on the issue; it touches the metadata model and needs per-DB integration tests, so it'll be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)