### PR TITLE
ci(release): pin semantic-release toolchain to restore release notes

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -77,13 +77,18 @@ jobs:
           node-version: '24'
           
       - name: Install semantic-release
+        # Versions are PINNED. Unpinned installs let conventional-changelog-conventionalcommits drift
+        # to a major (v10) incompatible with semantic-release 24's bundled release-notes-generator
+        # (which expects v8); that silently produced empty release notes / CHANGELOG entries while
+        # commit-analyzer kept bumping versions. Keep semantic-release at 24 and the preset at 8.
         run: |
-          npm install -g semantic-release
-          npm install -g @semantic-release/changelog
-          npm install -g @semantic-release/git
-          npm install -g @semantic-release/github
-          npm install -g @semantic-release/exec
-          npm install -g conventional-changelog-conventionalcommits
+          npm install -g \
+            semantic-release@24 \
+            @semantic-release/changelog@6 \
+            @semantic-release/git@10 \
+            @semantic-release/github@11 \
+            @semantic-release/exec@7 \
+            conventional-changelog-conventionalcommits@8
 
       - name: Create semantic-release config
         run: |

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ public class MyGenerators implements GeneratorPlugin {
 
 ### Semantic / Realistic Data (`bloviate-datafaker`)
 
-By default an `email VARCHAR` gets random text, not a plausible email. The optional
+The type-driven default fills an `email VARCHAR` from its type (random text). The optional
 **`bloviate-datafaker`** module maps common column **names** (`email`, `first_name`, `phone`, `city`,
 `zip`, …) to realistic [Datafaker](https://www.datafaker.net/) values — keeping the core
 dependency-free (Datafaker only lands if you add this module).


### PR DESCRIPTION
Fixes the broken changelog/release-notes you flagged: every release since **2.5.0** has an empty CHANGELOG entry **and** an empty GitHub release body — just the `## [x.y.z](…) (date)` header, no Features/Fixes — even though versions kept bumping.

## Root cause
The release workflow installs the semantic-release toolchain **globally and unpinned**. Around 2026-06-27, `conventional-changelog-conventionalcommits` drifted to a **new major (v10)** that's incompatible with the `release-notes-generator` bundled in **semantic-release 24** (which expects **v8**). Version bumping still worked (`commit-analyzer` uses `releaseRules`, unaffected), but note generation silently emitted an empty body. Worked on 06-26 (≤2.4.0), broke on 06-27 (2.5.0+) with the *same config* — classic unpinned-dependency drift.

## Verified locally (not guessed)
Running the **same** `release-notes-generator` over the **same** sample commits:

| preset version | output |
|---|---|
| `conventionalcommits@8` | **298 chars** — `### Features` + `### Bug Fixes` with the commits |
| `conventionalcommits@10` (current latest) | **85 chars** — only the version header, no sections |

The v10 output is byte-for-byte the shape of the broken entries.

## Fix
Pin the install to `semantic-release@24` + `conventional-changelog-conventionalcommits@8` (and pinned companion plugins), in a single `npm install -g` for one consistent tree. Future releases will again include Features/Fixes sections.

(Also includes a one-line docs tweak neutralizing the "type-driven default" phrasing in the realistic-data section.)

### Not included
The **already-published** 2.5.0–2.15.0 entries stay empty — this fixes generation going forward. I can backfill the historical CHANGELOG in a follow-up (regenerating each tag's notes with the pinned preset) if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)