### PR TITLE
build: silence datafaker deprecation and shade uber-jar overlap warnings

### DIFF
--- a/bloviate-benchmarks/pom.xml
+++ b/bloviate-benchmarks/pom.xml
@@ -155,6 +155,9 @@
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <!-- merge the duplicate legal files the dependencies ship instead of letting one silently win -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>
@@ -165,6 +168,10 @@
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
                                         <exclude>module-info.class</exclude>
+                                        <!-- multi-release jars tuck a second copy here; the top-level exclude misses it -->
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                        <!-- ManifestResourceTransformer regenerates this, so drop the dependencies' copies -->
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerGeneratorPlugin.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerGeneratorPlugin.java
@@ -71,7 +71,7 @@ public class DatafakerGeneratorPlugin implements GeneratorPlugin {
         rule(builder, ".*email.*", f -> f.internet().safeEmailAddress());
         rule(builder, ".*first_?name.*", f -> f.name().firstName());
         rule(builder, ".*last_?name.*", f -> f.name().lastName());
-        rule(builder, ".*user_?name.*", f -> f.name().username());
+        rule(builder, ".*user_?name.*", f -> f.credentials().username());
         rule(builder, ".*full_?name.*|name", f -> f.name().fullName());
         rule(builder, ".*phone.*", f -> f.regexify("\\([0-9]{3}\\) 555-01[0-9]{2}"));
         rule(builder, ".*company.*", f -> f.company().name());


### PR DESCRIPTION
## Summary

Resolves the non-Javadoc warnings surfaced by `./mvnw verify`/`package`. (The Javadoc warnings are handled separately by the merged docs work and are left untouched here.)

Two distinct warning sources:

- **`bloviate-datafaker` — deprecation.** `Name.username()` is deprecated-for-removal. Following the bytecode, both `Name.username()` and `Internet.username()` simply delegate to the new `Credentials` provider (deprecated since datafaker 2.5.0), so the rule now calls `f.credentials().username()` directly.

- **`bloviate-benchmarks` — shade uber-jar overlaps.** The JMH `benchmarks.jar` merges ~20 dependencies that ship overlapping `META-INF` files. Cleared by:
  - merging duplicate `LICENSE`/`NOTICE` files via `ApacheLicenseResourceTransformer` + `ApacheNoticeResourceTransformer`,
  - broadening the module-info exclude to catch multi-release copies (`META-INF/versions/*/module-info.class`),
  - excluding the source `META-INF/MANIFEST.MF` (the `ManifestResourceTransformer` regenerates it).

## Verification

- `./mvnw clean verify -DskipTests` → **BUILD SUCCESS**, **0 deprecation warnings**, **0 shade/overlap warnings** (only the Javadoc warnings remain).
- The JMH uber-jar still builds and `java -jar benchmarks.jar -l` lists the benchmarks correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)