### PR TITLE
build: give the core and parent artifacts meaningful descriptions

### DIFF
--- a/bloviate-core/pom.xml
+++ b/bloviate-core/pom.xml
@@ -31,7 +31,7 @@
     <packaging>jar</packaging>
 
     <name>Bloviate Core</name>
-    <description>Dummy data generator for Java</description>
+    <description>Bloviate's dependency-free engine: auto-discovers a JDBC schema and fills it with reproducible, foreign-key-aware test data (and CSV/TSV files)</description>
 
     <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <packaging>pom</packaging>
 
     <name>Bloviate Parent</name>
-    <description>Dummy data generator for Java</description>
+    <description>Reproducible, foreign-key-aware test-data generator for JDBC databases and flat files</description>
     <url>https://github.com/timveil/bloviate</url>
     <inceptionYear>2020</inceptionYear>
     <licenses>


### PR DESCRIPTION
The GitHub **Packages** pages show each Maven artifact's `pom.xml` `<description>`. `bloviate-parent` and `bloviate-core` both still said the generic **"Dummy data generator for Java"**; the other modules already have meaningful descriptions.

| Artifact | New description |
|---|---|
| `bloviate-parent` | Reproducible, foreign-key-aware test-data generator for JDBC databases and flat files |
| `bloviate-core` | Bloviate's dependency-free engine: auto-discovers a JDBC schema and fills it with reproducible, foreign-key-aware test data (and CSV/TSV files) |

Landed as **`build:`** (→ patch release) so the artifacts **republish immediately** and the Packages pages pick up the new descriptions, rather than waiting for the next feature release. As a bonus this is the first release to run through the notes pipeline fixed in #493, so it doubles as an end-to-end check that release notes are working again.

(The repo's "About" description is separate and already good.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)