### PR TITLE
docs: resolve remaining Javadoc warnings across the public API

### DIFF
--- a/bloviate-core/src/main/java/io/bloviate/db/ColumnConstraint.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/ColumnConstraint.java
@@ -39,22 +39,41 @@ import java.util.List;
  */
 public record ColumnConstraint(List<String> allowedValues, BigDecimal min, boolean minInclusive, BigDecimal max, boolean maxInclusive) {
 
-    /** A set-of-allowed-values constraint (categorical / enum / {@code IN}). */
+    /**
+     * A set-of-allowed-values constraint (categorical / enum / {@code IN}).
+     *
+     * @param allowedValues the permitted values (their text form); defensively copied
+     * @return a constraint that admits only {@code allowedValues}
+     */
     public static ColumnConstraint ofValues(List<String> allowedValues) {
         return new ColumnConstraint(List.copyOf(allowedValues), null, false, null, false);
     }
 
-    /** A closed numeric range {@code [min, max]} (both inclusive). */
+    /**
+     * A closed numeric range {@code [min, max]} (both inclusive).
+     *
+     * @param min the inclusive lower bound
+     * @param max the inclusive upper bound
+     * @return a constraint that admits values in {@code [min, max]}
+     */
     public static ColumnConstraint ofRange(BigDecimal min, BigDecimal max) {
         return new ColumnConstraint(null, min, true, max, true);
     }
 
-    /** True if this is a set-of-allowed-values constraint. */
+    /**
+     * True if this is a set-of-allowed-values constraint.
+     *
+     * @return whether allowed values are present
+     */
     public boolean hasAllowedValues() {
         return allowedValues != null && !allowedValues.isEmpty();
     }
 
-    /** True if this is a numeric range with <em>both</em> bounds (the form the engine can honor). */
+    /**
+     * True if this is a numeric range with <em>both</em> bounds (the form the engine can honor).
+     *
+     * @return whether both {@code min} and {@code max} are present
+     */
     public boolean hasBoundedRange() {
         return min != null && max != null;
     }

--- a/bloviate-core/src/main/java/io/bloviate/db/CommitStrategy.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/CommitStrategy.java
@@ -52,6 +52,8 @@ public record CommitStrategy(Mode mode, int batches) {
     }
 
     /**
+     * Validates the mode/batches pairing.
+     *
      * @throws IllegalArgumentException if {@code mode} is null, or {@code batches < 1} for
      *                                  {@link Mode#EVERY_N_BATCHES}
      */
@@ -64,12 +66,20 @@ public record CommitStrategy(Mode mode, int batches) {
         }
     }
 
-    /** The back-compatible default: the engine never changes the connection's autocommit state. */
+    /**
+     * The back-compatible default: the engine never changes the connection's autocommit state.
+     *
+     * @return a {@link Mode#CONNECTION_DEFAULT} strategy
+     */
     public static CommitStrategy connectionDefault() {
         return new CommitStrategy(Mode.CONNECTION_DEFAULT, 0);
     }
 
-    /** Autocommit off, a single commit once the table is fully filled. */
+    /**
+     * Autocommit off, a single commit once the table is fully filled.
+     *
+     * @return a {@link Mode#PER_TABLE} strategy
+     */
     public static CommitStrategy perTable() {
         return new CommitStrategy(Mode.PER_TABLE, 0);
     }
@@ -84,7 +94,11 @@ public record CommitStrategy(Mode mode, int batches) {
         return new CommitStrategy(Mode.EVERY_N_BATCHES, n);
     }
 
-    /** Whether the engine manages the transaction (i.e. anything other than {@link Mode#CONNECTION_DEFAULT}). */
+    /**
+     * Whether the engine manages the transaction (i.e. anything other than {@link Mode#CONNECTION_DEFAULT}).
+     *
+     * @return whether the engine drives autocommit and commits/rolls back itself
+     */
     public boolean managesTransaction() {
         return mode != Mode.CONNECTION_DEFAULT;
     }

