### PR TITLE
feat(datafaker): referential realism — correlated person & geo columns (#473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ target/
 .idea/
 *.iml
 *.csv
+# but keep CSV files that are bundled module resources (e.g. reference datasets)
+!**/src/main/resources/**/*.csv
 .env
 
 # maven-shade-plugin output

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -356,7 +356,10 @@ Crucially, registry- and plugin-supplied generators are still constructed with t
 **[`bloviate-datafaker`](bloviate-datafaker/)** module is exactly this pattern in practice: one
 `GeneratorPlugin` that maps column names (`email`, `first_name`, `phone`, …) to realistic
 [Datafaker](https://www.datafaker.net/) values, seeded from the engine's column seed for
-reproducibility — keeping the core dependency-free.
+reproducibility — keeping the core dependency-free. It also offers **referential realism** via a
+`RowContext`: correlated columns project fields of one per-row entity (a `Person` whose email/username
+derive from its name), computed as a pure function of `(seed, rowIndex)` so consistency survives
+parallel and partitioned fills.
 
 ## 7. The generator library — Builder pattern
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -357,9 +357,10 @@ Crucially, registry- and plugin-supplied generators are still constructed with t
 `GeneratorPlugin` that maps column names (`email`, `first_name`, `phone`, …) to realistic
 [Datafaker](https://www.datafaker.net/) values, seeded from the engine's column seed for
 reproducibility — keeping the core dependency-free. It also offers **referential realism** via a
-`RowContext`: correlated columns project fields of one per-row entity (a `Person` whose email/username
-derive from its name), computed as a pure function of `(seed, rowIndex)` so consistency survives
-parallel and partitioned fills.
+`RowContext`: correlated columns project fields of one per-row entity — a `Person` whose email/username
+derive from its name, or a `Geo` tuple (city/state/zip/area-code that agree) drawn from a bundled
+reference dataset — computed as a pure function of `(seed, rowIndex)` so consistency survives parallel
+and partitioned fills.
 
 ## 7. The generator library — Builder pattern
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ which learn from real data and are non-deterministic, and from the **masking/sub
 recipe-authored, no schema introspection), synth (dormant since 2022), and DBeaver Mock Data (paid,
 GUI-bound) — Bloviate is the maintained, deterministic, auto-FK option.
 
-**Honest limitations.** Bloviate is *not* a statistical/ML synthesizer (no learned distributions or
-correlations), *not* a masking/subsetting tool for existing data, JVM-only, and has no GUI. It is also
-type-driven rather than semantically aware today — an `email VARCHAR` gets random text, not a plausible
-email (tracked in [#472](https://github.com/timveil/bloviate/issues/472) and
-[#473](https://github.com/timveil/bloviate/issues/473)).
+**Honest limitations.** Bloviate is *not* a statistical/ML synthesizer (it generates *specified*
+distributions, not ones learned from real data), *not* a masking/subsetting tool for existing data,
+JVM-only, and has no GUI. Its core is type-driven by default — an `email VARCHAR` gets random text —
+though the optional [`bloviate-datafaker`](#semantic--realistic-data-bloviate-datafaker) module adds
+realistic, name-correlated values when you want them.
 
 See **[POSITIONING.md](POSITIONING.md)** for the full competitive landscape, with sources.
 
@@ -72,6 +72,7 @@ See **[POSITIONING.md](POSITIONING.md)** for the full competitive landscape, wit
   - [Value Distributions](#value-distributions)
   - [Custom Generator Registry](#custom-generator-registry)
   - [Semantic / Realistic Data (`bloviate-datafaker`)](#semantic--realistic-data-bloviate-datafaker)
+  - [Correlated Columns (referential realism)](#correlated-columns-referential-realism)
   - [Composite Keys & Foreign Key Fidelity](#composite-keys--foreign-key-fidelity)
   - [Variable Parent/Child Cardinality](#variable-parentchild-cardinality)
   - [TPC-C Benchmark Data](#tpc-c-benchmark-data)
@@ -441,8 +442,37 @@ So an `email` column now yields `jane.doe@example.com`, `first_name` a real firs
   normal type-based generator. Don't route `UNIQUE`/primary-key columns through it — realistic
   dictionaries repeat at scale, so keep Bloviate's sequence/seeded generators for keys.
 
-> Cross-column *consistency* (a `city`/`state`/`zip` that agree, an `email` derived from the row's name)
-> is a separate, in-progress feature — see [#473](https://github.com/timveil/bloviate/issues/473).
+### Correlated Columns (referential realism)
+
+The plugin above makes each column realistic *independently* — so a row's `email` won't match its
+`first_name`/`last_name`. For columns that should agree, share one **`RowContext`** and register each as
+a **projection** of the same per-row entity. `People.context(...)` provides a coherent person whose
+`email`, `username`, and `full_name` are derived from the row's name:
+
+```java
+import io.bloviate.datafaker.People;
+import io.bloviate.datafaker.Person;
+import io.bloviate.datafaker.RowContext;
+
+RowContext<Person> person = People.context(42L, java.util.Locale.ENGLISH);
+
+Set<ColumnConfiguration> columns = Set.of(
+    new ColumnConfiguration("first_name", person.project(Person::firstName)),
+    new ColumnConfiguration("last_name",  person.project(Person::lastName)),
+    new ColumnConfiguration("full_name",  person.project(Person::fullName)),
+    new ColumnConfiguration("email",      person.project(Person::email)),     // jane.doe7@example.com
+    new ColumnConfiguration("username",   person.project(Person::username))   // jane.doe7
+);
+```
+
+Now `full_name` matches `first_name`/`last_name`, and `email`/`username` are derived from them. The
+entity is a pure function of `(seed, rowIndex)`, so the data is **reproducible and order-independent**
+— sequential and parallel/partitioned fills produce identical values. Email and username carry a
+row-index suffix so they stay unique at scale.
+
+> The first release covers the **person** entity. Consistent geo tuples (a `city`/`state`/`zip` that
+> agree) need a bundled reference dataset and are tracked as the next step on
+> [#473](https://github.com/timveil/bloviate/issues/473).
 
 ### Composite Keys & Foreign Key Fidelity
 

--- a/README.md
+++ b/README.md
@@ -470,9 +470,26 @@ entity is a pure function of `(seed, rowIndex)`, so the data is **reproducible a
 — sequential and parallel/partitioned fills produce identical values. Email and username carry a
 row-index suffix so they stay unique at scale.
 
-> The first release covers the **person** entity. Consistent geo tuples (a `city`/`state`/`zip` that
-> agree) need a bundled reference dataset and are tracked as the next step on
-> [#473](https://github.com/timveil/bloviate/issues/473).
+The same mechanism gives **consistent geo tuples**: `Places.unitedStates(...)` draws one real place
+per row from a bundled reference dataset, so a row's `city`, `state`, `zip`, and `area_code` agree (a
+real city in its real state with a valid local ZIP — not "Springfield, WY 90210"):
+
+```java
+import io.bloviate.datafaker.Geo;
+import io.bloviate.datafaker.Places;
+
+RowContext<Geo> place = Places.unitedStates(42L);
+
+Set<ColumnConfiguration> columns = Set.of(
+    new ColumnConfiguration("city",      place.project(Geo::city)),
+    new ColumnConfiguration("state",     place.project(Geo::stateAbbreviation)),
+    new ColumnConfiguration("zip",       place.project(Geo::zip)),
+    new ColumnConfiguration("area_code", place.project(Geo::areaCode))
+);
+```
+
+> The bundled geo dataset is a representative sample of US places, not exhaustive, and tuples repeat
+> across rows — keep `UNIQUE` columns on Bloviate's sequence/seeded generators.
 
 ### Composite Keys & Foreign Key Fidelity
 

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Geo.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Geo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+/**
+ * A real, internally consistent geographic tuple for one row: the {@code city}, {@code state}
+ * (and {@code stateAbbreviation}), {@code zip}, {@code areaCode}, and {@code country} all belong
+ * together (a real city in its real state with a valid local zip and area code) — not "Springfield,
+ * WY 90210". Drawn from a bundled reference dataset by {@link Places}; this is what Datafaker's
+ * independent address parts cannot provide.
+ *
+ * @since 2.12.0
+ * @see Places
+ * @see RowContext
+ */
+public record Geo(String city, String stateAbbreviation, String state, String zip, String areaCode, String country) {
+}

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/People.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/People.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.util.Mixers;
+import net.datafaker.Faker;
+import net.datafaker.service.RandomService;
+
+import java.util.Locale;
+import java.util.Random;
+
+/**
+ * Builds a {@link RowContext} of coherent {@link Person} identities for correlated person columns
+ * (issue #473). For each row a name is drawn from Datafaker, and the email, username, and full name
+ * are <em>derived from that name</em>, so the columns agree.
+ *
+ * <pre>{@code
+ * RowContext<Person> person = People.context(seed, Locale.ENGLISH);
+ * Set.of(
+ *     new ColumnConfiguration("first_name", person.project(Person::firstName)),
+ *     new ColumnConfiguration("last_name",  person.project(Person::lastName)),
+ *     new ColumnConfiguration("full_name",  person.project(Person::fullName)),
+ *     new ColumnConfiguration("email",      person.project(Person::email)),
+ *     new ColumnConfiguration("username",   person.project(Person::username)));
+ * }</pre>
+ *
+ * <p>The identity is a pure function of {@code (seed, rowIndex)} (mixed with splitmix64), so the data
+ * is reproducible and order-independent under parallel/partitioned fills. Email and username carry a
+ * row-index suffix ({@code jane.doe42@example.com}) so they are unique even at large row counts while
+ * still reading as derived from the name; the domain is the reserved {@code example.com}.
+ *
+ * @since 2.12.0
+ * @see RowContext
+ * @see Person
+ */
+public final class People {
+
+    private People() {
+    }
+
+    /**
+     * A context of coherent {@link Person} identities.
+     *
+     * @param seed   the group seed; vary it for a different (still reproducible) set of identities
+     * @param locale the locale for names (fixed for cross-machine reproducibility)
+     * @return a row context wireable via {@link RowContext#project}
+     */
+    public static RowContext<Person> context(long seed, Locale locale) {
+        return new RowContext<>(rowIndex -> build(seed, rowIndex, locale));
+    }
+
+    private static Person build(long seed, long rowIndex, Locale locale) {
+        Faker faker = new Faker(locale, new RandomService(new Random(Mixers.splitmix64(seed + rowIndex))));
+        String firstName = faker.name().firstName();
+        String lastName = faker.name().lastName();
+        String fullName = firstName + " " + lastName;
+        // derive a unique handle from the name so email/username agree with first/last and don't
+        // collide at scale
+        String handle = sanitize(firstName) + "." + sanitize(lastName) + rowIndex;
+        String email = handle + "@example.com";
+        return new Person(firstName, lastName, fullName, email, handle);
+    }
+
+    private static String sanitize(String value) {
+        return value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+    }
+}

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Person.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Person.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+/**
+ * A coherent person identity for one row: the {@code email}, {@code username}, and {@code fullName}
+ * are all <em>derived from</em> the same {@code firstName}/{@code lastName}, so columns that project
+ * different fields of the same {@link Person} agree (no "jane.doe with email bob@…"). Materialized
+ * once per row by {@link People}.
+ *
+ * @since 2.12.0
+ * @see People
+ * @see RowContext
+ */
+public record Person(String firstName, String lastName, String fullName, String email, String username) {
+}

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Places.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Places.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.util.Mixers;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds a {@link RowContext} of internally consistent {@link Geo} tuples for correlated geographic
+ * columns (issue #473). Unlike Datafaker's independent address parts (which yield "Springfield, WY
+ * 90210"), each row draws one <em>real</em> tuple from a bundled reference dataset, so the row's
+ * {@code city}, {@code state}, {@code zip}, and {@code area_code} columns agree.
+ *
+ * <pre>{@code
+ * RowContext<Geo> place = Places.unitedStates(seed);
+ * Set.of(
+ *     new ColumnConfiguration("city",      place.project(Geo::city)),
+ *     new ColumnConfiguration("state",     place.project(Geo::stateAbbreviation)),
+ *     new ColumnConfiguration("zip",       place.project(Geo::zip)),
+ *     new ColumnConfiguration("area_code", place.project(Geo::areaCode)));
+ * }</pre>
+ *
+ * <p>The tuple chosen for a row is a pure function of {@code (seed, rowIndex)}, so the data is
+ * reproducible and order-independent under parallel/partitioned fills. The bundled dataset is a
+ * representative sample of US cities, not exhaustive; tuples repeat across rows (geography is not
+ * unique), so do not route {@code UNIQUE} columns through it.
+ *
+ * @since 2.12.0
+ * @see RowContext
+ * @see Geo
+ */
+public final class Places {
+
+    private static final String COUNTRY = "United States";
+    private static final List<Geo> UNITED_STATES = load("/io/bloviate/datafaker/geo-us.csv");
+
+    private Places() {
+    }
+
+    /**
+     * A context of consistent US {@link Geo} tuples.
+     *
+     * @param seed the group seed; vary it for a different (still reproducible) sequence of places
+     * @return a row context wireable via {@link RowContext#project}
+     */
+    public static RowContext<Geo> unitedStates(long seed) {
+        List<Geo> tuples = UNITED_STATES;
+        int size = tuples.size();
+        return new RowContext<>(rowIndex -> tuples.get((int) Math.floorMod(Mixers.splitmix64(seed + rowIndex), size)));
+    }
+
+    /** The loaded reference tuples (package-private; for tests). */
+    static List<Geo> unitedStatesTuples() {
+        return UNITED_STATES;
+    }
+
+    private static List<Geo> load(String resource) {
+        List<Geo> tuples = new ArrayList<>();
+        try (InputStream in = Places.class.getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new IllegalStateException("missing geo reference dataset: " + resource);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    line = line.strip();
+                    if (line.isEmpty() || line.startsWith("#") || line.startsWith("city,")) {
+                        continue;
+                    }
+                    String[] fields = line.split(",");
+                    if (fields.length < 5) {
+                        continue;
+                    }
+                    tuples.add(new Geo(fields[0], fields[1], fields[2], fields[3], fields[4], COUNTRY));
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to load geo reference dataset: " + resource, e);
+        }
+        if (tuples.isEmpty()) {
+            throw new IllegalStateException("geo reference dataset is empty: " + resource);
+        }
+        return List.copyOf(tuples);
+    }
+}

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowContext.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowContext.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.db.ColumnGeneratorFactory;
+
+import java.util.function.Function;
+import java.util.function.LongFunction;
+
+/**
+ * Materializes one coherent <em>entity</em> per row (a {@link Person}, a geo tuple, …) and lets
+ * several columns project fields out of it, so correlated columns agree — issue #473 "referential
+ * realism".
+ *
+ * <p>This is how Bloviate keeps cross-column consistency without breaking its two core invariants.
+ * The entity for a row is a <strong>pure function of {@code (groupSeed, rowIndex)}</strong> (supplied
+ * as the {@code entityFactory}), so it is the same no matter the order columns are generated or how
+ * the table is partitioned across threads — sequential and parallel fills produce identical data. The
+ * result is cached per thread for the current row, so the participating columns of a row materialize
+ * the entity once between them, not once each.
+ *
+ * <p>Wire correlated columns by sharing <em>one</em> context and registering each as a
+ * {@link #project(Function) projection}:
+ *
+ * <pre>{@code
+ * RowContext<Person> person = People.context(seed, Locale.ENGLISH);
+ * Set.of(
+ *     new ColumnConfiguration("first_name", person.project(Person::firstName)),
+ *     new ColumnConfiguration("last_name",  person.project(Person::lastName)),
+ *     new ColumnConfiguration("email",      person.project(Person::email)));   // jane.doe…@example.com
+ * }</pre>
+ *
+ * @param <E> the entity type projected by the participating columns
+ * @since 2.12.0
+ * @see People
+ * @see RowProjectionGenerator
+ */
+public final class RowContext<E> {
+
+    private final LongFunction<E> entityFactory;
+    // per-thread, single-row cache: under intra-table partitioning several threads share this one
+    // context, so the cache must not be shared mutable state — ThreadLocal keeps each worker isolated
+    private final ThreadLocal<Memo<E>> memo = ThreadLocal.withInitial(Memo::new);
+
+    /**
+     * @param entityFactory a pure mapping from row index to the row's entity; must depend only on the
+     *                      row index (and a fixed seed it closes over) so output is order-independent
+     */
+    public RowContext(LongFunction<E> entityFactory) {
+        this.entityFactory = entityFactory;
+    }
+
+    /**
+     * Returns the entity for the given absolute row index, computing it at most once per row per
+     * thread.
+     *
+     * @param rowIndex the absolute, 0-based row index
+     * @return the row's entity
+     */
+    public E at(long rowIndex) {
+        Memo<E> current = memo.get();
+        if (!current.valid || current.rowIndex != rowIndex) {
+            current.entity = entityFactory.apply(rowIndex);
+            current.rowIndex = rowIndex;
+            current.valid = true;
+        }
+        return current.entity;
+    }
+
+    /**
+     * A {@link ColumnGeneratorFactory} that projects one field of this context's entity for each row.
+     * All projections of the same context stay in lockstep and consistent. The engine-supplied
+     * per-column {@code random} is intentionally ignored — the value comes from the shared entity.
+     *
+     * @param selector picks the field to emit (e.g. {@code Person::email})
+     * @return a factory wireable through {@code ColumnConfiguration}
+     */
+    public ColumnGeneratorFactory project(Function<E, String> selector) {
+        return random -> new RowProjectionGenerator<>(random, this, selector);
+    }
+
+    private static final class Memo<E> {
+        private long rowIndex;
+        private boolean valid;
+        private E entity;
+    }
+}

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowProjectionGenerator.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowProjectionGenerator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.gen.AbstractDataGenerator;
+import io.bloviate.gen.IndexedDataGenerator;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Function;
+import java.util.random.RandomGenerator;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Emits one field of a {@link RowContext}'s per-row entity. Several projections of the same context
+ * share that context, so they produce a consistent tuple per row (issue #473).
+ *
+ * <p>Each projection keeps its own row counter and is {@link IndexedDataGenerator seekable}, so the
+ * projections of a row advance in lockstep, stay order-independent, and reproduce the sequential
+ * output under intra-table partitioning (each partition seeks to its first row, then walks). The
+ * value is a pure function of the row index via the shared context, so partitioned output is
+ * byte-identical to a sequential fill.
+ *
+ * @param <E> the entity type
+ * @since 2.12.0
+ */
+public final class RowProjectionGenerator<E> extends AbstractDataGenerator<String> implements IndexedDataGenerator {
+
+    private final RowContext<E> context;
+    private final Function<E, String> selector;
+    private final AtomicLong counter = new AtomicLong(0);
+
+    RowProjectionGenerator(RandomGenerator random, RowContext<E> context, Function<E, String> selector) {
+        super(random);
+        this.context = context;
+        this.selector = selector;
+    }
+
+    @Override
+    public String generate() {
+        return selector.apply(context.at(counter.getAndIncrement()));
+    }
+
+    @Override
+    public void seek(long rowIndex) {
+        if (rowIndex < 0) {
+            throw new IllegalArgumentException("rowIndex must be non-negative: " + rowIndex);
+        }
+        counter.set(rowIndex);
+    }
+
+    @Override
+    public String get(ResultSet resultSet, int columnIndex) throws SQLException {
+        return resultSet.getString(columnIndex);
+    }
+}

--- a/bloviate-datafaker/src/main/resources/io/bloviate/datafaker/geo-us.csv
+++ b/bloviate-datafaker/src/main/resources/io/bloviate/datafaker/geo-us.csv
@@ -1,0 +1,96 @@
+# Reference dataset of real, internally consistent US geographic tuples used by io.bloviate.datafaker.Places.
+# Each row is one coherent place: a real city in its state with a valid local ZIP and area code.
+# Format: city,stateAbbreviation,state,zip,areaCode   (country is United States)
+# Lines starting with '#' and the header row are ignored.
+city,stateAbbreviation,state,zip,areaCode
+New York,NY,New York,10001,212
+Brooklyn,NY,New York,11201,718
+Buffalo,NY,New York,14202,716
+Rochester,NY,New York,14604,585
+Los Angeles,CA,California,90001,213
+San Francisco,CA,California,94103,415
+San Diego,CA,California,92101,619
+San Jose,CA,California,95113,408
+Sacramento,CA,California,95814,916
+Fresno,CA,California,93721,559
+Long Beach,CA,California,90802,562
+Oakland,CA,California,94607,510
+Chicago,IL,Illinois,60601,312
+Springfield,IL,Illinois,62701,217
+Houston,TX,Texas,77002,713
+Dallas,TX,Texas,75201,214
+Austin,TX,Texas,78701,512
+San Antonio,TX,Texas,78205,210
+Fort Worth,TX,Texas,76102,817
+El Paso,TX,Texas,79901,915
+Phoenix,AZ,Arizona,85003,602
+Tucson,AZ,Arizona,85701,520
+Mesa,AZ,Arizona,85201,480
+Philadelphia,PA,Pennsylvania,19103,215
+Pittsburgh,PA,Pennsylvania,15222,412
+Columbus,OH,Ohio,43215,614
+Cleveland,OH,Ohio,44114,216
+Cincinnati,OH,Ohio,45202,513
+Indianapolis,IN,Indiana,46204,317
+Detroit,MI,Michigan,48226,313
+Grand Rapids,MI,Michigan,49503,616
+Charlotte,NC,North Carolina,28202,704
+Raleigh,NC,North Carolina,27601,919
+Seattle,WA,Washington,98101,206
+Spokane,WA,Washington,99201,509
+Denver,CO,Colorado,80202,303
+Colorado Springs,CO,Colorado,80903,719
+Washington,DC,District of Columbia,20001,202
+Boston,MA,Massachusetts,02108,617
+Nashville,TN,Tennessee,37203,615
+Memphis,TN,Tennessee,38103,901
+Portland,OR,Oregon,97205,503
+Las Vegas,NV,Nevada,89101,702
+Reno,NV,Nevada,89501,775
+Louisville,KY,Kentucky,40202,502
+Baltimore,MD,Maryland,21202,410
+Milwaukee,WI,Wisconsin,53202,414
+Madison,WI,Wisconsin,53703,608
+Albuquerque,NM,New Mexico,87102,505
+Atlanta,GA,Georgia,30303,404
+Savannah,GA,Georgia,31401,912
+Miami,FL,Florida,33130,305
+Orlando,FL,Florida,32801,407
+Tampa,FL,Florida,33602,813
+Jacksonville,FL,Florida,32202,904
+Kansas City,MO,Missouri,64106,816
+Saint Louis,MO,Missouri,63101,314
+Omaha,NE,Nebraska,68102,402
+Minneapolis,MN,Minnesota,55401,612
+Saint Paul,MN,Minnesota,55102,651
+New Orleans,LA,Louisiana,70112,504
+Baton Rouge,LA,Louisiana,70801,225
+Oklahoma City,OK,Oklahoma,73102,405
+Tulsa,OK,Oklahoma,74103,918
+Salt Lake City,UT,Utah,84101,801
+Boise,ID,Idaho,83702,208
+Honolulu,HI,Hawaii,96813,808
+Anchorage,AK,Alaska,99501,907
+Richmond,VA,Virginia,23219,804
+Virginia Beach,VA,Virginia,23451,757
+Hartford,CT,Connecticut,06103,860
+Providence,RI,Rhode Island,02903,401
+Newark,NJ,New Jersey,07102,973
+Jersey City,NJ,New Jersey,07302,201
+Birmingham,AL,Alabama,35203,205
+Montgomery,AL,Alabama,36104,334
+Little Rock,AR,Arkansas,72201,501
+Des Moines,IA,Iowa,50309,515
+Wichita,KS,Kansas,67202,316
+Jackson,MS,Mississippi,39201,601
+Columbia,SC,South Carolina,29201,803
+Charleston,SC,South Carolina,29401,843
+Sioux Falls,SD,South Dakota,57104,605
+Fargo,ND,North Dakota,58102,701
+Billings,MT,Montana,59101,406
+Cheyenne,WY,Wyoming,82001,307
+Burlington,VT,Vermont,05401,802
+Manchester,NH,New Hampshire,03101,603
+Portland,ME,Maine,04101,207
+Wilmington,DE,Delaware,19801,302
+Charleston,WV,West Virginia,25301,304

--- a/bloviate-datafaker/src/test/java/io/bloviate/datafaker/GeoRealismTest.java
+++ b/bloviate-datafaker/src/test/java/io/bloviate/datafaker/GeoRealismTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.gen.IndexedDataGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the issue #473 geo tuples: each row draws one real, internally consistent place from the
+ * bundled reference dataset, and columns projecting it agree — reproducibly and order-independently.
+ */
+class GeoRealismTest {
+
+    private static final long SEED = 42L;
+
+    private static DataGenerator<?> projection(RowContext<Geo> context, java.util.function.Function<Geo, String> selector) {
+        return context.project(selector).create(RandomGenerators.create(0));
+    }
+
+    @Test
+    void referenceDatasetIsWellFormed() {
+        var tuples = Places.unitedStatesTuples();
+        assertTrue(tuples.size() >= 50, "expected a representative dataset but had " + tuples.size());
+        for (Geo geo : tuples) {
+            assertTrue(!geo.city().isBlank(), "blank city");
+            assertEquals(2, geo.stateAbbreviation().length(), "state abbreviation must be 2 chars: " + geo);
+            assertTrue(geo.zip().matches("\\d{5}"), "zip must be 5 digits: " + geo);
+            assertTrue(geo.areaCode().matches("\\d{3}"), "area code must be 3 digits: " + geo);
+            assertEquals("United States", geo.country());
+        }
+    }
+
+    @Test
+    void eachRowIsOneRealConsistentTuple() {
+        // because at() always returns a whole tuple from the dataset, city/state/zip/areaCode agree
+        RowContext<Geo> place = Places.unitedStates(SEED);
+        for (long row = 0; row < 500; row++) {
+            assertTrue(Places.unitedStatesTuples().contains(place.at(row)),
+                    "row " + row + " produced a tuple not in the reference dataset: " + place.at(row));
+        }
+    }
+
+    @Test
+    void columnsProjectingTheSameContextAgreeRowByRow() {
+        RowContext<Geo> place = Places.unitedStates(SEED);
+        DataGenerator<?> city = projection(place, Geo::city);
+        DataGenerator<?> state = projection(place, Geo::stateAbbreviation);
+        DataGenerator<?> zip = projection(place, Geo::zip);
+        DataGenerator<?> areaCode = projection(place, Geo::areaCode);
+
+        for (long row = 0; row < 200; row++) {
+            Geo expected = place.at(row);
+            assertEquals(expected.city(), city.generate(), "row " + row + " city");
+            assertEquals(expected.stateAbbreviation(), state.generate(), "row " + row + " state");
+            assertEquals(expected.zip(), zip.generate(), "row " + row + " zip");
+            assertEquals(expected.areaCode(), areaCode.generate(), "row " + row + " area code");
+        }
+    }
+
+    @Test
+    void sameSeedIsReproducible() {
+        RowContext<Geo> a = Places.unitedStates(SEED);
+        RowContext<Geo> b = Places.unitedStates(SEED);
+        for (long row = 0; row < 1_000; row++) {
+            assertEquals(a.at(row), b.at(row), "same seed must reproduce the same place at row " + row);
+        }
+    }
+
+    @Test
+    void seekReproducesSequentialOutputForPartitioning() {
+        RowContext<Geo> place = Places.unitedStates(SEED);
+
+        DataGenerator<?> sequential = projection(place, Geo::zip);
+        String[] expected = new String[60];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = (String) sequential.generate();
+        }
+        for (int start : new int[]{0, 1, 23, 59}) {
+            DataGenerator<?> seeker = projection(place, Geo::zip);
+            ((IndexedDataGenerator) seeker).seek(start);
+            for (int i = start; i < expected.length; i++) {
+                assertEquals(expected[i], seeker.generate(), "seek(" + start + ") must match sequential zip at row " + i);
+            }
+        }
+    }
+}

--- a/bloviate-datafaker/src/test/java/io/bloviate/datafaker/ReferentialRealismTest.java
+++ b/bloviate-datafaker/src/test/java/io/bloviate/datafaker/ReferentialRealismTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.datafaker;
+
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.gen.IndexedDataGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies issue #473 referential realism: columns projecting the same {@link RowContext} produce a
+ * mutually consistent, reproducible, order-independent tuple per row.
+ */
+class ReferentialRealismTest {
+
+    private static final long SEED = 42L;
+
+    private static DataGenerator<?> projection(RowContext<Person> context, java.util.function.Function<Person, String> selector) {
+        return context.project(selector).create(RandomGenerators.create(0));
+    }
+
+    @Test
+    void derivedFieldsAgreeWithTheName() {
+        Person person = People.context(SEED, Locale.ENGLISH).at(7);
+        assertEquals(person.firstName() + " " + person.lastName(), person.fullName(), "full name must match its parts");
+        assertEquals(person.username() + "@example.com", person.email(), "email must be the username at the reserved domain");
+        String expectedHandle = person.firstName().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+        assertTrue(person.email().toLowerCase(Locale.ROOT).contains(expectedHandle), "email should be derived from the first name: " + person.email());
+    }
+
+    @Test
+    void columnsProjectingTheSameContextStayConsistentRowByRow() {
+        RowContext<Person> person = People.context(SEED, Locale.ENGLISH);
+        DataGenerator<?> firstName = projection(person, Person::firstName);
+        DataGenerator<?> lastName = projection(person, Person::lastName);
+        DataGenerator<?> fullName = projection(person, Person::fullName);
+        DataGenerator<?> email = projection(person, Person::email);
+        DataGenerator<?> username = projection(person, Person::username);
+
+        for (int row = 0; row < 100; row++) {
+            // generate one cell per column, in column order, exactly as the fill loop does
+            String f = (String) firstName.generate();
+            String l = (String) lastName.generate();
+            String full = (String) fullName.generate();
+            String e = (String) email.generate();
+            String u = (String) username.generate();
+
+            assertEquals(f + " " + l, full, "row " + row + ": full name inconsistent");
+            assertEquals(u + "@example.com", e, "row " + row + ": email inconsistent with username");
+        }
+    }
+
+    @Test
+    void sameSeedIsReproducible() {
+        RowContext<Person> a = People.context(SEED, Locale.ENGLISH);
+        RowContext<Person> b = People.context(SEED, Locale.ENGLISH);
+        for (long row = 0; row < 1_000; row++) {
+            assertEquals(a.at(row), b.at(row), "same seed must reproduce the same identity at row " + row);
+        }
+    }
+
+    @Test
+    void differentSeedsDiffer() {
+        Person a = People.context(1L, Locale.ENGLISH).at(0);
+        Person b = People.context(2L, Locale.ENGLISH).at(0);
+        assertTrue(!a.equals(b), "different seeds should generally yield different identities");
+    }
+
+    @Test
+    void emailsAreUniqueAcrossRows() {
+        RowContext<Person> person = People.context(SEED, Locale.ENGLISH);
+        java.util.Set<String> emails = new java.util.HashSet<>();
+        for (long row = 0; row < 5_000; row++) {
+            assertTrue(emails.add(person.at(row).email()), "email collided at row " + row);
+        }
+    }
+
+    @Test
+    void seekReproducesSequentialOutputForPartitioning() {
+        RowContext<Person> person = People.context(SEED, Locale.ENGLISH);
+
+        DataGenerator<?> sequential = projection(person, Person::email);
+        String[] expected = new String[50];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = (String) sequential.generate();
+        }
+
+        for (int start : new int[]{0, 1, 17, 49}) {
+            DataGenerator<?> seeker = projection(person, Person::email);
+            ((IndexedDataGenerator) seeker).seek(start);
+            for (int i = start; i < expected.length; i++) {
+                assertEquals(expected[i], seeker.generate(), "seek(" + start + ") must match sequential email at row " + i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Phase 2 of semantic/realistic data (#473, builds on #472). Makes correlated columns **agree** — `full_name` matches `first_name`/`last_name`, and `email`/`username` derive from the row's name — without breaking reproducibility or parallelism. No core-engine change.

## Mechanism (the approved design)
A **`RowContext<E>`** materializes one entity per row as a **pure function of `(seed, rowIndex)`** (cached per thread for the current row). Correlated columns share one context and register as **projections** through the existing `ColumnConfiguration`:

```java
RowContext<Person> person = People.context(42L, Locale.ENGLISH);
Set.of(
    new ColumnConfiguration("first_name", person.project(Person::firstName)),
    new ColumnConfiguration("last_name",  person.project(Person::lastName)),
    new ColumnConfiguration("full_name",  person.project(Person::fullName)),
    new ColumnConfiguration("email",      person.project(Person::email)),    // jane.doe7@example.com
    new ColumnConfiguration("username",   person.project(Person::username)));
```

- **Order-independent & partition-safe** — `RowProjectionGenerator` keeps a per-row counter and implements `IndexedDataGenerator.seek`, so projections advance in lockstep and reproduce the sequential output byte-for-byte under intra-table partitioning. Because the entity is pure in `(seed, rowIndex)`, sequential and parallel fills are identical.
- **Thread-safe** — the per-row cache is a `ThreadLocal`, so a shared context used across partition workers has no shared mutable state.
- **Safe defaults** — reserved `example.com`; email/username carry a row-index suffix for uniqueness at scale.

## Scope
Explicit declaration + **person-only** first cut, as agreed. Consistent **geo tuples** (city/state/zip that agree) need a bundled reference dataset and are the next step, tracked on #473.

## Tests & docs
6 tests — field consistency, reproducibility, row-by-row lockstep, uniqueness, and `seek` == sequential. README ("Correlated Columns") + ARCHITECTURE updated; the "Why Bloviate" limitation now points at the opt-in realistic layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)