### PR TITLE
docs: add detailed Javadoc across the public API

### DIFF
--- a/bloviate-core/src/main/java/io/bloviate/db/Fillable.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/Fillable.java
@@ -19,18 +19,21 @@ package io.bloviate.db;
 import java.sql.SQLException;
 
 /**
- * Interface for objects that can be filled with generated data.
- * Implementations of this interface can populate database tables
- * or other data structures with synthetic data.
+ * Contract for components that populate a target with generated data.
+ *
+ * <p>A {@code Fillable} drives a one-shot fill operation: invoking {@link #fill()} runs the work to
+ * completion (or fails), rather than returning a stream or builder. The two engine entry points
+ * implement it — {@link DatabaseFiller} fills an entire database in dependency order and
+ * {@link TableFiller} fills a single table — so callers can treat either uniformly.
  *
  * @since 1.0.0
  */
 public interface Fillable {
 
     /**
-     * Fills the target with generated data.
+     * Fills the target with generated data, running the operation to completion.
      *
-     * @throws SQLException if a database access error occurs during the fill operation
+     * @throws SQLException if any database access error occurs during the fill operation
      */
     void fill() throws SQLException;
 }

--- a/bloviate-core/src/main/java/io/bloviate/db/ForeignKey.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/ForeignKey.java
@@ -19,9 +19,15 @@ package io.bloviate.db;
 import java.util.List;
 
 /**
- * Represents a foreign key constraint in a database table.
- * A foreign key establishes a link between data in two tables by referencing
- * the primary key of another table.
+ * A foreign-key relationship: the columns of one table that reference the {@link PrimaryKey} of
+ * another.
+ *
+ * <p>This is the edge that drives the fill engine's topological ordering — the referenced (parent)
+ * table must be populated before the table that depends on it, so {@link DatabaseFiller} builds its
+ * dependency graph from these relationships. It also lets {@link TableFiller} seed a foreign-key
+ * column from its associated primary-key column so the generated values line up. Like a primary key,
+ * a foreign key may span several columns, paired in order with the primary-key columns they
+ * reference.
  *
  * @param foreignKeyColumns the columns that make up the foreign key
  * @param primaryKey the primary key that this foreign key references

--- a/bloviate-core/src/main/java/io/bloviate/db/Key.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/Key.java
@@ -17,9 +17,13 @@
 package io.bloviate.db;
 
 /**
- * Represents a key relationship between two database tables.
- * This record encapsulates the metadata about a foreign key constraint,
- * including the tables and columns involved in the relationship.
+ * One column-level link of a foreign-key relationship between two tables.
+ *
+ * <p>Each instance maps a single foreign-key column to the primary-key column it references, naming
+ * both tables and columns involved. For a composite foreign key the relationship is described by
+ * several {@code Key} rows that share a constraint {@code name} and are ordered by {@code sequence};
+ * a simple key is just one such row. This is the flat, JDBC-metadata-shaped view from which the
+ * richer {@link ForeignKey}/{@link KeyColumn} structures are assembled.
  *
  * @param primaryTableName the name of the table containing the primary key
  * @param primaryColumnName the name of the primary key column

--- a/bloviate-core/src/main/java/io/bloviate/db/KeyColumn.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/KeyColumn.java
@@ -17,8 +17,12 @@
 package io.bloviate.db;
 
 /**
- * Represents a column that is part of a key (primary or foreign) in a database table.
- * This record pairs a column with its position in a composite key.
+ * One column of a possibly-composite key, paired with its position within that key.
+ *
+ * <p>It joins a {@link Column} to its 1-based {@code sequence} in the enclosing primary or foreign
+ * key, so a multi-column key is described by several {@code KeyColumn}s in declared order. A simple
+ * key holds a single instance at sequence {@code 1}. Preserving the position matters because the
+ * columns of a foreign key must align with the primary-key columns they reference.
  *
  * @param sequence the ordinal position of this column in a composite key (1-based)
  * @param column the column that is part of the key

--- a/bloviate-core/src/main/java/io/bloviate/db/PrimaryKey.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/PrimaryKey.java
@@ -19,9 +19,12 @@ package io.bloviate.db;
 import java.util.List;
 
 /**
- * Represents a primary key constraint in a database table.
- * A primary key uniquely identifies each record in a table and can consist
- * of one or more columns (composite key).
+ * The primary key of a database table — the column or columns that uniquely identify each row.
+ *
+ * <p>A primary key may be simple (one column) or composite (several), so it carries an ordered list
+ * of {@link KeyColumn}s whose sequence positions preserve the declared key order. The fill engine
+ * uses this both to recognize key columns when choosing generators and as the reference target that
+ * {@link ForeignKey}s point at.
  *
  * @param tableName the name of the table containing this primary key
  * @param keyColumns the ordered list of columns that comprise this primary key

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -92,6 +92,21 @@ public class TableFiller implements Fillable {
         this.rangeEndExclusive = 0;
     }
 
+    /**
+     * Fills this single table with generated data, respecting its column types and foreign-key
+     * relationships.
+     *
+     * <p>Generators are resolved once per column (per-column override, then custom registry, then
+     * any applicable {@code CHECK}/enum constraint, then the {@link DatabaseSupport} default) and the
+     * engine seeds each one for reproducibility. Rows are then produced in batches of the configured
+     * size and inserted through a {@link PreparedStatement}. Unless the {@link CommitStrategy} leaves
+     * the connection on its default, the engine owns the transaction: autocommit is turned off for the
+     * fill, commits happen at the configured cadence, the work is rolled back on error, and the prior
+     * autocommit setting is restored on completion. When a row range is configured this fills only that
+     * one partition; otherwise it fills the whole table.
+     *
+     * @throws SQLException if any database access error occurs during the fill operation
+     */
     @Override
     public void fill() throws SQLException {
 
@@ -309,6 +324,15 @@ public class TableFiller implements Fillable {
     }
 
 
+    /**
+     * Builder for constructing {@link TableFiller} instances.
+     *
+     * <p>Follows the builder pattern to assemble a filler for one table: the connection, database
+     * metadata, and {@link DatabaseConfiguration} are required, while the target table, an optional
+     * {@link CommitStrategy} override, and an optional row range are set fluently before
+     * {@link #build()}. A {@code TableFiller} is typically created by {@link DatabaseFiller} once the
+     * fill order has been determined.
+     */
     public static class Builder {
 
         private final Connection connection;
@@ -321,17 +345,38 @@ public class TableFiller implements Fillable {
         private long rangeStartInclusive;
         private long rangeEndExclusive;
 
+        /**
+         * Creates a builder for a filler bound to the given connection, database metadata, and
+         * configuration.
+         *
+         * @param connection the database connection to fill on
+         * @param database the database metadata, used to resolve tables and foreign-key relationships
+         * @param databaseConfiguration the configuration controlling batch size, row counts, seed, and commit behavior
+         */
         public Builder(Connection connection, Database database, DatabaseConfiguration databaseConfiguration) {
             this.connection = connection;
             this.database = database;
             this.databaseConfiguration = databaseConfiguration;
         }
 
+        /**
+         * Sets the table to fill by resolving its name against the database metadata (case-insensitive).
+         *
+         * @param tableName the name of the table to fill
+         * @return this builder
+         * @throws IllegalArgumentException if no table with the given name exists
+         */
         public Builder table(String tableName) {
             this.table = database.getTable(tableName);
             return this;
         }
 
+        /**
+         * Sets the table to fill directly from its metadata.
+         *
+         * @param table the table to fill
+         * @return this builder
+         */
         public Builder table(Table table) {
             this.table = table;
             return this;
@@ -370,6 +415,11 @@ public class TableFiller implements Fillable {
             return this;
         }
 
+        /**
+         * Builds a {@link TableFiller} from the configured parameters.
+         *
+         * @return a new filler ready to fill the configured table
+         */
         public TableFiller build() {
             return new TableFiller(this);
         }

--- a/bloviate-core/src/main/java/io/bloviate/ext/DefaultSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/DefaultSupport.java
@@ -16,6 +16,18 @@
 
 package io.bloviate.ext;
 
+/**
+ * Fallback {@link DatabaseSupport} for generic or unknown JDBC databases.
+ *
+ * <p>This support adds no vendor-specific generators on top of {@link AbstractDatabaseSupport}, so it
+ * handles only the standard JDBC types every driver reports. It is used when no product-specific
+ * support (PostgreSQL, MySQL, CockroachDB, etc.) matches the database, providing reasonable default
+ * behavior at the cost of not understanding any non-standard, vendor-specific column types.
+ *
+ * @since 1.0.0
+ * @see AbstractDatabaseSupport
+ * @see DatabaseSupport
+ */
 public class DefaultSupport extends AbstractDatabaseSupport {
 
 }

--- a/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
@@ -41,6 +41,16 @@ import java.util.Map;
  */
 public class MySQLSupport extends AbstractDatabaseSupport {
 
+    /**
+     * Returns {@code rewriteBatchedStatements}, the MySQL Connector/J parameter that rewrites a batch
+     * of single-row {@code INSERT}s into one multi-row statement. Enabling it (e.g.
+     * {@code jdbc:mysql://host/db?rewriteBatchedStatements=true}) collapses many round trips into one
+     * and is often the single biggest fill speedup; Bloviate logs a one-time recommendation when a
+     * fill connection's URL does not set it.
+     *
+     * @return the {@code rewriteBatchedStatements} parameter name
+     * @since 2.10.0
+     */
     @Override
     public String batchRewriteUrlParameter() {
         return "rewriteBatchedStatements";

--- a/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
@@ -67,6 +67,16 @@ import java.util.Map;
  */
 public class PostgresSupport extends AbstractDatabaseSupport {
 
+    /**
+     * Returns {@code reWriteBatchedInserts}, the PostgreSQL JDBC driver parameter that rewrites a
+     * batch of single-row {@code INSERT}s into one multi-row statement. Enabling it (e.g.
+     * {@code jdbc:postgresql://host/db?reWriteBatchedInserts=true}) drastically cuts the number of
+     * round trips and is often the single biggest fill speedup; Bloviate logs a one-time
+     * recommendation when a fill connection's URL does not set it.
+     *
+     * @return the {@code reWriteBatchedInserts} parameter name
+     * @since 2.10.0
+     */
     @Override
     public String batchRewriteUrlParameter() {
         return "reWriteBatchedInserts";

--- a/bloviate-core/src/main/java/io/bloviate/file/CsvFile.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/CsvFile.java
@@ -16,8 +16,15 @@
 
 package io.bloviate.file;
 
+/**
+ * {@link FileDefinition} for comma-delimited (CSV) output. Fields are separated by a
+ * comma ({@code ,}).
+ */
 public class CsvFile extends FileDefinition {
 
+    /**
+     * Constructs a new CSV file definition using the {@link FileType#CSV} format.
+     */
     public CsvFile() {
         super(FileType.CSV);
     }

--- a/bloviate-core/src/main/java/io/bloviate/file/FileGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/FileGenerator.java
@@ -16,9 +16,23 @@
 
 package io.bloviate.file;
 
+/**
+ * Generates output files from a set of column definitions.
+ *
+ * <p>Implementations write generated data to disk and can also export their own
+ * configuration as YAML.
+ */
 public interface FileGenerator {
 
+    /**
+     * Generates the output data file, writing one header row followed by the configured
+     * number of data rows.
+     */
     void generate();
 
+    /**
+     * Exports this generator's configuration to a YAML file (named after the generator's
+     * base file name with a {@code .yaml} extension).
+     */
     void yaml();
 }

--- a/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
@@ -170,26 +170,58 @@ public class FlatFileGenerator implements FileGenerator {
         }
 
 
+        /**
+         * Sets the output file format definition. Defaults to {@link CsvFile} (CSV output)
+         * when not specified.
+         *
+         * @param fileDefinition the file format definition controlling the delimiter and extension
+         * @return this builder, for chaining
+         */
         public Builder output(FileDefinition fileDefinition) {
             this.definition = fileDefinition;
             return this;
         }
 
+        /**
+         * Replaces the column definitions with the supplied list. The columns are written in the
+         * order given, one delimited field per column.
+         *
+         * @param columnDefinitions the column definitions to use
+         * @return this builder, for chaining
+         */
         public Builder addAll(List<ColumnDefinition> columnDefinitions) {
             this.columnDefinitions = columnDefinitions;
             return this;
         }
 
+        /**
+         * Appends a single column definition to the existing list of columns.
+         *
+         * @param columnDefinition the column definition to append
+         * @return this builder, for chaining
+         */
         public Builder add(ColumnDefinition columnDefinition) {
             this.columnDefinitions.add(columnDefinition);
             return this;
         }
 
+        /**
+         * Sets the number of data rows to generate, excluding the header row. Defaults to
+         * {@code 1000} when not specified.
+         *
+         * @param rows the number of data rows to write
+         * @return this builder, for chaining
+         */
         public Builder rows(long rows) {
             this.rows = rows;
             return this;
         }
 
+        /**
+         * Builds a new {@link FlatFileGenerator} from this builder's configuration.
+         *
+         * @return a configured {@link FlatFileGenerator}
+         */
         public FlatFileGenerator build() {
             return new FlatFileGenerator(this);
         }

--- a/bloviate-core/src/main/java/io/bloviate/file/PipeDelimitedFile.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/PipeDelimitedFile.java
@@ -16,8 +16,15 @@
 
 package io.bloviate.file;
 
+/**
+ * {@link FileDefinition} for pipe-delimited output. Fields are separated by a
+ * pipe character ({@code |}).
+ */
 public class PipeDelimitedFile extends FileDefinition {
 
+    /**
+     * Constructs a new pipe-delimited file definition using the {@link FileType#PIPE} format.
+     */
     public PipeDelimitedFile() {
         super(FileType.PIPE);
     }

--- a/bloviate-core/src/main/java/io/bloviate/file/TabDelimitedFile.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/TabDelimitedFile.java
@@ -16,8 +16,15 @@
 
 package io.bloviate.file;
 
+/**
+ * {@link FileDefinition} for tab-delimited (TSV) output. Fields are separated by a
+ * tab character ({@code \t}).
+ */
 public class TabDelimitedFile extends FileDefinition {
 
+    /**
+     * Constructs a new tab-delimited file definition using the {@link FileType#TDV} format.
+     */
     public TabDelimitedFile() {
         super(FileType.TDV);
     }

--- a/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
@@ -25,6 +25,16 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates {@link BigDecimal} values sized to a column's declared precision and scale using
+ * the seeded random source, so a given seed yields a reproducible sequence. When a precision
+ * is configured the value has up to {@code maxPrecision} total significant digits with
+ * {@code maxDigits} of them to the right of the decimal point; both bounds are capped at
+ * {@code 25} to keep test values manageable (some databases report enormous precision). When
+ * no precision is configured the value falls back to one produced by a {@link DoubleGenerator}.
+ * For a value constrained to an explicit numeric range and fixed scale see
+ * {@link ScaledBigDecimalGenerator}; for a fixed value see {@link StaticBigDecimalGenerator}.
+ */
 public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
 
     // this is the number of digits on both sides of the decimal point, can be null
@@ -89,15 +99,37 @@ public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
         private Integer maxPrecision;
         private Integer maxDigits;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the maximum total precision: the number of significant digits on both sides of the
+         * decimal point. May be {@code null} (the default), in which case the value falls back to a
+         * {@link DoubleGenerator} result. When set, the effective precision is capped at {@code 25}.
+         *
+         * @param maxPrecision the maximum total number of significant digits, or {@code null} for none
+         * @return this builder, for chaining
+         */
         public Builder precision(Integer maxPrecision) {
             this.maxPrecision = maxPrecision;
             return this;
         }
 
+        /**
+         * Sets the maximum scale: the number of fractional digits to the right of the decimal point.
+         * May be {@code null} (the default), which is treated as a scale of {@code 0}. The effective
+         * scale is capped at the effective precision, and must not exceed the configured precision or
+         * {@link #build()} will produce a generator that throws at generation time.
+         *
+         * @param maxDigits the maximum number of fractional digits, or {@code null} for none
+         * @return this builder, for chaining
+         */
         public Builder digits(Integer maxDigits) {
             this.maxDigits = maxDigits;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
@@ -20,6 +20,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates a single bit as an {@code Integer} that is either {@code 0} or {@code 1}, chosen
+ * uniformly using the seeded random source (so a given seed yields a reproducible sequence).
+ * Backed by an {@link IntegerGenerator} over the half-open range {@code [0, 2)}. Suitable for
+ * {@code BIT} columns.
+ */
 public class BitGenerator extends AbstractDataGenerator<Integer> {
 
     private final IntegerGenerator integerGenerator;
@@ -37,6 +43,11 @@ public class BitGenerator extends AbstractDataGenerator<Integer> {
 
     public static class Builder extends AbstractBuilder<Integer> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
@@ -20,6 +20,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates a string of {@code '0'} and {@code '1'} characters for SQL {@code BIT} / {@code VARBIT}
+ * columns, e.g. {@code 10110}.
+ *
+ * <p>The number of bits is the configured {@link Builder#size(int) size} clamped to {@code [1, 25]}:
+ * {@code BIT}/{@code VARBIT} columns must hold at least one bit, and an unbounded {@code VARBIT}
+ * reports a max size of {@code 0} which would otherwise yield an empty (invalid) value. Size
+ * defaults to {@code 1}. Output is seeded and therefore reproducible for a given random source.
+ */
 public class BitStringGenerator extends AbstractDataGenerator<String> {
 
     private final int size;
@@ -51,10 +60,22 @@ public class BitStringGenerator extends AbstractDataGenerator<String> {
     public static class Builder extends AbstractBuilder<String> {
         private int size = 1;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the requested number of bits. The generated length is this value clamped to
+         * {@code [1, 25]}. Defaults to {@code 1}.
+         *
+         * @param size the requested bit-string length
+         * @return this builder, for chaining
+         */
         public Builder size(int size) {
             this.size = size;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/ByteGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ByteGenerator.java
@@ -25,6 +25,12 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates an array of random {@code Byte}s using the seeded random source, so a given seed
+ * yields a reproducible sequence. The array length is the configured {@code size} capped at
+ * {@code 25} bytes; the default size is {@code 25}. Suitable for {@code BINARY}/{@code VARBINARY}
+ * style columns.
+ */
 public class ByteGenerator extends AbstractDataGenerator<Byte[]> {
 
     private final int size;
@@ -59,10 +65,23 @@ public class ByteGenerator extends AbstractDataGenerator<Byte[]> {
 
         private int size = 25;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the requested number of bytes to generate. Defaults to {@code 25}. The effective
+         * length is capped at {@code 25} bytes at generation time, so larger values produce a
+         * 25-byte array.
+         *
+         * @param size the requested array length in bytes
+         * @return this builder, for chaining
+         */
         public Builder size(int size) {
             this.size = size;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
@@ -20,6 +20,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates a single lowercase ASCII letter ({@code 'a'} through {@code 'z'}) chosen uniformly
+ * using the seeded random source, so a given seed yields a reproducible sequence. Backed by an
+ * {@link IntegerGenerator} over the half-open range {@code [0, 26)} offset from {@code 'a'}.
+ */
 public class CharacterGenerator extends AbstractDataGenerator<Character> {
 
     private final IntegerGenerator integerGenerator;
@@ -47,6 +52,11 @@ public class CharacterGenerator extends AbstractDataGenerator<Character> {
     }
 
     public static class Builder extends AbstractBuilder<Character> {
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
@@ -77,11 +77,27 @@ public class ChildCountGenerator extends AbstractDataGenerator<Integer> implemen
             super(random);
         }
 
+        /**
+         * The {@link ChildCardinality} consulted for each parent row: row {@code k} emits
+         * {@link ChildCardinality#count(long) cardinality.count(k)}. To keep this column honest, it
+         * <b>must be the same {@link ChildCardinality} instance</b> shared with the child table's
+         * {@link ChildKeyComponentGenerator}s, so each parent's declared child count equals the number
+         * of child rows actually generated for it. Required — {@link #build()} throws if left unset.
+         *
+         * @param cardinality the shared per-parent child-count source
+         * @return this builder, for chaining
+         */
         public Builder cardinality(ChildCardinality cardinality) {
             this.cardinality = cardinality;
             return this;
         }
 
+        /**
+         * Builds the generator.
+         *
+         * @return a new {@link ChildCountGenerator}
+         * @throws IllegalStateException if no {@link #cardinality(ChildCardinality) cardinality} was set
+         */
         @Override
         public ChildCountGenerator build() {
             return new ChildCountGenerator(this);

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
@@ -147,29 +147,61 @@ public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> i
             super(random);
         }
 
+        /**
+         * The {@link ChildCardinality} that supplies each parent's child count. This drives the walk
+         * over parents in both modes, so it <b>must be the same {@link ChildCardinality} instance</b>
+         * shared with this child table's other component generators and with the parent table's
+         * {@link ChildCountGenerator}; otherwise the parent keys, sequence numbers, and declared child
+         * counts will not line up. Required — {@link #build()} throws if left unset.
+         *
+         * @param cardinality the shared per-parent child-count source
+         * @return this builder, for chaining
+         */
         public Builder cardinality(ChildCardinality cardinality) {
             this.cardinality = cardinality;
             return this;
         }
 
         /**
-         * Emit the child's 1-based sequence number within its parent (using {@code start}
-         * as the base). Mutually exclusive with {@link #repeat(long)}/{@link #cycle(int)}.
+         * Switches this generator into <b>sequence mode</b>: it emits the child's 1-based sequence
+         * number within its parent ({@code start + positionWithinParent}, so {@code start = 1} yields
+         * {@code 1, 2, 3, ...}). Use this for the trailing sequence column of the child key. Mutually
+         * exclusive with the parent-component mode configured via {@link #repeat(long)}/
+         * {@link #cycle(int)} (which is the default when {@code sequence()} is not called); in that
+         * mode the generator instead reproduces one dimension of the parent's key.
+         *
+         * @return this builder, for chaining
          */
         public Builder sequence() {
             this.sequence = true;
             return this;
         }
 
+        /**
+         * The base value, inclusive. In {@linkplain #sequence() sequence mode} it is the number of the
+         * first child within each parent ({@code start = 1} yields {@code 1, 2, 3, ...}); in
+         * parent-component mode it is the {@code start} term of
+         * {@code start + ((parentIndex / repeat) % cycle)} and must match the corresponding parent
+         * {@link CompositeKeyComponentGenerator.Builder#start(int) start}. Defaults to {@code 1}.
+         *
+         * @param start the first value of the sequence or parent dimension, inclusive
+         * @return this builder, for chaining
+         */
         public Builder start(int start) {
             this.start = start;
             return this;
         }
 
         /**
-         * For a parent-component generator, the number of consecutive parents that share this
-         * dimension's value — i.e. the product of the sizes of all parent dimensions nested
-         * inside this one (mirrors {@link CompositeKeyComponentGenerator}).
+         * For a parent-component generator (i.e. when {@link #sequence()} is not used), the number of
+         * consecutive parents that share this dimension's value — i.e. the product of the sizes of all
+         * parent dimensions nested inside this one (mirrors {@link CompositeKeyComponentGenerator}, and
+         * must match the parent's own {@code repeat}). The {@code repeat} term in
+         * {@code start + ((parentIndex / repeat) % cycle)}. Ignored in sequence mode. Defaults to
+         * {@code 1}.
+         *
+         * @param repeat the number of consecutive parents per value (product of inner parent dimension sizes)
+         * @return this builder, for chaining
          */
         public Builder repeat(long repeat) {
             this.repeat = repeat;
@@ -177,13 +209,25 @@ public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> i
         }
 
         /**
-         * For a parent-component generator, the size of this parent dimension.
+         * For a parent-component generator (i.e. when {@link #sequence()} is not used), the size
+         * (cardinality) of this parent dimension — the {@code cycle} term in
+         * {@code start + ((parentIndex / repeat) % cycle)}, which must match the parent's own
+         * {@code cycle}. Ignored in sequence mode. Defaults to {@code 1}.
+         *
+         * @param cycle the number of distinct values (size) of this parent dimension
+         * @return this builder, for chaining
          */
         public Builder cycle(int cycle) {
             this.cycle = cycle;
             return this;
         }
 
+        /**
+         * Builds the generator.
+         *
+         * @return a new {@link ChildKeyComponentGenerator}
+         * @throws IllegalStateException if no {@link #cardinality(ChildCardinality) cardinality} was set
+         */
         @Override
         public ChildKeyComponentGenerator build() {
             return new ChildKeyComponentGenerator(this);

--- a/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
@@ -47,6 +47,11 @@ public class CidrGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
@@ -93,16 +93,41 @@ public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Intege
             super(random);
         }
 
+        /**
+         * The first (lowest) value this dimension takes, inclusive — the {@code start} term in
+         * {@code start + ((rowIndex / repeat) % cycle)}. It is the value emitted for row 0, and the
+         * dimension then ranges over {@code [start, start + cycle)}. Defaults to {@code 1}.
+         *
+         * @param start the first value of this dimension, inclusive
+         * @return this builder, for chaining
+         */
         public Builder start(int start) {
             this.start = start;
             return this;
         }
 
+        /**
+         * How many consecutive rows share this dimension's value before it advances — the
+         * {@code repeat} term in {@code start + ((rowIndex / repeat) % cycle)}. It must equal the
+         * product of the sizes ({@code cycle}s) of all dimensions nested inside this one (use
+         * {@code 1} for the innermost dimension). Defaults to {@code 1}.
+         *
+         * @param repeat the number of consecutive rows per value (product of inner dimension sizes)
+         * @return this builder, for chaining
+         */
         public Builder repeat(long repeat) {
             this.repeat = repeat;
             return this;
         }
 
+        /**
+         * This dimension's cardinality — how many distinct values it takes before wrapping back to
+         * {@code start}; the {@code cycle} term in {@code start + ((rowIndex / repeat) % cycle)}.
+         * Defaults to {@code 1}.
+         *
+         * @param cycle the number of distinct values (size) of this dimension
+         * @return this builder, for chaining
+         */
         public Builder cycle(int cycle) {
             this.cycle = cycle;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/DateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DateGenerator.java
@@ -24,6 +24,13 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates random {@link java.util.Date} values drawn uniformly from a millisecond instant in the
+ * half-open range {@code [start, end)} (start inclusive, end exclusive). By default the range spans
+ * from the Unix {@linkplain java.time.Instant#EPOCH epoch} up to (but excluding)
+ * {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 days. Backed by the builder's seeded
+ * {@link java.util.random.RandomGenerator}, so the same seed yields identical output.
+ */
 public class DateGenerator extends AbstractDataGenerator<Date> {
 
 
@@ -43,20 +50,42 @@ public class DateGenerator extends AbstractDataGenerator<Date> {
         return timestamp != null ? new Date(timestamp.getTime()) : null;
     }
 
+    /**
+     * Builder for {@link DateGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<Date> {
 
         private Date startInclusive = Date.from(Instant.EPOCH);
         private Date endExclusive = Date.from(DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS));
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range.
+         *
+         * @param start the earliest possible date, inclusive. Defaults to the Unix
+         *              {@linkplain java.time.Instant#EPOCH epoch}.
+         * @return this builder, for chaining
+         */
         public Builder start(Date start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range.
+         *
+         * @param end the date one millisecond past the latest possible value, exclusive. Defaults
+         *            to {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 days.
+         * @return this builder, for chaining
+         */
         public Builder end(Date end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/DoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DoubleGenerator.java
@@ -22,6 +22,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates {@code double} values drawn uniformly from the half-open range
+ * {@code [startInclusive, endExclusive)} using the seeded random source, so a given seed
+ * yields a reproducible sequence. The default range is {@code [0, Double.MAX_VALUE)}.
+ * For a Gaussian distribution see {@link NormalDoubleGenerator}; for a fixed value see
+ * {@link StaticDoubleGenerator}.
+ */
 public class DoubleGenerator extends AbstractDataGenerator<Double> {
 
     private final double startInclusive;
@@ -48,15 +55,33 @@ public class DoubleGenerator extends AbstractDataGenerator<Double> {
         private double startInclusive = 0;
         private double endExclusive = Double.MAX_VALUE;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range. Defaults to {@code 0}.
+         *
+         * @param start the smallest value that may be generated (inclusive)
+         * @return this builder, for chaining
+         */
         public Builder start(double start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range. Defaults to {@code Double.MAX_VALUE};
+         * generated values are always strictly less than this bound.
+         *
+         * @param end the upper bound that may never be generated (exclusive)
+         * @return this builder, for chaining
+         */
         public Builder end(double end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/FloatGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/FloatGenerator.java
@@ -22,6 +22,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates {@code float} values drawn uniformly from the half-open range
+ * {@code [startInclusive, endExclusive)} using the seeded random source, so a given seed
+ * yields a reproducible sequence. The default range is {@code [0, Float.MAX_VALUE)}. The
+ * single-precision analogue of {@link DoubleGenerator}.
+ */
 public class FloatGenerator extends AbstractDataGenerator<Float> {
 
     private final float startInclusive;
@@ -48,15 +54,33 @@ public class FloatGenerator extends AbstractDataGenerator<Float> {
         private float startInclusive = 0;
         private float endExclusive = Float.MAX_VALUE;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range. Defaults to {@code 0}.
+         *
+         * @param start the smallest value that may be generated (inclusive)
+         * @return this builder, for chaining
+         */
         public Builder start(float start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range. Defaults to {@code Float.MAX_VALUE};
+         * generated values are always strictly less than this bound.
+         *
+         * @param end the upper bound that may never be generated (exclusive)
+         * @return this builder, for chaining
+         */
         public Builder end(float end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
@@ -121,27 +121,53 @@ public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> 
         }
 
         /**
-         * The size of each permutation group; each run of this many rows is a fresh permutation
-         * of {@code [start, start + groupSize)}. Must be in {@code [1, 2^30]}.
+         * The size of each permutation group: every consecutive run of this many rows is an
+         * independent shuffle (a within-group permutation) of {@code [start, start + groupSize)}, after
+         * which a fresh permutation begins. It is the {@code groupSize} divisor in
+         * {@code start + permute(rowIndex % groupSize)} keyed by {@code rowIndex / groupSize}. Must be
+         * in {@code [1, 2^30]}, otherwise {@link #build()} throws. Defaults to {@code 1}.
+         *
+         * @param groupSize the number of rows per permutation block; must be in {@code [1, 2^30]}
+         * @return this builder, for chaining
          */
         public Builder groupSize(int groupSize) {
             this.groupSize = groupSize;
             return this;
         }
 
+        /**
+         * The lowest value of the permuted range, inclusive: each group is a permutation of
+         * {@code [start, start + groupSize)} (the {@code start} offset added to each permuted index).
+         * Defaults to {@code 0}.
+         *
+         * @param start the lowest value of the permuted range, inclusive
+         * @return this builder, for chaining
+         */
         public Builder start(int start) {
             this.start = start;
             return this;
         }
 
         /**
-         * Salt for the per-group permutation key; fix it for reproducible datasets.
+         * Salt for the per-group permutation key. The key for each group is derived deterministically
+         * from this seed and the group index, so a fixed seed yields a fully reproducible shuffle for
+         * every group (independent of the injected random source). Change it to obtain a different but
+         * equally reproducible set of per-group orderings. Defaults to {@code 0}.
+         *
+         * @param seed the salt mixed with the group index to key each within-group permutation
+         * @return this builder, for chaining
          */
         public Builder seed(long seed) {
             this.seed = seed;
             return this;
         }
 
+        /**
+         * Builds the generator.
+         *
+         * @return a new {@link GroupedPermutationGenerator}
+         * @throws IllegalArgumentException if {@code groupSize} is not in {@code [1, 2^30]}
+         */
         @Override
         public GroupedPermutationGenerator build() {
             return new GroupedPermutationGenerator(this);

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
@@ -103,25 +103,55 @@ public class GroupedPrefixGenerator<T> extends AbstractDataGenerator<T> implemen
             super(random);
         }
 
+        /**
+         * The size of each consecutive group of rows; the sparse-prefix pattern repeats every
+         * {@code groupSize} rows. A row's position within its group is {@code rowIndex % groupSize};
+         * positions below {@link #prefixSize(int) prefixSize} get a value, the rest are {@code null}.
+         * Must be {@code >= 1}, otherwise {@link #build()} throws. Defaults to {@code 1}.
+         *
+         * @param groupSize the number of rows per group; must be {@code >= 1}
+         * @return this builder, for chaining
+         */
         public Builder<T> groupSize(int groupSize) {
             this.groupSize = groupSize;
             return this;
         }
 
         /**
-         * How many rows at the start of each group receive a (non-null) value from the delegate;
-         * the remaining {@code groupSize - prefixSize} rows are NULL.
+         * How many rows at the start of each group receive a (non-null) value from the delegate; the
+         * remaining {@code groupSize - prefixSize} rows emit SQL {@code NULL}. So {@code prefixSize = 0}
+         * makes the whole column null and {@code prefixSize = groupSize} makes it fully populated. Must
+         * be in {@code [0, groupSize]}, otherwise {@link #build()} throws. Defaults to {@code 0}.
+         *
+         * @param prefixSize the number of leading non-null rows per group; must be in {@code [0, groupSize]}
+         * @return this builder, for chaining
          */
         public Builder<T> prefixSize(int prefixSize) {
             this.prefixSize = prefixSize;
             return this;
         }
 
+        /**
+         * The wrapped generator that supplies the value for each prefix (non-null) row; it is consulted
+         * only on prefix rows, never for the null tail, so a stateless delegate is recommended.
+         * Required — {@link #build()} throws if left unset.
+         *
+         * @param delegate the generator producing the non-null prefix values
+         * @return this builder, for chaining
+         */
         public Builder<T> delegate(DataGenerator<T> delegate) {
             this.delegate = delegate;
             return this;
         }
 
+        /**
+         * Builds the generator.
+         *
+         * @return a new {@link GroupedPrefixGenerator}
+         * @throws IllegalArgumentException if {@code groupSize < 1} or {@code prefixSize} is not in
+         *                                  {@code [0, groupSize]}
+         * @throws IllegalStateException    if no {@link #delegate(DataGenerator) delegate} was set
+         */
         @Override
         public GroupedPrefixGenerator<T> build() {
             return new GroupedPrefixGenerator<>(this);

--- a/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
@@ -20,6 +20,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates IPv4 host addresses as a dotted-quad {@link String}, e.g. {@code 12.198.4.251}.
+ *
+ * <p>Each of the four octets is drawn from {@code 1..255} (inclusive), so the value is a valid
+ * PostgreSQL {@code inet} host address. Output is seeded and therefore reproducible for a given
+ * random source.
+ */
 public class InetGenerator extends AbstractDataGenerator<String> {
 
     private final IntegerGenerator integerGenerator;
@@ -41,6 +48,11 @@ public class InetGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/InstantGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InstantGenerator.java
@@ -23,6 +23,13 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates random {@link java.time.Instant} values drawn uniformly from a millisecond instant in
+ * the half-open range {@code [start, end)} (start inclusive, end exclusive). By default the range
+ * spans from the {@linkplain java.time.Instant#EPOCH epoch} up to (but excluding)
+ * {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 days. Backed by the builder's seeded
+ * {@link java.util.random.RandomGenerator}, so the same seed yields identical output.
+ */
 public class InstantGenerator extends AbstractDataGenerator<Instant> {
 
     private final LongGenerator longGenerator;
@@ -41,20 +48,42 @@ public class InstantGenerator extends AbstractDataGenerator<Instant> {
         return timestamp != null ? timestamp.toInstant() : null;
     }
 
+    /**
+     * Builder for {@link InstantGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<Instant> {
 
         private Instant startInclusive = Instant.EPOCH;
         private Instant endExclusive = DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS);
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range.
+         *
+         * @param start the earliest possible instant, inclusive. Defaults to the
+         *              {@linkplain java.time.Instant#EPOCH epoch}.
+         * @return this builder, for chaining
+         */
         public Builder start(Instant start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range.
+         *
+         * @param end the instant one millisecond past the latest possible value, exclusive.
+         *            Defaults to {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 days.
+         * @return this builder, for chaining
+         */
         public Builder end(Instant end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
@@ -19,6 +19,13 @@ package io.bloviate.gen;
 import java.sql.*;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates a fixed-length {@code Integer[]} whose elements are unbounded random {@code int}
+ * values, bound to JDBC arrays of SQL type {@code INTEGER}.
+ *
+ * <p>The array {@link Builder#length(int) length} defaults to {@code 3}. Output is seeded and
+ * therefore reproducible for a given random source.
+ */
 public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
 
     private final int length;
@@ -62,10 +69,21 @@ public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
 
         private int length = 3;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the number of elements in the generated array. Defaults to {@code 3}.
+         *
+         * @param length the array length
+         * @return this builder, for chaining
+         */
         public Builder length(int length) {
             this.length = length;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerGenerator.java
@@ -22,6 +22,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates {@code int} values drawn uniformly from the half-open range
+ * {@code [startInclusive, endExclusive)} using the seeded random source, so a given seed
+ * yields a reproducible sequence. The default range is {@code [0, Integer.MAX_VALUE)}.
+ * For non-uniform whole-number distributions see {@link NormalIntegerGenerator} (Gaussian)
+ * and {@link ZipfianIntegerGenerator} (skewed), or {@link StaticIntegerGenerator} for a fixed value.
+ */
 public class IntegerGenerator extends AbstractDataGenerator<Integer> {
 
     private final int startInclusive;
@@ -48,15 +55,33 @@ public class IntegerGenerator extends AbstractDataGenerator<Integer> {
         private int startInclusive = 0;
         private int endExclusive = Integer.MAX_VALUE;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range. Defaults to {@code 0}.
+         *
+         * @param start the smallest value that may be generated (inclusive)
+         * @return this builder, for chaining
+         */
         public Builder start(int start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range. Defaults to {@code Integer.MAX_VALUE};
+         * generated values are always strictly less than this bound.
+         *
+         * @param end the upper bound that may never be generated (exclusive)
+         * @return this builder, for chaining
+         */
         public Builder end(int end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
@@ -20,6 +20,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates time spans as a {@link String} in PostgreSQL {@code interval} input form,
+ * {@code years-months days hours:minutes:seconds}, e.g. {@code 3-7 14 21:45:09}.
+ *
+ * <p>Each component is drawn from a fixed range: years {@code 1..9}, months {@code 1..11},
+ * days {@code 1..29}, hours {@code 1..23}, minutes and seconds {@code 1..59} (all inclusive).
+ * Output is seeded and therefore reproducible for a given random source.
+ */
 public class IntervalGenerator extends AbstractDataGenerator<String> {
 
     private final IntegerGenerator yearGenerator;
@@ -48,6 +56,11 @@ public class IntervalGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/JsonbGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/JsonbGenerator.java
@@ -71,10 +71,22 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
 
         private int fields = 3;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the number of key/value pairs in the generated JSON object. Field values cycle
+         * through string, integer, double, and boolean types in order. Defaults to {@code 3}.
+         *
+         * @param fields the number of fields to emit
+         * @return this builder, for chaining
+         */
         public Builder fields(int fields) {
             this.fields = fields;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/LongGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/LongGenerator.java
@@ -22,6 +22,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates {@code long} values drawn uniformly from the half-open range
+ * {@code [startInclusive, endExclusive)} using the seeded random source, so a given seed
+ * yields a reproducible sequence. The default range is {@code [0, Long.MAX_VALUE)}. The
+ * 64-bit analogue of {@link IntegerGenerator}.
+ */
 public class LongGenerator extends AbstractDataGenerator<Long> {
 
     private final long startInclusive;
@@ -48,15 +54,33 @@ public class LongGenerator extends AbstractDataGenerator<Long> {
         private long startInclusive = 0;
         private long endExclusive = Long.MAX_VALUE;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range. Defaults to {@code 0}.
+         *
+         * @param start the smallest value that may be generated (inclusive)
+         * @return this builder, for chaining
+         */
         public Builder start(long start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range. Defaults to {@code Long.MAX_VALUE};
+         * generated values are always strictly less than this bound.
+         *
+         * @param end the upper bound that may never be generated (exclusive)
+         * @return this builder, for chaining
+         */
         public Builder end(long end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
@@ -57,10 +57,22 @@ public class MacAddressGenerator extends AbstractDataGenerator<String> {
 
         private int octets = 6;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the number of hex octets in the generated address. Defaults to {@code 6}
+         * (PostgreSQL {@code macaddr}); use {@code 8} for the EUI-64 {@code macaddr8} form.
+         *
+         * @param octets the number of colon-separated octets to emit
+         * @return this builder, for chaining
+         */
         public Builder octets(int octets) {
             this.octets = octets;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
@@ -59,20 +59,45 @@ public class ScaledBigDecimalGenerator extends AbstractDataGenerator<BigDecimal>
         private double endExclusive = 1;
         private int scale = 2;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range. Defaults to {@code 0}.
+         *
+         * @param start the smallest value that may be generated (inclusive)
+         * @return this builder, for chaining
+         */
         public Builder start(double start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range. Defaults to {@code 1}; generated
+         * values are always strictly less than this bound.
+         *
+         * @param end the upper bound that may never be generated (exclusive)
+         * @return this builder, for chaining
+         */
         public Builder end(double end) {
             this.endExclusive = end;
             return this;
         }
 
+        /**
+         * Sets the number of decimal places (fractional digits) the value is rounded to, using
+         * {@code RoundingMode.HALF_UP}. Defaults to {@code 2}.
+         *
+         * @param scale the number of digits to the right of the decimal point
+         * @return this builder, for chaining
+         */
         public Builder scale(int scale) {
             this.scale = scale;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -78,16 +78,38 @@ public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> i
             super(random);
         }
 
+        /**
+         * The first value of the sequence, <b>inclusive</b>. It is the value emitted for row 0 and the
+         * value the sequence wraps back to after {@code end} is emitted. Defaults to {@code 1}.
+         *
+         * @param start the lowest value of the cycle, inclusive
+         * @return this builder, for chaining
+         */
         public Builder start(int start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * The last value of the sequence, <b>inclusive</b>. Once {@code end} is emitted the next call
+         * wraps back to {@code start}, so the generator cycles through {@code [start, end]} forever.
+         * Defaults to {@link Integer#MAX_VALUE}. Must be {@code >= start}, otherwise {@link #build()}
+         * throws.
+         *
+         * @param end the highest value of the cycle, inclusive
+         * @return this builder, for chaining
+         */
         public Builder end(int end) {
             this.endInclusive = end;
             return this;
         }
 
+        /**
+         * Builds the generator.
+         *
+         * @return a new {@link SequentialIntegerGenerator} over the inclusive range {@code [start, end]}
+         * @throws IllegalArgumentException if {@code end < start}
+         */
         @Override
         public SequentialIntegerGenerator build() {
             if (endInclusive < startInclusive) {

--- a/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
@@ -22,6 +22,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates {@code short} values drawn uniformly from the half-open range
+ * {@code [startInclusive, endExclusive)} using the seeded random source, so a given seed
+ * yields a reproducible sequence. Delegates to an {@link IntegerGenerator} and narrows the
+ * result to a {@code short}; the bounds are therefore constrained to
+ * {@code [Short.MIN_VALUE, Short.MAX_VALUE]}. The default range is {@code [0, Short.MAX_VALUE)}.
+ */
 public class ShortGenerator extends AbstractDataGenerator<Short> {
 
     private final IntegerGenerator integerGenerator;
@@ -47,10 +54,22 @@ public class ShortGenerator extends AbstractDataGenerator<Short> {
         private int startInclusive = 0;
         private int endExclusive = Short.MAX_VALUE;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range. Defaults to {@code 0}.
+         *
+         * @param start the smallest value that may be generated (inclusive)
+         * @return this builder, for chaining
+         * @throws IllegalArgumentException if {@code start} is less than {@code Short.MIN_VALUE}
+         */
         public Builder start(int start) {
             if (start < Short.MIN_VALUE) {
                 throw new IllegalArgumentException("invalid start value.  Less than Short.MIN_VALUE.");
@@ -59,6 +78,14 @@ public class ShortGenerator extends AbstractDataGenerator<Short> {
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range. Defaults to {@code Short.MAX_VALUE};
+         * generated values are always strictly less than this bound.
+         *
+         * @param end the upper bound that may never be generated (exclusive)
+         * @return this builder, for chaining
+         * @throws IllegalArgumentException if {@code end} is greater than {@code Short.MAX_VALUE}
+         */
         public Builder end(int end) {
             if (end > Short.MAX_VALUE) {
                 throw new IllegalArgumentException("invalid end value.  Greater than Short.MAX_VALUE.");

--- a/bloviate-core/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SimpleStringGenerator.java
@@ -20,6 +20,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates fixed-length random strings. Every value is exactly {@code size} characters long
+ * (capped at 2000 at generation time), drawn from a configurable character set: ASCII letters
+ * ({@code A-Za-z}), decimal digits ({@code 0-9}), or both. Backed by the builder's seeded
+ * {@link java.util.random.RandomGenerator}, so the same seed yields identical output.
+ */
 public class SimpleStringGenerator extends AbstractDataGenerator<String> {
 
     private final int size;
@@ -37,6 +43,9 @@ public class SimpleStringGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /**
+     * Builder for {@link SimpleStringGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<String> {
 
         private int size = 10;
@@ -45,20 +54,44 @@ public class SimpleStringGenerator extends AbstractDataGenerator<String> {
 
         private boolean numbers = false;
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the fixed string length.
+         *
+         * @param size the number of characters in each generated string; capped at 2000 at
+         *             generation time. Defaults to {@code 10}.
+         * @return this builder, for chaining
+         */
         public Builder size(int size) {
             this.size = size;
             return this;
         }
 
+        /**
+         * Controls whether ASCII letters ({@code A-Za-z}) are included in the character set.
+         *
+         * @param letters {@code true} to include letters. Defaults to {@code true}.
+         * @return this builder, for chaining
+         */
         public Builder letters(boolean letters) {
             this.letters = letters;
             return this;
         }
 
+        /**
+         * Controls whether decimal digits ({@code 0-9}) are included in the character set.
+         *
+         * @param numbers {@code true} to include digits. Defaults to {@code false}.
+         * @return this builder, for chaining
+         */
         public Builder numbers(boolean numbers) {
             this.numbers = numbers;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlBlobGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlBlobGenerator.java
@@ -19,6 +19,15 @@ package io.bloviate.gen;
 import java.sql.*;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generator for SQL {@code BLOB} (binary large object) columns.
+ *
+ * <p>Generation is not yet implemented: {@link #generate()} and {@link #generateAsString()}
+ * currently return {@code null}, so nullable {@code BLOB} columns fill with {@code null} and a
+ * non-nullable one will fail at insert. {@link #set(Connection, PreparedStatement, int, Blob)}
+ * and {@link #get(ResultSet, int)} bind and read a {@link Blob} normally, so round-tripping an
+ * existing value works.
+ */
 public class SqlBlobGenerator extends AbstractDataGenerator<Blob> {
     //todo
 
@@ -44,6 +53,11 @@ public class SqlBlobGenerator extends AbstractDataGenerator<Blob> {
 
     public static class Builder extends AbstractBuilder<Blob> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlClobGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlClobGenerator.java
@@ -19,6 +19,15 @@ package io.bloviate.gen;
 import java.sql.*;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generator for SQL {@code CLOB} (character large object) columns.
+ *
+ * <p>Generation is not yet implemented: {@link #generate()} and {@link #generateAsString()}
+ * currently return {@code null}, so nullable {@code CLOB} columns fill with {@code null} and a
+ * non-nullable one will fail at insert. {@link #set(Connection, PreparedStatement, int, Clob)}
+ * and {@link #get(ResultSet, int)} bind and read a {@link Clob} normally, so round-tripping an
+ * existing value works.
+ */
 public class SqlClobGenerator extends AbstractDataGenerator<Clob> {
     //todo
 
@@ -44,6 +53,11 @@ public class SqlClobGenerator extends AbstractDataGenerator<Clob> {
 
     public static class Builder extends AbstractBuilder<Clob> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlDateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlDateGenerator.java
@@ -21,6 +21,13 @@ import java.sql.*;
 import java.time.temporal.ChronoUnit;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates random {@link java.sql.Date} values for binding to JDBC {@code DATE} columns, drawn
+ * uniformly from a millisecond instant in the half-open range {@code [start, end)} (start inclusive,
+ * end exclusive). By default the range is centered on {@link AbstractBuilder#DEFAULT_REFERENCE},
+ * spanning from 100 days before it up to (but excluding) 100 days after it. Backed by the builder's
+ * seeded {@link java.util.random.RandomGenerator}, so the same seed yields identical output.
+ */
 public class SqlDateGenerator extends AbstractDataGenerator<Date> {
 
     private final LongGenerator longGenerator;
@@ -43,20 +50,42 @@ public class SqlDateGenerator extends AbstractDataGenerator<Date> {
         return resultSet.getDate(columnIndex);
     }
 
+    /**
+     * Builder for {@link SqlDateGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<Date> {
 
         private Date startInclusive = new Date(DEFAULT_REFERENCE.minus(100, ChronoUnit.DAYS).toEpochMilli());
         private Date endExclusive = new Date(DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS).toEpochMilli());
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range.
+         *
+         * @param start the earliest possible date, inclusive. Defaults to
+         *              {@link AbstractBuilder#DEFAULT_REFERENCE} minus 100 days.
+         * @return this builder, for chaining
+         */
         public Builder start(Date start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range.
+         *
+         * @param end the date one millisecond past the latest possible value, exclusive. Defaults
+         *            to {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 days.
+         * @return this builder, for chaining
+         */
         public Builder end(Date end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlStructGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlStructGenerator.java
@@ -61,6 +61,11 @@ public class SqlStructGenerator extends AbstractDataGenerator<Struct> {
 
     public static class Builder extends AbstractBuilder<Struct> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlTimeGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlTimeGenerator.java
@@ -21,6 +21,14 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates random {@link java.sql.Time} values for binding to JDBC {@code TIME} columns, drawn
+ * uniformly from a millisecond instant in the half-open range {@code [start, end)} (start inclusive,
+ * end exclusive). By default the range spans from the {@linkplain java.time.Instant#EPOCH epoch} up
+ * to (but excluding) {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 hours. Backed by the
+ * builder's seeded {@link java.util.random.RandomGenerator}, so the same seed yields identical
+ * output.
+ */
 public class SqlTimeGenerator extends AbstractDataGenerator<Time> {
 
     private final LongGenerator longGenerator;
@@ -43,20 +51,42 @@ public class SqlTimeGenerator extends AbstractDataGenerator<Time> {
         return resultSet.getTime(columnIndex);
     }
 
+    /**
+     * Builder for {@link SqlTimeGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<Time> {
 
         private Time startInclusive = new Time(Instant.EPOCH.toEpochMilli());
         private Time endExclusive = new Time(DEFAULT_REFERENCE.plus(100, ChronoUnit.HOURS).toEpochMilli());
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range.
+         *
+         * @param start the earliest possible time, inclusive. Defaults to the
+         *              {@linkplain java.time.Instant#EPOCH epoch}.
+         * @return this builder, for chaining
+         */
         public Builder start(Time start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range.
+         *
+         * @param end the time one millisecond past the latest possible value, exclusive. Defaults
+         *            to {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 hours.
+         * @return this builder, for chaining
+         */
         public Builder end(Time end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlTimestampGenerator.java
@@ -21,6 +21,14 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates random {@link java.sql.Timestamp} values for binding to JDBC {@code TIMESTAMP} columns,
+ * drawn uniformly from a millisecond instant in the half-open range {@code [start, end)} (start
+ * inclusive, end exclusive). By default the range is centered on
+ * {@link AbstractBuilder#DEFAULT_REFERENCE}, spanning from 100 days before it up to (but excluding)
+ * 100 days after it. Backed by the builder's seeded {@link java.util.random.RandomGenerator}, so the
+ * same seed yields identical output.
+ */
 public class SqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
 
     private final LongGenerator longGenerator;
@@ -43,20 +51,42 @@ public class SqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
         return resultSet.getTimestamp(columnIndex);
     }
 
+    /**
+     * Builder for {@link SqlTimestampGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<Timestamp> {
 
         private Timestamp startInclusive = Timestamp.from(DEFAULT_REFERENCE.minus(100, ChronoUnit.DAYS));
         private Timestamp endExclusive = Timestamp.from(DEFAULT_REFERENCE.plus(100, ChronoUnit.DAYS));
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the generated range.
+         *
+         * @param start the earliest possible timestamp, inclusive. Defaults to
+         *              {@link AbstractBuilder#DEFAULT_REFERENCE} minus 100 days.
+         * @return this builder, for chaining
+         */
         public Builder start(Timestamp start) {
             this.startInclusive = start;
             return this;
         }
 
+        /**
+         * Sets the exclusive upper bound of the generated range.
+         *
+         * @param end the timestamp one millisecond past the latest possible value, exclusive.
+         *            Defaults to {@link AbstractBuilder#DEFAULT_REFERENCE} plus 100 days.
+         * @return this builder, for chaining
+         */
         public Builder end(Timestamp end) {
             this.endExclusive = end;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
@@ -49,15 +49,35 @@ public class StaticBigDecimalGenerator extends AbstractDataGenerator<BigDecimal>
 
         private BigDecimal value = BigDecimal.ZERO;
 
+        /**
+         * Creates a builder backed by the given random source. The source is never used, since this
+         * generator always returns the configured value.
+         *
+         * @param random the (unused) random source
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the fixed value returned by every call to {@code generate()}. Defaults to
+         * {@code BigDecimal.ZERO}.
+         *
+         * @param value the constant value to generate
+         * @return this builder, for chaining
+         */
         public Builder value(BigDecimal value) {
             this.value = value;
             return this;
         }
 
+        /**
+         * Sets the fixed value returned by every call to {@code generate()}, parsed from the given
+         * string via the {@link BigDecimal#BigDecimal(String)} constructor.
+         *
+         * @param value the constant value to generate, as a {@code BigDecimal} string representation
+         * @return this builder, for chaining
+         */
         public Builder value(String value) {
             this.value = new BigDecimal(value);
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
@@ -49,10 +49,22 @@ public class StaticDoubleGenerator extends AbstractDataGenerator<Double> {
 
         private Double value = 0d;
 
+        /**
+         * Creates a builder backed by the given random source. The source is never used, since this
+         * generator always returns the configured value.
+         *
+         * @param random the (unused) random source
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the fixed value returned by every call to {@code generate()}. Defaults to {@code 0}.
+         *
+         * @param value the constant value to generate
+         * @return this builder, for chaining
+         */
         public Builder value(Double value) {
             this.value = value;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
@@ -49,10 +49,22 @@ public class StaticFloatGenerator extends AbstractDataGenerator<Float> {
 
         private Float value = 0f;
 
+        /**
+         * Creates a builder backed by the given random source. The source is never used, since this
+         * generator always returns the configured value.
+         *
+         * @param random the (unused) random source
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the fixed value returned by every call to {@code generate()}. Defaults to {@code 0}.
+         *
+         * @param value the constant value to generate
+         * @return this builder, for chaining
+         */
         public Builder value(Float value) {
             this.value = value;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
@@ -49,10 +49,22 @@ public class StaticIntegerGenerator extends AbstractDataGenerator<Integer> {
 
         private Integer value = 0;
 
+        /**
+         * Creates a builder backed by the given random source. The source is never used, since this
+         * generator always returns the configured value.
+         *
+         * @param random the (unused) random source
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the fixed value returned by every call to {@code generate()}. Defaults to {@code 0}.
+         *
+         * @param value the constant value to generate
+         * @return this builder, for chaining
+         */
         public Builder value(Integer value) {
             this.value = value;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticStringGenerator.java
@@ -37,14 +37,29 @@ public class StaticStringGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /**
+     * Builder for {@link StaticStringGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<String> {
 
         private String value = "";
 
+        /**
+         * Constructs a new builder. The random generator is required by the builder contract but
+         * is never consulted, since the generated value is constant.
+         *
+         * @param random the random generator (unused by this generator)
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the constant value returned by every call to the generator.
+         *
+         * @param value the fixed string to emit. Defaults to the empty string {@code ""}.
+         * @return this builder, for chaining
+         */
         public Builder value(String value) {
             this.value = value;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
@@ -19,6 +19,14 @@ package io.bloviate.gen;
 import java.sql.*;
 import java.util.random.RandomGenerator;
 
+/**
+ * Generates a fixed-length {@code String[]} whose elements are random alphabetic strings, bound
+ * to JDBC arrays of SQL type {@code VARCHAR}.
+ *
+ * <p>The array {@link Builder#length(int) length} defaults to {@code 3} and each element's
+ * {@link Builder#elementLength(int) elementLength} defaults to {@code 10} characters. Output is
+ * seeded and therefore reproducible for a given random source.
+ */
 public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
 
     private final int length;
@@ -69,15 +77,32 @@ public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
         private int length = 3;
         private int elementLength = 10;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the number of elements in the generated array. Defaults to {@code 3}.
+         *
+         * @param length the array length
+         * @return this builder, for chaining
+         */
         public Builder length(int length) {
             this.length = length;
             return this;
         }
 
+        /**
+         * Sets the character length of each generated string element. Defaults to {@code 10}.
+         *
+         * @param elementLength the number of alphabetic characters per element
+         * @return this builder, for chaining
+         */
         public Builder elementLength(int elementLength) {
             this.elementLength = elementLength;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/VariableStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/VariableStringGenerator.java
@@ -43,6 +43,9 @@ public class VariableStringGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /**
+     * Builder for {@link VariableStringGenerator} instances.
+     */
     public static class Builder extends AbstractBuilder<String> {
 
         private int minLength = 1;
@@ -50,25 +53,55 @@ public class VariableStringGenerator extends AbstractDataGenerator<String> {
         private boolean letters = true;
         private boolean numbers = false;
 
+        /**
+         * Constructs a new builder.
+         *
+         * @param random the seeded random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the inclusive lower bound of the random length range.
+         *
+         * @param minLength the minimum string length; effectively clamped up to {@code 1} at
+         *                  generation time (lengths below 1 are treated as 1). Defaults to {@code 1}.
+         * @return this builder, for chaining
+         */
         public Builder minLength(int minLength) {
             this.minLength = minLength;
             return this;
         }
 
+        /**
+         * Sets the inclusive upper bound of the random length range.
+         *
+         * @param maxLength the maximum string length, inclusive. Defaults to {@code 10}.
+         * @return this builder, for chaining
+         */
         public Builder maxLength(int maxLength) {
             this.maxLength = maxLength;
             return this;
         }
 
+        /**
+         * Controls whether ASCII letters ({@code A-Za-z}) are included in the character set.
+         *
+         * @param letters {@code true} to include letters. Defaults to {@code true}.
+         * @return this builder, for chaining
+         */
         public Builder letters(boolean letters) {
             this.letters = letters;
             return this;
         }
 
+        /**
+         * Controls whether decimal digits ({@code 0-9}) are included in the character set.
+         *
+         * @param numbers {@code true} to include digits. Defaults to {@code false}.
+         * @return this builder, for chaining
+         */
         public Builder numbers(boolean numbers) {
             this.numbers = numbers;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
@@ -47,6 +47,11 @@ public class XmlGenerator extends AbstractDataGenerator<String> {
 
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/util/SeededRandomUtils.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/SeededRandomUtils.java
@@ -46,14 +46,40 @@ public record SeededRandomUtils(RandomGenerator random) {
     private static final char[] ALPHANUMERIC =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
 
+    /**
+     * Generates a random string of ASCII digits ({@code 0-9}) whose length is chosen randomly
+     * from the range {@code [minLengthInclusive, maxLengthExclusive)}.
+     *
+     * @param minLengthInclusive the inclusive minimum length of the generated string
+     * @param maxLengthExclusive the exclusive maximum length of the generated string
+     * @return a random numeric string
+     */
     public String randomNumeric(int minLengthInclusive, int maxLengthExclusive) {
         return randomNumeric(nextInt(minLengthInclusive, maxLengthExclusive));
     }
 
+    /**
+     * Generates a random string of the given length composed only of ASCII digits ({@code 0-9}).
+     *
+     * @param count the length of the string to create
+     * @return a random numeric string of length {@code count}
+     */
     public String randomNumeric(final int count) {
         return random(count, false, true);
     }
 
+    /**
+     * Generates a random string of the requested length drawn from a fixed character pool selected
+     * by the {@code letters}/{@code numbers} flags: letters only ({@code A-Za-z}), digits only
+     * ({@code 0-9}), or alphanumeric ({@code A-Za-z0-9}). When both flags are {@code false} the
+     * general {@code [start, end)} code-point path is used, drawing from any code point.
+     *
+     * @param count   the length of the string to create
+     * @param letters whether ASCII letters are allowed
+     * @param numbers whether ASCII digits are allowed
+     * @return the generated random string
+     * @throws IllegalArgumentException if {@code count} is negative
+     */
     public String random(final int count, final boolean letters, final boolean numbers) {
         if (count < 0) {
             throw new IllegalArgumentException("Requested random string length " + count + " is less than 0.");
@@ -158,10 +184,27 @@ public record SeededRandomUtils(RandomGenerator random) {
         return builder.toString();
     }
 
+    /**
+     * Generates a random string of the given length composed only of ASCII letters
+     * ({@code A-Za-z}).
+     *
+     * @param count the length of the string to create
+     * @return a random alphabetic string of length {@code count}
+     */
     public String randomAlphabetic(final int count) {
         return random(count, true, false);
     }
 
+    /**
+     * Returns a random {@code int} within the range {@code [startInclusive, endExclusive)}. When
+     * the two bounds are equal, that value is returned.
+     *
+     * @param startInclusive the inclusive lower bound (must be non-negative)
+     * @param endExclusive   the exclusive upper bound (must be {@code >= startInclusive})
+     * @return a random {@code int} in the range
+     * @throws IllegalArgumentException if {@code endExclusive < startInclusive} or
+     *                                  {@code startInclusive} is negative
+     */
     public int nextInt(final int startInclusive, final int endExclusive) {
         Validate.isTrue(endExclusive >= startInclusive, "Start value must be smaller or equal to end value.");
         Validate.isTrue(startInclusive >= 0, "Both range values must be non-negative.");
@@ -173,6 +216,16 @@ public record SeededRandomUtils(RandomGenerator random) {
         return startInclusive + random.nextInt(endExclusive - startInclusive);
     }
 
+    /**
+     * Returns a random {@code double} within the range {@code [startInclusive, endExclusive)}. When
+     * the two bounds are equal, that value is returned.
+     *
+     * @param startInclusive the inclusive lower bound (must be non-negative)
+     * @param endExclusive   the exclusive upper bound (must be {@code >= startInclusive})
+     * @return a random {@code double} in the range
+     * @throws IllegalArgumentException if {@code endExclusive < startInclusive} or
+     *                                  {@code startInclusive} is negative
+     */
     public double nextDouble(final double startInclusive, final double endExclusive) {
         Validate.isTrue(endExclusive >= startInclusive, "Start value must be smaller or equal to end value.");
         Validate.isTrue(startInclusive >= 0, "Both range values must be non-negative.");
@@ -184,6 +237,16 @@ public record SeededRandomUtils(RandomGenerator random) {
         return startInclusive + ((endExclusive - startInclusive) * random.nextDouble());
     }
 
+    /**
+     * Returns a random {@code float} within the range {@code [startInclusive, endExclusive)}. When
+     * the two bounds are equal, that value is returned.
+     *
+     * @param startInclusive the inclusive lower bound (must be non-negative)
+     * @param endExclusive   the exclusive upper bound (must be {@code >= startInclusive})
+     * @return a random {@code float} in the range
+     * @throws IllegalArgumentException if {@code endExclusive < startInclusive} or
+     *                                  {@code startInclusive} is negative
+     */
     public float nextFloat(final float startInclusive, final float endExclusive) {
         Validate.isTrue(endExclusive >= startInclusive, "Start value must be smaller or equal to end value.");
         Validate.isTrue(startInclusive >= 0, "Both range values must be non-negative.");
@@ -195,6 +258,17 @@ public record SeededRandomUtils(RandomGenerator random) {
         return startInclusive + ((endExclusive - startInclusive) * random.nextFloat());
     }
 
+    /**
+     * Returns a random {@code long} within the range {@code [startInclusive, endExclusive)}. When
+     * the two bounds are equal, that value is returned. The value is generated directly as a
+     * {@code long} so the top of wide ranges (above {@code 2^53}) remains reachable.
+     *
+     * @param startInclusive the inclusive lower bound (must be non-negative)
+     * @param endExclusive   the exclusive upper bound (must be {@code >= startInclusive})
+     * @return a random {@code long} in the range
+     * @throws IllegalArgumentException if {@code endExclusive < startInclusive} or
+     *                                  {@code startInclusive} is negative
+     */
     public long nextLong(final long startInclusive, final long endExclusive) {
         Validate.isTrue(endExclusive >= startInclusive, "Start value must be smaller or equal to end value.");
         Validate.isTrue(startInclusive >= 0, "Both range values must be non-negative.");

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowProjectionGenerator.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowProjectionGenerator.java
@@ -50,11 +50,27 @@ public final class RowProjectionGenerator<E> extends AbstractDataGenerator<Strin
         this.selector = selector;
     }
 
+    /**
+     * Projects the selected field of the entity for the current row, then advances this
+     * projection's row counter by one. The entity is resolved from the shared {@link RowContext}
+     * for the current row index, so sibling projections of the same context yield a consistent
+     * tuple.
+     *
+     * @return the selected field of the current row's entity, as a string
+     */
     @Override
     public String generate() {
         return selector.apply(context.at(counter.getAndIncrement()));
     }
 
+    /**
+     * Positions this projection's row counter at the given row index, so the next
+     * {@link #generate()} projects that row's entity. Used for positional or partitioned access,
+     * where each partition seeks to its first row and then walks forward.
+     *
+     * @param rowIndex the zero-based row index to position at
+     * @throws IllegalArgumentException if {@code rowIndex} is negative
+     */
     @Override
     public void seek(long rowIndex) {
         if (rowIndex < 0) {
@@ -63,6 +79,14 @@ public final class RowProjectionGenerator<E> extends AbstractDataGenerator<Strin
         counter.set(rowIndex);
     }
 
+    /**
+     * Reads this projection's value back from a {@link ResultSet} as a string.
+     *
+     * @param resultSet   the result set positioned on the row to read
+     * @param columnIndex the one-based column index to read
+     * @return the column value as a string
+     * @throws SQLException if the value cannot be read from the result set
+     */
     @Override
     public String get(ResultSet resultSet, int columnIndex) throws SQLException {
         return resultSet.getString(columnIndex);


### PR DESCRIPTION
## Summary

A comprehensive Javadoc pass over the public API of `bloviate-core` and the integration modules. This was prompted by exploring a published API reference for the docs site — generating one made it obvious that **many important, user-facing functions had missing or thin doc comments**. Rather than ship a reference over weak source docs, this fixes the source.

**Javadoc-only — no code, signatures, or behavior changed.**

## What changed (56 files)

- **`gen`** (the biggest gap, ~40% → complete): class docs + builder-setter docs for every generator, with **explicit inclusive/exclusive bounds**, units, defaults, and `@throws`. Bounds were read from each generator's `generate()`/field names so they're accurate — e.g. `IntegerGenerator.end` is exclusive `[start, end)`, while `SequentialIntegerGenerator.end` is inclusive and wraps. The subtle key/cardinality generators (`CompositeKeyComponentGenerator`, `ChildKeyComponentGenerator`, `ChildCountGenerator`, `SequentialIntegerGenerator`, `GroupedPermutationGenerator`, `GroupedPrefixGenerator`) document their formulas and the shared-`ChildCardinality` contract.
- **`db`**: `TableFiller.Builder` + `fill()`, the metadata records (`Key`/`PrimaryKey`/`ForeignKey`/`KeyColumn`/`Fillable`/`ColumnConfiguration`) explained by role, and `@param` on the config-record constructors.
- **`ext`**: `DefaultSupport` class doc; `batchRewriteUrlParameter()` on `PostgresSupport`/`MySQLSupport`.
- **`file` / `util` / `datafaker`**: `FlatFileGenerator.Builder`, the delimited-file classes, `FileGenerator`, `SeededRandomUtils`, `RowProjectionGenerator`.

## Verification

- `./mvnw -DskipTests compile` — clean across all modules.
- `./mvnw -DskipTests javadoc:javadoc` — doclint clean, zero errors/warnings (no broken `@param`/`@link`/`@return`).
- Diff confirmed comment-only (no code lines removed/changed).
- Bound/formula claims spot-checked against the implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)