### PR TITLE
feat(datafaker): optional semantic/realistic data via column-name inference (#472)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -352,7 +352,11 @@ GeneratorRegistry registry = new GeneratorRegistry.Builder()
 ```
 
 Crucially, registry- and plugin-supplied generators are still constructed with the engine's seeded
-`RandomGenerator`, so they remain just as reproducible as the built-ins.
+`RandomGenerator`, so they remain just as reproducible as the built-ins. The optional
+**[`bloviate-datafaker`](bloviate-datafaker/)** module is exactly this pattern in practice: one
+`GeneratorPlugin` that maps column names (`email`, `first_name`, `phone`, …) to realistic
+[Datafaker](https://www.datafaker.net/) values, seeded from the engine's column seed for
+reproducibility — keeping the core dependency-free.
 
 ## 7. The generator library — Builder pattern
 
@@ -413,10 +417,13 @@ graph TD
     core["bloviate-core<br/><i>dependency-free engine</i><br/>db · ext · gen · file · util"]
     junit["bloviate-junit<br/><i>@FillDatabase / @FillSource</i><br/>BloviateExtension"]
     tc["bloviate-testcontainers<br/><i>BloviateContainers</i>"]
+    df["bloviate-datafaker<br/><i>DatafakerGeneratorPlugin</i>"]
     junit -->|depends on| core
     tc -->|depends on| core
+    df -->|depends on| core
     junit -.->|provided| j[JUnit Jupiter]
     tc -.->|provided| t[Testcontainers]
+    df -->|depends on| d[Datafaker]
 ```
 
 - **[`bloviate-core`](bloviate-core/)** — everything above: introspection, the DAG, generators,
@@ -429,6 +436,9 @@ graph TD
 - **[`bloviate-testcontainers`](bloviate-testcontainers/)** — fill a started
   `JdbcDatabaseContainer` in one fluent call via
   [`BloviateContainers.forContainer(...)`](bloviate-testcontainers/src/main/java/io/bloviate/testcontainers/BloviateContainers.java).
+- **[`bloviate-datafaker`](bloviate-datafaker/)** — optional semantic/realistic values by column name,
+  via a `GeneratorPlugin` over [Datafaker](https://www.datafaker.net/). Unlike the others, Datafaker is
+  a normal (not `provided`) dependency — it only reaches your classpath if you add this module.
 
 ## Design patterns at a glance
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See **[POSITIONING.md](POSITIONING.md)** for the full competitive landscape, wit
   - [Per-Column Generation Overrides](#per-column-generation-overrides)
   - [Value Distributions](#value-distributions)
   - [Custom Generator Registry](#custom-generator-registry)
+  - [Semantic / Realistic Data (`bloviate-datafaker`)](#semantic--realistic-data-bloviate-datafaker)
   - [Composite Keys & Foreign Key Fidelity](#composite-keys--foreign-key-fidelity)
   - [Variable Parent/Child Cardinality](#variable-parentchild-cardinality)
   - [TPC-C Benchmark Data](#tpc-c-benchmark-data)
@@ -106,6 +107,7 @@ version of JUnit / Testcontainers:
 | `bloviate-core` | The data-generation engine (`DatabaseFiller`, generators, flat files) |
 | `bloviate-junit` | JUnit Jupiter: fill a test database declaratively with `@FillDatabase` |
 | `bloviate-testcontainers` | Fill a started `JdbcDatabaseContainer` in one call |
+| `bloviate-datafaker` | Optional realistic values by column name (email, name, address …) via Datafaker |
 
 ```xml
 <!-- test-scoped: JUnit 5 integration -->
@@ -405,6 +407,42 @@ public class MyGenerators implements GeneratorPlugin {
     }
 }
 ```
+
+### Semantic / Realistic Data (`bloviate-datafaker`)
+
+By default an `email VARCHAR` gets random text, not a plausible email. The optional
+**`bloviate-datafaker`** module maps common column **names** (`email`, `first_name`, `phone`, `city`,
+`zip`, …) to realistic [Datafaker](https://www.datafaker.net/) values — keeping the core
+dependency-free (Datafaker only lands if you add this module).
+
+It's **opt-in twice over**: add the module, and build a `GeneratorRegistry` that includes its plugin —
+either by `discover()` (it registers via `ServiceLoader`) or explicitly:
+
+```java
+import io.bloviate.datafaker.DatafakerGeneratorPlugin;
+import io.bloviate.ext.GeneratorRegistry;
+
+GeneratorRegistry registry = new GeneratorRegistry.Builder()
+    .discover()                                  // picks up DatafakerGeneratorPlugin from the classpath
+    .build();
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    128, 100, new PostgresSupport(), null, registry);   // registry sits between per-column overrides and type defaults
+```
+
+So an `email` column now yields `jane.doe@example.com`, `first_name` a real first name, `phone` a
+`(555) 555-01xx` number, and so on. Properties:
+
+- **Reproducible** — realistic values are seeded from the engine's column seed, so the same seed gives
+  the same data; the locale is fixed (default `Locale.ENGLISH`) so output is identical across machines.
+- **Safe by default** — reserved `example.*` email domains and `555-01xx` phone numbers (never real
+  identifiers); values are truncated to the column's length.
+- **Unmatched columns are untouched** — anything the dictionary doesn't recognize falls through to the
+  normal type-based generator. Don't route `UNIQUE`/primary-key columns through it — realistic
+  dictionaries repeat at scale, so keep Bloviate's sequence/seeded generators for keys.
+
+> Cross-column *consistency* (a `city`/`state`/`zip` that agree, an `email` derived from the row's name)
+> is a separate, in-progress feature — see [#473](https://github.com/timveil/bloviate/issues/473).
 
 ### Composite Keys & Foreign Key Fidelity
 

--- a/bloviate-datafaker/pom.xml
+++ b/bloviate-datafaker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.bloviate</groupId>
         <artifactId>bloviate-parent</artifactId>
-        <version>2.11.0</version>
+        <version>2.12.0</version>
     </parent>
 
     <artifactId>bloviate-datafaker</artifactId>

--- a/bloviate-datafaker/pom.xml
+++ b/bloviate-datafaker/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Tim Veil
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.bloviate</groupId>
+        <artifactId>bloviate-parent</artifactId>
+        <version>2.11.0</version>
+    </parent>
+
+    <artifactId>bloviate-datafaker</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>Bloviate Datafaker</name>
+    <description>Optional semantic/realistic data for Bloviate: maps column names to Datafaker providers</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.bloviate</groupId>
+            <artifactId>bloviate-core</artifactId>
+        </dependency>
+
+        <!-- realistic value providers; pulled in transitively when a user adds this module -->
+        <dependency>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+        </dependency>
+
+        <!-- Testing Dependencies -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerGeneratorPlugin.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerGeneratorPlugin.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.ext.GeneratorPlugin;
+import io.bloviate.ext.GeneratorRegistry;
+import net.datafaker.Faker;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+/**
+ * A {@link GeneratorPlugin} that maps common column <em>names</em> to realistic
+ * <a href="https://www.datafaker.net/">Datafaker</a> providers, so an {@code email VARCHAR} gets a
+ * plausible email instead of random text. This is the opt-in semantic-data layer (issue #472).
+ *
+ * <p><strong>Opt-in, twice over.</strong> Nothing changes unless you (a) put {@code bloviate-datafaker}
+ * on the classpath and (b) build a {@link GeneratorRegistry} that includes this plugin — either via
+ * {@link GeneratorRegistry.Builder#discover()} (it is registered as a {@link java.util.ServiceLoader}
+ * provider) or explicitly with {@link GeneratorRegistry.Builder#register(GeneratorPlugin)}. The
+ * registry is consulted between per-column overrides and the built-in {@code DatabaseSupport}
+ * defaults, which remain the fallback for every unmatched column.
+ *
+ * <p><strong>Safety defaults.</strong> Emails use Datafaker's reserved {@code example.*} domains and
+ * phone numbers the reserved {@code 555-01xx} range, so generated identifiers never collide with real
+ * ones. Values are truncated to the column's length. The locale is fixed (default {@link Locale#ENGLISH})
+ * for reproducible, charset-safe output; pass another locale to the {@link #DatafakerGeneratorPlugin(Locale)}
+ * constructor and register it explicitly if you need one.
+ *
+ * <p><strong>Caveats.</strong> Realistic values are drawn from bounded dictionaries, so they can repeat
+ * at high row counts — do not route {@code UNIQUE}/primary-key columns through this plugin (keep
+ * Bloviate's sequence/seeded generators for those). Realistic generation is also slower than the
+ * type-driven default, so it is best kept off the highest-throughput fills.
+ *
+ * @since 2.11.0
+ */
+public class DatafakerGeneratorPlugin implements GeneratorPlugin {
+
+    private final Locale locale;
+
+    /** Uses {@link Locale#ENGLISH}; this is the constructor the {@link java.util.ServiceLoader} calls. */
+    public DatafakerGeneratorPlugin() {
+        this(Locale.ENGLISH);
+    }
+
+    /**
+     * @param locale the locale for realistic values; fixed (not the JVM default) for reproducibility
+     */
+    public DatafakerGeneratorPlugin(Locale locale) {
+        this.locale = locale;
+    }
+
+    @Override
+    public void contribute(GeneratorRegistry.Builder builder) {
+        // Patterns are full-match and case-insensitive; the first match wins, so order matters —
+        // e.g. ".*email.*" is registered before ".*address.*" so "email_address" stays an email.
+        rule(builder, ".*email.*", f -> f.internet().safeEmailAddress());
+        rule(builder, ".*first_?name.*", f -> f.name().firstName());
+        rule(builder, ".*last_?name.*", f -> f.name().lastName());
+        rule(builder, ".*user_?name.*", f -> f.name().username());
+        rule(builder, ".*full_?name.*|name", f -> f.name().fullName());
+        rule(builder, ".*phone.*", f -> f.regexify("\\([0-9]{3}\\) 555-01[0-9]{2}"));
+        rule(builder, ".*company.*", f -> f.company().name());
+        rule(builder, ".*(url|website).*", f -> f.internet().url());
+        rule(builder, ".*city.*", f -> f.address().city());
+        rule(builder, ".*(state|province).*", f -> f.address().state());
+        rule(builder, ".*country.*", f -> f.address().country());
+        rule(builder, ".*(zip|postal).*", f -> f.address().zipCode());
+        rule(builder, ".*(street|address).*", f -> f.address().streetAddress());
+    }
+
+    private void rule(GeneratorRegistry.Builder builder, String regex, Function<Faker, String> valueFunction) {
+        builder.registerColumnNamePattern(regex, (column, random) ->
+                new DatafakerStringGenerator(random, locale, column.maxSize(), valueFunction));
+    }
+}

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerStringGenerator.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerStringGenerator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.gen.AbstractDataGenerator;
+import net.datafaker.Faker;
+import net.datafaker.service.RandomService;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.random.RandomGenerator;
+
+/**
+ * Produces a realistic {@link String} value from a <a href="https://www.datafaker.net/">Datafaker</a>
+ * provider — an email, a name, a phone number, an address part, and so on. The provider is supplied as
+ * a {@code Function<Faker, String>} by {@link DatafakerGeneratorPlugin}.
+ *
+ * <p><strong>Reproducibility.</strong> Datafaker needs a {@link Random}; this generator seeds one from
+ * the engine's column-seeded {@link RandomGenerator}, so the same base seed yields the same realistic
+ * values on every run. {@link #reseed(long)} rebuilds the {@link Faker} so the output stays
+ * deterministic under foreign-key wraparound and intra-table partitioning too. The {@link Locale} is
+ * fixed (not the JVM default) so output is identical across machines.
+ *
+ * <p>If the produced value is longer than the column's declared size it is truncated, so locale-specific
+ * output cannot overflow a {@code VARCHAR(n)}.
+ *
+ * @since 2.11.0
+ */
+public class DatafakerStringGenerator extends AbstractDataGenerator<String> {
+
+    private final Locale locale;
+    private final Integer maxSize;
+    private final Function<Faker, String> valueFunction;
+    private Faker faker;
+
+    /**
+     * @param random        the engine-supplied, column-seeded random source
+     * @param locale        the locale for realistic values (fixed for reproducibility)
+     * @param maxSize        the column's max length, or null/0 for unbounded; longer values are truncated
+     * @param valueFunction the Datafaker provider to draw from
+     */
+    public DatafakerStringGenerator(RandomGenerator random, Locale locale, Integer maxSize, Function<Faker, String> valueFunction) {
+        super(random);
+        this.locale = locale;
+        this.maxSize = maxSize;
+        this.valueFunction = valueFunction;
+        this.faker = newFaker(random);
+    }
+
+    private Faker newFaker(RandomGenerator source) {
+        // derive a deterministic seed from the column's RNG so the Faker is reproducible
+        return new Faker(locale, new RandomService(new Random(source.nextLong())));
+    }
+
+    @Override
+    public String generate() {
+        String value = valueFunction.apply(faker);
+        if (value != null && maxSize != null && maxSize > 0 && value.length() > maxSize) {
+            return value.substring(0, maxSize);
+        }
+        return value;
+    }
+
+    @Override
+    public void reseed(long seed) {
+        super.reseed(seed);
+        this.faker = newFaker(this.random);
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+}

--- a/bloviate-datafaker/src/main/resources/META-INF/services/io.bloviate.ext.GeneratorPlugin
+++ b/bloviate-datafaker/src/main/resources/META-INF/services/io.bloviate.ext.GeneratorPlugin
@@ -1,0 +1,1 @@
+io.bloviate.datafaker.DatafakerGeneratorPlugin

--- a/bloviate-datafaker/src/test/java/io/bloviate/datafaker/DatafakerGeneratorPluginTest.java
+++ b/bloviate-datafaker/src/test/java/io/bloviate/datafaker/DatafakerGeneratorPluginTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.db.Column;
+import io.bloviate.ext.GeneratorRegistry;
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DatafakerGeneratorPluginTest {
+
+    private static final long SEED = 42L;
+
+    private static final GeneratorRegistry EXPLICIT =
+            new GeneratorRegistry.Builder().register(new DatafakerGeneratorPlugin()).build();
+
+    private static Column column(String name, JDBCType type, int maxSize) {
+        return new Column(name, "t", null, null, type, maxSize, null, type.getName().toLowerCase(), false, true, null, 1);
+    }
+
+    private static String value(GeneratorRegistry registry, String columnName, int maxSize) {
+        DataGenerator<?> generator = registry.resolve(column(columnName, JDBCType.VARCHAR, maxSize), RandomGenerators.create(SEED));
+        return (String) generator.generate();
+    }
+
+    @Test
+    void emailColumnGetsReservedEmail() {
+        String email = value(EXPLICIT, "email", 255);
+        assertTrue(email.matches(".+@example\\.(com|net|org)"), "expected a reserved example.* email but got " + email);
+    }
+
+    @Test
+    void emailMatchesEvenWhenNameContainsIt() {
+        // ".*email.*" full-matches "user_email_address", and email is registered before address rules
+        String email = value(EXPLICIT, "user_email_address", 255);
+        assertTrue(email.matches(".+@example\\.(com|net|org)"), "expected an email but got " + email);
+    }
+
+    @Test
+    void phoneColumnGetsReserved555Number() {
+        String phone = value(EXPLICIT, "phone_number", 32);
+        assertTrue(phone.matches("\\([0-9]{3}\\) 555-01[0-9]{2}"), "expected a reserved 555-01xx phone but got " + phone);
+    }
+
+    @Test
+    void nameColumnsGetRealisticValues() {
+        assertFalse(value(EXPLICIT, "first_name", 64).isBlank());
+        assertFalse(value(EXPLICIT, "last_name", 64).isBlank());
+        assertFalse(value(EXPLICIT, "city", 64).isBlank());
+    }
+
+    @Test
+    void sameSeedProducesIdenticalValues() {
+        // reproducibility: a fresh generator on the same seed yields the same realistic value
+        assertEquals(value(EXPLICIT, "email", 255), value(EXPLICIT, "email", 255));
+        assertEquals(value(EXPLICIT, "first_name", 64), value(EXPLICIT, "first_name", 64));
+    }
+
+    @Test
+    void valueIsTruncatedToColumnSize() {
+        String email = value(EXPLICIT, "email", 5);
+        assertTrue(email.length() <= 5, "value must fit the column size but was " + email);
+    }
+
+    @Test
+    void unmatchedColumnFallsThroughToNull() {
+        // a column the dictionary doesn't recognize returns null so the engine uses its type default
+        assertNull(EXPLICIT.resolve(column("widget_count", JDBCType.INTEGER, 0), RandomGenerators.create(SEED)));
+    }
+
+    @Test
+    void pluginIsDiscoveredViaServiceLoader() {
+        // the META-INF/services entry makes discover() pick the plugin up with no explicit registration
+        GeneratorRegistry discovered = new GeneratorRegistry.Builder().discover().build();
+        DataGenerator<?> generator = discovered.resolve(column("email", JDBCType.VARCHAR, 255), RandomGenerators.create(SEED));
+        assertInstanceOf(DatafakerStringGenerator.class, generator);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>bloviate-core</module>
         <module>bloviate-junit</module>
         <module>bloviate-testcontainers</module>
+        <module>bloviate-datafaker</module>
         <module>bloviate-benchmarks</module>
     </modules>
 
@@ -65,6 +66,7 @@
         <slf4j.version>2.0.18</slf4j.version>
         <jgrapht.version>1.5.3</jgrapht.version>
         <junit-jupiter.version>6.1.0</junit-jupiter.version>
+        <datafaker.version>2.4.4</datafaker.version>
 
         <!-- test / integration dependency versions -->
         <testcontainers.version>1.21.4</testcontainers.version>
@@ -104,6 +106,11 @@
             </dependency>
 
             <!-- compile -->
+            <dependency>
+                <groupId>net.datafaker</groupId>
+                <artifactId>datafaker</artifactId>
+                <version>${datafaker.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
Closes #472 (Phase 1). Adds the optional **`bloviate-datafaker`** module — realistic values inferred from column **names** — while the core stays dependency-free.

## What it does
An `email VARCHAR` now gets `jane.doe@example.com` instead of random text. A `GeneratorPlugin` maps a dictionary of column-name regexes to [Datafaker](https://www.datafaker.net/) providers (email, first/last/full name, username, phone, company, url, city, state, country, zip, street/address).

## Opt-in twice over
Nothing changes unless you (a) add the module and (b) build a `GeneratorRegistry` that includes the plugin — via `discover()` (ServiceLoader) or `register(new DatafakerGeneratorPlugin())`. The registry sits between per-column overrides and the type defaults; unmatched columns fall through untouched.

## Design highlights
- **Reproducible** — `DatafakerStringGenerator` seeds Datafaker from the engine's column RNG, and **rebuilds the Faker on `reseed()`** so output stays deterministic under FK wraparound and intra-table partitioning. Locale is fixed (default `ENGLISH`) so results are identical across machines.
- **Safe defaults** — reserved `example.*` email domains and `555-01xx` phones (never real identifiers); values truncated to the column's length; documented caveat not to route `UNIQUE`/PK columns through realistic dictionaries.
- **Match semantics** — full-match, case-insensitive, first-match-wins; `.*email.*` is ordered before `.*address.*` so `email_address` stays an email.
- **Core stays dependency-free** — `net.datafaker` resolves only if you add this module.

## Tests & docs
8 module tests (reserved formats, reproducibility, truncation, fall-through, ServiceLoader discovery), all green; core's full suite re-ran green via `-am`. README ("Semantic / Realistic Data") + ARCHITECTURE (§6, §9) + Installation table updated. Parent pom adds the module, `datafaker.version`, and dependency management.

**Phase 2 — referential realism** (consistent city/state/zip, email-from-name) is the harder, row-context problem tracked in #473; I'll bring a design proposal before building it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)