--- a/bloviate-core/src/main/java/io/bloviate/db/Distributions.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/Distributions.java
@@ -68,6 +68,10 @@ public final class Distributions {
     /**
      * A normal (Gaussian) {@code double} distribution clamped to {@code [min, max]}.
      *
+     * @param mean              the center of the distribution
+     * @param standardDeviation the spread
+     * @param min               the inclusive lower clamp
+     * @param max               the inclusive upper clamp
      * @return a factory for a {@link NormalDoubleGenerator}
      */
     public static ColumnGeneratorFactory normal(double mean, double standardDeviation, double min, double max) {
@@ -78,6 +82,10 @@ public final class Distributions {
     /**
      * A normal (Gaussian) {@code int} distribution, rounded and clamped to {@code [min, max]}.
      *
+     * @param mean              the center of the distribution
+     * @param standardDeviation the spread
+     * @param min               the inclusive lower clamp
+     * @param max               the inclusive upper clamp
      * @return a factory for a {@link NormalIntegerGenerator}
      */
     public static ColumnGeneratorFactory normalInt(double mean, double standardDeviation, int min, int max) {
@@ -88,6 +96,7 @@ public final class Distributions {
     /**
      * A Zipfian (power-law) distribution over {@code [1, size]} with the classic exponent {@code 1.0}.
      *
+     * @param size the number of distinct values
      * @return a factory for a {@link ZipfianIntegerGenerator}
      */
     public static ColumnGeneratorFactory zipfian(int size) {
@@ -97,6 +106,9 @@ public final class Distributions {
     /**
      * A Zipfian (power-law) distribution over {@code [start, start + size)} with the given exponent.
      *
+     * @param start    the first (most frequent) value
+     * @param size     the number of distinct values
+     * @param exponent the skew exponent (larger ⇒ more skew)
      * @return a factory for a {@link ZipfianIntegerGenerator}
      */
     public static ColumnGeneratorFactory zipfian(int start, int size, double exponent) {
@@ -116,6 +128,9 @@ public final class Distributions {
     /**
      * Recency-skewed timestamps over {@code [start, end]} with the given skew ({@code 1.0} = uniform).
      *
+     * @param start the inclusive start of the window
+     * @param end   the inclusive end of the window
+     * @param skew  the recency skew ({@code 1.0} = uniform, larger ⇒ more weight toward {@code end})
      * @return a factory for a {@link SkewedTimestampGenerator}
      */
     public static ColumnGeneratorFactory recentTimestamps(Instant start, Instant end, double skew) {

--- a/bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
@@ -39,6 +39,10 @@ public abstract class AbstractDatabaseSupport implements DatabaseSupport {
 
     private final Map<JDBCType, GeneratorFactory> registry;
 
+    /**
+     * Builds the support, seeding the registry with cross-database defaults and then invoking
+     * {@link #configure(Map)} so subclasses can add or replace entries.
+     */
     protected AbstractDatabaseSupport() {
         Map<JDBCType, GeneratorFactory> defaults = new EnumMap<>(JDBCType.class);
         registerDefaults(defaults);

--- a/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java
@@ -31,6 +31,10 @@ package io.bloviate.ext;
  */
 public class CockroachDBSupport extends PostgresSupport {
 
+    /** Creates the CockroachDB support with its default configuration. */
+    public CockroachDBSupport() {
+    }
+
     /**
      * CockroachDB ignores the PostgreSQL driver's {@code reWriteBatchedInserts} parameter, so
      * there is nothing to recommend; overrides {@link PostgresSupport#batchRewriteUrlParameter()}

--- a/bloviate-core/src/main/java/io/bloviate/ext/DefaultSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/DefaultSupport.java
@@ -30,4 +30,8 @@ package io.bloviate.ext;
  */
 public class DefaultSupport extends AbstractDatabaseSupport {
 
+    /** Creates the fallback support with only the cross-database default generators. */
+    public DefaultSupport() {
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/GeneratorRegistry.java
@@ -138,6 +138,10 @@ public final class GeneratorRegistry {
         private final Map<String, GeneratorFactory> typeNameRules = new LinkedHashMap<>();
         private final Map<JDBCType, GeneratorFactory> jdbcTypeRules = new EnumMap<>(JDBCType.class);
 
+        /** Creates an empty builder with no rules registered. */
+        public Builder() {
+        }
+
         /**
          * Registers a generator for columns whose {@link Column#name() name} matches the given
          * regular expression. Matching is full ({@link java.util.regex.Matcher#matches()}) and
@@ -207,6 +211,8 @@ public final class GeneratorRegistry {
         }
 
         /**
+         * Builds the registry from the rules registered so far.
+         *
          * @return an immutable registry holding the rules registered so far
          */
         public GeneratorRegistry build() {

--- a/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
@@ -41,6 +41,10 @@ import java.util.Map;
  */
 public class MySQLSupport extends AbstractDatabaseSupport {
 
+    /** Creates the MySQL support with its default configuration. */
+    public MySQLSupport() {
+    }
+
     /**
      * Returns {@code rewriteBatchedStatements}, the MySQL Connector/J parameter that rewrites a batch
      * of single-row {@code INSERT}s into one multi-row statement. Enabling it (e.g.

--- a/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
@@ -67,6 +67,10 @@ import java.util.Map;
  */
 public class PostgresSupport extends AbstractDatabaseSupport {
 
+    /** Creates a PostgreSQL support instance. */
+    public PostgresSupport() {
+    }
+
     /**
      * Returns {@code reWriteBatchedInserts}, the PostgreSQL JDBC driver parameter that rewrites a
      * batch of single-row {@code INSERT}s into one multi-row statement. Enabling it (e.g.

--- a/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
@@ -126,18 +126,38 @@ public class FlatFileGenerator implements FileGenerator {
         }
     }
 
+    /**
+     * Returns the base output file name (the format-specific extension is appended at generation time).
+     *
+     * @return the base file name
+     */
     public String getFileName() {
         return fileName;
     }
 
+    /**
+     * Returns the file format definition controlling the delimiter and extension.
+     *
+     * @return the file format definition
+     */
     public FileDefinition getDefinition() {
         return definition;
     }
 
+    /**
+     * Returns the column definitions, in output order.
+     *
+     * @return the column definitions
+     */
     public List<ColumnDefinition> getColumnDefinitions() {
         return columnDefinitions;
     }
 
+    /**
+     * Returns the number of data rows to generate, excluding the header row.
+     *
+     * @return the data row count
+     */
     public long getRows() {
         return rows;
     }
@@ -157,6 +177,7 @@ public class FlatFileGenerator implements FileGenerator {
         csvPrinter.println();
     }
 
+    /** Builds a {@link FlatFileGenerator}, defaulting to CSV output and {@code 1000} rows with no columns. */
     public static class Builder {
 
         private final String fileName;
@@ -165,6 +186,11 @@ public class FlatFileGenerator implements FileGenerator {
         private List<ColumnDefinition> columnDefinitions = new ArrayList<>();
         private long rows = 1000;
 
+        /**
+         * Creates a builder for the given base output file name (the extension is added per output format).
+         *
+         * @param fileName the base file name, without extension
+         */
         public Builder(String fileName) {
             this.fileName = fileName;
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
@@ -52,6 +52,7 @@ public abstract class AbstractDataGenerator<T> implements DataGenerator<T> {
 
     final Logger logger = LoggerFactory.getLogger(getClass());
 
+    /** The random source backing all value generation; swapped out by {@link #reseed(long)}. */
     protected RandomGenerator random;
 
     /**
@@ -62,6 +63,11 @@ public abstract class AbstractDataGenerator<T> implements DataGenerator<T> {
      */
     protected SeededRandomUtils randomUtils;
 
+    /**
+     * Initializes the generator with the given random source and a {@link SeededRandomUtils} view over it.
+     *
+     * @param random the random source backing all value generation
+     */
     public AbstractDataGenerator(RandomGenerator random) {
         this.random = random;
         this.randomUtils = new SeededRandomUtils(random);

--- a/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
@@ -94,6 +94,7 @@ public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
         return resultSet.getBigDecimal(columnIndex);
     }
 
+    /** Fluent builder for {@link BigDecimalGenerator}. */
     public static class Builder extends AbstractBuilder<BigDecimal> {
 
         private Integer maxPrecision;

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
@@ -41,6 +41,7 @@ public class BitGenerator extends AbstractDataGenerator<Integer> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link BitGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
@@ -57,6 +57,7 @@ public class BitStringGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link BitStringGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
         private int size = 1;
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/ByteGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ByteGenerator.java
@@ -61,6 +61,7 @@ public class ByteGenerator extends AbstractDataGenerator<Byte[]> {
         return ArrayUtils.toObject(resultSet.getBytes(columnIndex));
     }
 
+    /** Fluent builder for {@link ByteGenerator}. */
     public static class Builder extends AbstractBuilder<Byte[]> {
 
         private int size = 25;

--- a/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
@@ -51,6 +51,7 @@ public class CharacterGenerator extends AbstractDataGenerator<Character> {
         return null;
     }
 
+    /** Fluent builder for {@link CharacterGenerator}. */
     public static class Builder extends AbstractBuilder<Character> {
         /**
          * Creates a builder backed by the given seeded random source.

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildCardinality.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildCardinality.java
@@ -40,6 +40,8 @@ public final class ChildCardinality {
     private final long seed;
 
     /**
+     * Creates a cardinality over the inclusive range {@code [minChildren, maxChildren]}.
+     *
      * @param minChildren minimum children per parent (inclusive), {@code >= 0}
      * @param maxChildren maximum children per parent (inclusive), {@code >= minChildren}
      * @param seed        salt mixed into the hash, so different datasets can vary independently
@@ -92,10 +94,20 @@ public final class ChildCardinality {
         return sum;
     }
 
+    /**
+     * Returns the minimum children per parent (inclusive).
+     *
+     * @return the minimum child count
+     */
     public int minChildren() {
         return minChildren;
     }
 
+    /**
+     * Returns the maximum children per parent (inclusive).
+     *
+     * @return the maximum child count
+     */
     public int maxChildren() {
         return maxChildren;
     }

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildCountGenerator.java
@@ -69,10 +69,16 @@ public class ChildCountGenerator extends AbstractDataGenerator<Integer> implemen
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Builder for {@link ChildCountGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private ChildCardinality cardinality;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random source (unused by this generator, but required by the contract)
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildKeyComponentGenerator.java
@@ -135,6 +135,7 @@ public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> i
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Builder for {@link ChildKeyComponentGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private ChildCardinality cardinality;
@@ -143,6 +144,11 @@ public class ChildKeyComponentGenerator extends AbstractDataGenerator<Integer> i
         private long repeat = 1;
         private int cycle = 1;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random source (unused by this generator, but required by the contract)
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
@@ -45,6 +45,7 @@ public class CidrGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link CidrGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CompositeKeyComponentGenerator.java
@@ -83,12 +83,18 @@ public class CompositeKeyComponentGenerator extends AbstractDataGenerator<Intege
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Builder for {@link CompositeKeyComponentGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private int start = 1;
         private long repeat = 1;
         private int cycle = 1;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random source (unused by this generator, but required by the contract)
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/CurrentSqlTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CurrentSqlTimestampGenerator.java
@@ -45,8 +45,14 @@ public class CurrentSqlTimestampGenerator extends AbstractDataGenerator<Timestam
         return resultSet.getTimestamp(columnIndex);
     }
 
+    /** Fluent builder for {@link CurrentSqlTimestampGenerator}. */
     public static class Builder extends AbstractBuilder<Timestamp> {
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/DoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DoubleGenerator.java
@@ -50,6 +50,7 @@ public class DoubleGenerator extends AbstractDataGenerator<Double> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link DoubleGenerator}. */
     public static class Builder extends AbstractBuilder<Double> {
 
         private double startInclusive = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/FloatGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/FloatGenerator.java
@@ -49,6 +49,7 @@ public class FloatGenerator extends AbstractDataGenerator<Float> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link FloatGenerator}. */
     public static class Builder extends AbstractBuilder<Float> {
 
         private float startInclusive = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
@@ -110,12 +110,18 @@ public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> 
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Builder for {@link GroupedPermutationGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private int groupSize = 1;
         private int start = 0;
         private long seed = 0;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random source (unused by this generator, but required by the contract)
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPrefixGenerator.java
@@ -93,12 +93,22 @@ public class GroupedPrefixGenerator<T> extends AbstractDataGenerator<T> implemen
         return delegate.get(resultSet, columnIndex);
     }
 
+    /**
+     * Builder for {@link GroupedPrefixGenerator}.
+     *
+     * @param <T> the Java type produced by the wrapped delegate
+     */
     public static class Builder<T> extends AbstractBuilder<T> {
 
         private int groupSize = 1;
         private int prefixSize = 0;
         private DataGenerator<T> delegate;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random source (the wrapped delegate may use it)
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
@@ -46,6 +46,7 @@ public class InetGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link InetGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
@@ -65,6 +65,7 @@ public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
         return result;
     }
 
+    /** Fluent builder for {@link IntegerArrayGenerator}. */
     public static class Builder extends AbstractBuilder<Integer[]> {
 
         private int length = 3;

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerGenerator.java
@@ -50,6 +50,7 @@ public class IntegerGenerator extends AbstractDataGenerator<Integer> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link IntegerGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private int startInclusive = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
@@ -54,6 +54,7 @@ public class IntervalGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link IntervalGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/JsonbGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/JsonbGenerator.java
@@ -67,6 +67,7 @@ public class JsonbGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link JsonbGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
 
         private int fields = 3;

--- a/bloviate-core/src/main/java/io/bloviate/gen/LongGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/LongGenerator.java
@@ -49,6 +49,7 @@ public class LongGenerator extends AbstractDataGenerator<Long> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link LongGenerator}. */
     public static class Builder extends AbstractBuilder<Long> {
 
         private long startInclusive = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
@@ -53,6 +53,7 @@ public class MacAddressGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link MacAddressGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
 
         private int octets = 6;

--- a/bloviate-core/src/main/java/io/bloviate/gen/NormalDoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/NormalDoubleGenerator.java
@@ -58,6 +58,7 @@ public class NormalDoubleGenerator extends AbstractDataGenerator<Double> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Builds a {@link NormalDoubleGenerator}, defaulting to a standard normal distribution (mean 0, standard deviation 1) with effectively unbounded {@code min}/{@code max}. */
     public static class Builder extends AbstractBuilder<Double> {
 
         private double mean = 0.0;
@@ -65,25 +66,54 @@ public class NormalDoubleGenerator extends AbstractDataGenerator<Double> {
         private double min = -Double.MAX_VALUE;
         private double max = Double.MAX_VALUE;
 
+        /**
+         * Creates a builder drawing from the given random source.
+         *
+         * @param random the random source backing the generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the distribution mean (center). Returns this builder for chaining.
+         *
+         * @param mean the mean of the normal distribution
+         * @return this builder
+         */
         public Builder mean(double mean) {
             this.mean = mean;
             return this;
         }
 
+        /**
+         * Sets the distribution standard deviation (spread); must be non-negative. Returns this builder for chaining.
+         *
+         * @param standardDeviation the standard deviation of the normal distribution
+         * @return this builder
+         */
         public Builder standardDeviation(double standardDeviation) {
             this.standardDeviation = standardDeviation;
             return this;
         }
 
+        /**
+         * Sets the inclusive lower bound that generated values are clamped to. Returns this builder for chaining.
+         *
+         * @param min the minimum value
+         * @return this builder
+         */
         public Builder min(double min) {
             this.min = min;
             return this;
         }
 
+        /**
+         * Sets the inclusive upper bound that generated values are clamped to. Returns this builder for chaining.
+         *
+         * @param max the maximum value
+         * @return this builder
+         */
         public Builder max(double max) {
             this.max = max;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/NormalIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/NormalIntegerGenerator.java
@@ -54,6 +54,7 @@ public class NormalIntegerGenerator extends AbstractDataGenerator<Integer> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Builds a {@link NormalIntegerGenerator}, defaulting to a standard normal distribution (mean 0, standard deviation 1) spanning the full {@code int} range. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private double mean = 0.0;
@@ -61,25 +62,54 @@ public class NormalIntegerGenerator extends AbstractDataGenerator<Integer> {
         private int min = Integer.MIN_VALUE;
         private int max = Integer.MAX_VALUE;
 
+        /**
+         * Creates a builder drawing from the given random source.
+         *
+         * @param random the random source backing the generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the distribution mean (center); kept as a {@code double} so the center may sit between integers. Returns this builder for chaining.
+         *
+         * @param mean the mean of the normal distribution
+         * @return this builder
+         */
         public Builder mean(double mean) {
             this.mean = mean;
             return this;
         }
 
+        /**
+         * Sets the distribution standard deviation (spread); must be non-negative. Returns this builder for chaining.
+         *
+         * @param standardDeviation the standard deviation of the normal distribution
+         * @return this builder
+         */
         public Builder standardDeviation(double standardDeviation) {
             this.standardDeviation = standardDeviation;
             return this;
         }
 
+        /**
+         * Sets the inclusive lower bound that rounded values are clamped to. Returns this builder for chaining.
+         *
+         * @param min the minimum value
+         * @return this builder
+         */
         public Builder min(int min) {
             this.min = min;
             return this;
         }
 
+        /**
+         * Sets the inclusive upper bound that rounded values are clamped to. Returns this builder for chaining.
+         *
+         * @param max the maximum value
+         * @return this builder
+         */
         public Builder max(int max) {
             this.max = max;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ScaledBigDecimalGenerator.java
@@ -53,6 +53,7 @@ public class ScaledBigDecimalGenerator extends AbstractDataGenerator<BigDecimal>
         return resultSet.getBigDecimal(columnIndex);
     }
 
+    /** Fluent builder for {@link ScaledBigDecimalGenerator}. */
     public static class Builder extends AbstractBuilder<BigDecimal> {
 
         private double startInclusive = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SequentialIntegerGenerator.java
@@ -69,11 +69,17 @@ public class SequentialIntegerGenerator extends AbstractDataGenerator<Integer> i
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link SequentialIntegerGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private int startInclusive = 1;
         private int endInclusive = Integer.MAX_VALUE;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
@@ -49,6 +49,7 @@ public class ShortGenerator extends AbstractDataGenerator<Short> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link ShortGenerator}. */
     public static class Builder extends AbstractBuilder<Short> {
 
         private int startInclusive = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SkewedTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SkewedTimestampGenerator.java
@@ -61,27 +61,50 @@ public class SkewedTimestampGenerator extends AbstractDataGenerator<Timestamp> {
         return resultSet.getTimestamp(columnIndex);
     }
 
+    /** Fluent builder for {@link SkewedTimestampGenerator}. */
     public static class Builder extends AbstractBuilder<Timestamp> {
 
         private Instant start = DEFAULT_REFERENCE;
         private Instant end = DEFAULT_REFERENCE.plus(Duration.ofDays(5 * 365));
         private double skew = 3.0;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * The earliest timestamp, inclusive.
+         *
+         * @param start the lower bound of the generated range
+         * @return this builder, for chaining
+         */
         public Builder start(Instant start) {
             this.start = start;
             return this;
         }
 
+        /**
+         * The latest timestamp, inclusive.
+         *
+         * @param end the upper bound of the generated range
+         * @return this builder, for chaining
+         */
         public Builder end(Instant end) {
             this.end = end;
             return this;
         }
 
-        /** Recency skew; {@code 1.0} is uniform, larger pulls mass toward {@code end}. Must be {@code > 0}. */
+        /**
+         * Recency skew; {@code 1.0} is uniform, larger pulls mass toward {@code end}. Must be {@code > 0}.
+         *
+         * @param skew the skew exponent applied across the range
+         * @return this builder, for chaining
+         */
         public Builder skew(double skew) {
             this.skew = skew;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlBlobGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlBlobGenerator.java
@@ -51,6 +51,7 @@ public class SqlBlobGenerator extends AbstractDataGenerator<Blob> {
         return resultSet.getBlob(columnIndex);
     }
 
+    /** Fluent builder for {@link SqlBlobGenerator}. */
     public static class Builder extends AbstractBuilder<Blob> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlClobGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlClobGenerator.java
@@ -51,6 +51,7 @@ public class SqlClobGenerator extends AbstractDataGenerator<Clob> {
         return resultSet.getClob(columnIndex);
     }
 
+    /** Fluent builder for {@link SqlClobGenerator}. */
     public static class Builder extends AbstractBuilder<Clob> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlStructGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlStructGenerator.java
@@ -59,6 +59,7 @@ public class SqlStructGenerator extends AbstractDataGenerator<Struct> {
         return (Struct) resultSet.getObject(columnIndex);
     }
 
+    /** Fluent builder for {@link SqlStructGenerator}. */
     public static class Builder extends AbstractBuilder<Struct> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticBigDecimalGenerator.java
@@ -45,6 +45,7 @@ public class StaticBigDecimalGenerator extends AbstractDataGenerator<BigDecimal>
         return resultSet.getBigDecimal(columnIndex);
     }
 
+    /** Fluent builder for {@link StaticBigDecimalGenerator}. */
     public static class Builder extends AbstractBuilder<BigDecimal> {
 
         private BigDecimal value = BigDecimal.ZERO;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticDoubleGenerator.java
@@ -45,6 +45,7 @@ public class StaticDoubleGenerator extends AbstractDataGenerator<Double> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link StaticDoubleGenerator}. */
     public static class Builder extends AbstractBuilder<Double> {
 
         private Double value = 0d;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticFloatGenerator.java
@@ -45,6 +45,7 @@ public class StaticFloatGenerator extends AbstractDataGenerator<Float> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link StaticFloatGenerator}. */
     public static class Builder extends AbstractBuilder<Float> {
 
         private Float value = 0f;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StaticIntegerGenerator.java
@@ -45,6 +45,7 @@ public class StaticIntegerGenerator extends AbstractDataGenerator<Integer> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link StaticIntegerGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private Integer value = 0;

--- a/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
@@ -72,6 +72,7 @@ public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
         return result;
     }
 
+    /** Fluent builder for {@link StringArrayGenerator}. */
     public static class Builder extends AbstractBuilder<String[]> {
 
         private int length = 3;

--- a/bloviate-core/src/main/java/io/bloviate/gen/WeightedCategoricalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/WeightedCategoricalGenerator.java
@@ -75,6 +75,11 @@ public class WeightedCategoricalGenerator<T> extends AbstractDataGenerator<T> {
         return (T) resultSet.getObject(columnIndex);
     }
 
+    /**
+     * Fluent builder for {@link WeightedCategoricalGenerator}.
+     *
+     * @param <T> the category value type produced by the generator
+     */
     public static class Builder<T> extends AbstractBuilder<T> {
 
         private record Entry<T>(T value, double weight) {
@@ -82,12 +87,21 @@ public class WeightedCategoricalGenerator<T> extends AbstractDataGenerator<T> {
 
         private final List<Entry<T>> entries = new ArrayList<>();
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
         /**
          * Adds one value with its (positive) weight. Calls accumulate, so this can be chained.
+         *
+         * @param value  the value to emit
+         * @param weight the relative weight of the value; must be positive
+         * @return this builder, for chaining
          */
         public Builder<T> add(T value, double weight) {
             if (weight <= 0) {
@@ -100,6 +114,9 @@ public class WeightedCategoricalGenerator<T> extends AbstractDataGenerator<T> {
         /**
          * Adds every value/weight pair from the map. Order is irrelevant — the generator imposes a
          * stable canonical order so output is reproducible regardless of the map's iteration order.
+         *
+         * @param weights a map of values to their relative (positive) weights
+         * @return this builder, for chaining
          */
         public Builder<T> weights(Map<? extends T, ? extends Number> weights) {
             for (Map.Entry<? extends T, ? extends Number> entry : weights.entrySet()) {

--- a/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
@@ -45,6 +45,7 @@ public class XmlGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Fluent builder for {@link XmlGenerator}. */
     public static class Builder extends AbstractBuilder<String> {
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
@@ -68,29 +68,50 @@ public class ZipfianIntegerGenerator extends AbstractDataGenerator<Integer> {
         return resultSet.wasNull() ? null : value;
     }
 
+    /** Fluent builder for {@link ZipfianIntegerGenerator}. */
     public static class Builder extends AbstractBuilder<Integer> {
 
         private int start = 1;
         private int size = 0;
         private double exponent = 1.0;
 
+        /**
+         * Creates a builder backed by the given seeded random source.
+         *
+         * @param random the random source used to draw generated values
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
-        /** The first (most frequent) value; ranks run {@code [start, start + size)}. Default {@code 1}. */
+        /**
+         * The first (most frequent) value; ranks run {@code [start, start + size)}. Default {@code 1}.
+         *
+         * @param start the lowest rank value
+         * @return this builder, for chaining
+         */
         public Builder start(int start) {
             this.start = start;
             return this;
         }
 
-        /** The number of distinct values; required and must be {@code >= 1}. */
+        /**
+         * The number of distinct values; required and must be {@code >= 1}.
+         *
+         * @param size the count of distinct ranks
+         * @return this builder, for chaining
+         */
         public Builder size(int size) {
             this.size = size;
             return this;
         }
 
-        /** The skew exponent; {@code 1.0} is classic Zipf, higher concentrates more on the head. */
+        /**
+         * The skew exponent; {@code 1.0} is classic Zipf, higher concentrates more on the head.
+         *
+         * @param exponent the skew exponent
+         * @return this builder, for chaining
+         */
         public Builder exponent(double exponent) {
             this.exponent = exponent;
             return this;

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CreditGenerator.java
@@ -29,7 +29,10 @@ import java.util.random.RandomGenerator;
  */
 public class CreditGenerator extends AbstractDataGenerator<String> {
 
+    /** The TPC-C good-credit marker, {@code "GC"}. */
     public static final String GOOD_CREDIT = "GC";
+
+    /** The TPC-C bad-credit marker, {@code "BC"}. */
     public static final String BAD_CREDIT = "BC";
 
     @Override
@@ -42,8 +45,14 @@ public class CreditGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Builds {@link CreditGenerator} instances. */
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/CustomerLastNameGenerator.java
@@ -82,11 +82,17 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Builds {@link CustomerLastNameGenerator} instances. */
     public static class Builder extends AbstractBuilder<String> {
 
         private int groupSize = 0;
         private int enumeratedCount = 0;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
@@ -94,6 +100,9 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
         /**
          * The number of customers per district, used to locate each row's position within its
          * district when {@link #enumeratedCount(int)} is set.
+         *
+         * @param groupSize the number of customers per district
+         * @return this builder
          */
         public Builder groupSize(int groupSize) {
             this.groupSize = groupSize;
@@ -104,6 +113,9 @@ public class CustomerLastNameGenerator extends AbstractDataGenerator<String> {
          * The number of customers at the start of each district whose last name is enumerated
          * deterministically ({@code 0..enumeratedCount-1}); the rest use {@code NURand}. Must be
          * in {@code [0, }{@value #MAX_ENUMERATED}{@code ]}; {@code 0} disables enumeration.
+         *
+         * @param enumeratedCount the number of deterministically enumerated customers per district
+         * @return this builder
          */
         public Builder enumeratedCount(int enumeratedCount) {
             this.enumeratedCount = enumeratedCount;

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/DataColumnGenerator.java
@@ -30,6 +30,7 @@ import java.util.random.RandomGenerator;
  */
 public class DataColumnGenerator extends AbstractDataGenerator<String> {
 
+    /** The TPC-C "original" data marker embedded in 10% of generated values. */
     public static final String ORIGINAL = "ORIGINAL";
 
     @Override
@@ -51,8 +52,14 @@ public class DataColumnGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Builds {@link DataColumnGenerator} instances. */
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random generator backing the produced generator
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/OrderLineDeliveryDateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/OrderLineDeliveryDateGenerator.java
@@ -78,21 +78,39 @@ public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timest
         return resultSet.getTimestamp(columnIndex);
     }
 
+    /** Builds {@link OrderLineDeliveryDateGenerator} instances. */
     public static class Builder extends AbstractBuilder<Timestamp> {
 
         private ChildCardinality cardinality;
         private int ordersPerDistrict = 1;
         private int deliveredThreshold = 0;
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random generator to seed the generator with
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }
 
+        /**
+         * Sets the shared per-order line-count cardinality (required).
+         *
+         * @param cardinality the {@link ChildCardinality} shared with the {@code order_line} keys
+         * @return this builder
+         */
         public Builder cardinality(ChildCardinality cardinality) {
             this.cardinality = cardinality;
             return this;
         }
 
+        /**
+         * Sets the number of orders per district, used to wrap the parent {@code o_id} walker.
+         *
+         * @param ordersPerDistrict the number of orders per district
+         * @return this builder
+         */
         public Builder ordersPerDistrict(int ordersPerDistrict) {
             this.ordersPerDistrict = ordersPerDistrict;
             return this;
@@ -101,6 +119,9 @@ public class OrderLineDeliveryDateGenerator extends AbstractDataGenerator<Timest
         /**
          * Orders with {@code o_id <= deliveredThreshold} are delivered (timestamp); the rest are
          * undelivered (NULL). For TPC-C this is {@code ordersPerDistrict - newOrdersPerDistrict}.
+         *
+         * @param deliveredThreshold the highest {@code o_id} considered delivered
+         * @return this builder
          */
         public Builder deliveredThreshold(int deliveredThreshold) {
             this.deliveredThreshold = deliveredThreshold;

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -67,12 +67,19 @@ import java.util.Set;
  */
 public final class TPCCConfiguration {
 
+    /** Default number of items (I), per the spec. */
     public static final int DEFAULT_ITEMS = 100_000;
+    /** Default districts per warehouse (D), per the spec. */
     public static final int DEFAULT_DISTRICTS_PER_WAREHOUSE = 10;
+    /** Default customers (and orders) per district (C), per the spec. */
     public static final int DEFAULT_CUSTOMERS_PER_DISTRICT = 3_000;
+    /** Default minimum order lines per order (inclusive), per the spec. */
     public static final int DEFAULT_MIN_LINES_PER_ORDER = 5;
+    /** Default maximum order lines per order (inclusive), per the spec. */
     public static final int DEFAULT_MAX_LINES_PER_ORDER = 15;
+    /** Default most-recent (undelivered) orders per district held in {@code new_order}, per the spec. */
     public static final int DEFAULT_NEW_ORDERS_PER_DISTRICT = 900;
+    /** Default number of {@code c_last} names enumerated deterministically per district. */
     public static final int DEFAULT_ENUMERATED_LAST_NAMES = CustomerLastNameGenerator.MAX_ENUMERATED;
 
     // salt for the deterministic per-order line-count hash; fixed so datasets are reproducible

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/ZipCodeGenerator.java
@@ -42,8 +42,14 @@ public class ZipCodeGenerator extends AbstractDataGenerator<String> {
         return resultSet.getString(columnIndex);
     }
 
+    /** Builds {@link ZipCodeGenerator} instances. */
     public static class Builder extends AbstractBuilder<String> {
 
+        /**
+         * Creates a builder.
+         *
+         * @param random the random generator to seed the generator with
+         */
         public Builder(RandomGenerator random) {
             super(random);
         }

--- a/bloviate-core/src/main/java/io/bloviate/util/DatabaseUtils.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/DatabaseUtils.java
@@ -52,6 +52,10 @@ import java.util.*;
  */
 public class DatabaseUtils {
 
+    /** Static utility holder — not instantiable. */
+    private DatabaseUtils() {
+    }
+
     private static final Logger logger = LoggerFactory.getLogger(DatabaseUtils.class);
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/util/SeededRandomUtils.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/SeededRandomUtils.java
@@ -32,6 +32,8 @@ import java.util.random.RandomGenerator;
  * characters {@code RandomStringUtils} would yield for those flags &mdash; which avoids the
  * draw-and-reject loop entirely. The general {@code [start, end)} code-point path is retained for
  * completeness and mirrors the classic {@code RandomStringUtils.random(...)} rejection algorithm.
+ *
+ * @param random the seeded random source backing all helpers
  */
 
 public record SeededRandomUtils(RandomGenerator random) {

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerGeneratorPlugin.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerGeneratorPlugin.java
@@ -58,6 +58,8 @@ public class DatafakerGeneratorPlugin implements GeneratorPlugin {
     }
 
     /**
+     * Creates a plugin that generates realistic values in the given locale.
+     *
      * @param locale the locale for realistic values; fixed (not the JVM default) for reproducibility
      */
     public DatafakerGeneratorPlugin(Locale locale) {

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerStringGenerator.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/DatafakerStringGenerator.java
@@ -51,6 +51,8 @@ public class DatafakerStringGenerator extends AbstractDataGenerator<String> {
     private Faker faker;
 
     /**
+     * Creates a generator that draws realistic values from the given Datafaker provider.
+     *
      * @param random        the engine-supplied, column-seeded random source
      * @param locale        the locale for realistic values (fixed for reproducibility)
      * @param maxSize        the column's max length, or null/0 for unbounded; longer values are truncated

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Geo.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Geo.java
@@ -23,6 +23,12 @@ package io.bloviate.datafaker;
  * WY 90210". Drawn from a bundled reference dataset by {@link Places}; this is what Datafaker's
  * independent address parts cannot provide.
  *
+ * @param city              the city name
+ * @param stateAbbreviation the state's two-letter abbreviation
+ * @param state             the full state name
+ * @param zip               a valid zip/postal code for the city
+ * @param areaCode          a telephone area code local to the city
+ * @param country           the country name
  * @since 2.12.0
  * @see Places
  * @see RowContext

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Person.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Person.java
@@ -22,6 +22,11 @@ package io.bloviate.datafaker;
  * different fields of the same {@link Person} agree (no "jane.doe with email bob@…"). Materialized
  * once per row by {@link People}.
  *
+ * @param firstName the given name
+ * @param lastName  the family name
+ * @param fullName  the full name, derived from {@code firstName} and {@code lastName}
+ * @param email     an email address derived from the name (reserved {@code example.*} domain)
+ * @param username  a username derived from the name
  * @since 2.12.0
  * @see People
  * @see RowContext

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowContext.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/RowContext.java
@@ -57,6 +57,8 @@ public final class RowContext<E> {
     private final ThreadLocal<Memo<E>> memo = ThreadLocal.withInitial(Memo::new);
 
     /**
+     * Creates a context that materializes one entity per row from the given factory.
+     *
      * @param entityFactory a pure mapping from row index to the row's entity; must depend only on the
      *                      row index (and a fixed seed it closes over) so output is order-independent
      */

--- a/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
+++ b/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
@@ -49,6 +49,10 @@ import java.util.Optional;
  */
 public class BloviateExtension implements BeforeEachCallback {
 
+    /** Creates the extension; instantiated by JUnit via {@code @ExtendWith}. */
+    public BloviateExtension() {
+    }
+
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
         FillDatabase fill = resolveAnnotation(context);

--- a/bloviate-junit/src/main/java/io/bloviate/junit/FillDatabase.java
+++ b/bloviate-junit/src/main/java/io/bloviate/junit/FillDatabase.java
@@ -59,11 +59,15 @@ import java.lang.annotation.Target;
 public @interface FillDatabase {
 
     /**
+     * The number of rows to generate per table.
+     *
      * @return the number of rows to generate per table (the default row count); defaults to 100
      */
     long rows() default 100L;
 
     /**
+     * The JDBC batch size used for INSERTs.
+     *
      * @return the JDBC batch size used for INSERTs; defaults to 1000
      */
     int batchSize() default 1000;

--- a/bloviate-testcontainers/src/main/java/io/bloviate/testcontainers/BloviateContainers.java
+++ b/bloviate-testcontainers/src/main/java/io/bloviate/testcontainers/BloviateContainers.java
@@ -77,6 +77,8 @@ public final class BloviateContainers {
         }
 
         /**
+         * Sets the JDBC batch size for INSERTs.
+         *
          * @param batchSize the JDBC batch size for INSERTs (default 1000)
          * @return this builder
          */
@@ -86,6 +88,8 @@ public final class BloviateContainers {
         }
 
         /**
+         * Sets the default number of rows to generate per table.
+         *
          * @param rows the default number of rows to generate per table (default 100)
          * @return this builder
          */
@@ -95,6 +99,8 @@ public final class BloviateContainers {
         }
 
         /**
+         * Sets the base seed for reproducible generation.
+         *
          * @param seed the base seed for reproducible generation (default 0); vary it for a
          *             different but reproducible dataset
          * @return this builder
@@ -116,6 +122,8 @@ public final class BloviateContainers {
         }
 
         /**
+         * Sets optional per-table overrides.
+         *
          * @param tableConfigurations optional per-table overrides (row counts, column generators)
          * @return this builder
          */


### PR DESCRIPTION
## Summary

`./mvnw verify`/`package` still emitted ~120 `maven-javadoc-plugin` warnings even after the earlier Javadoc pass (#496). Javadoc's default output cap (100 warnings/module) had been hiding most of them, so they surfaced in waves. This backfills the missing documentation so the build produces **zero Javadoc warnings**.

Warning categories addressed:
- missing `@param`/`@return` on static factories and builder setters (`Distributions`, `ColumnConstraint`, `Zipfian*`, `WeightedCategorical*`, `SkewedTimestamp*`, TPC-C builders, …),
- undocumented inner `Builder` classes/constructors and record accessors,
- `no main description` on tag-only comments (annotation elements, container builder methods),
- undocumented record components (`Geo`, `Person`, `SeededRandomUtils`, `ChildCardinality`),
- `use of default constructor` — see below.

## Behavioral note

Mostly additive doc comments. To document classes that had only an **implicit** default constructor, explicit constructors were added (behaviorally identical):
- **public** no-arg constructors on the reflectively/`ServiceLoader`-instantiated service classes — `PostgresSupport`, `MySQLSupport`, `CockroachDBSupport`, `DefaultSupport`, `GeneratorRegistry.Builder`, and JUnit's `BloviateExtension` (kept public — JUnit instantiates it via `@ExtendWith`);
- a **private** constructor on the all-static `DatabaseUtils` to mark it non-instantiable.

## Verification

- `./mvnw clean verify -DskipTests` → **BUILD SUCCESS**, **0 Javadoc warnings**, **0 compile warnings** (the whole reactor, incl. test compilation).

> Note: this branch is off `main` and intentionally does **not** include the datafaker deprecation / shade fixes from #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)