### PR TITLE
docs: add security policy, code of conduct, and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: 🐛 Bug Report
+description: Report a problem or unexpected behavior in Bloviate
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please search
+        [existing issues](https://github.com/timveil/bloviate/issues) first to
+        avoid duplicates.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: |
+        How can we reproduce the issue? A minimal code snippet, schema, or
+        failing test is enormously helpful.
+      placeholder: |
+        1. Configure DatabaseFiller with '...'
+        2. Run against '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include full stack traces or logs if available.
+    validations:
+      required: true
+  - type: dropdown
+    id: module
+    attributes:
+      label: Affected module
+      options:
+        - bloviate-core
+        - bloviate-junit
+        - bloviate-testcontainers
+        - bloviate-datafaker
+        - Not sure
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Bloviate version
+      placeholder: e.g. 2.15.2
+    validations:
+      required: true
+  - type: input
+    id: database
+    attributes:
+      label: Database & version
+      description: Which database (and version) were you filling?
+      placeholder: e.g. PostgreSQL 17, MySQL 9, CockroachDB 24.x
+    validations:
+      required: false
+  - type: input
+    id: java
+    attributes:
+      label: Java version
+      placeholder: e.g. Temurin 25
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help us understand the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/timveil/bloviate/discussions
+    about: Ask questions, share ideas, or get help using Bloviate.
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/timveil/bloviate/security/advisories/new
+    about: Please report security issues privately, not as public issues. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for Bloviate
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please search
+        [existing issues](https://github.com/timveil/bloviate/issues) and
+        [discussions](https://github.com/timveil/bloviate/discussions) first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: |
+        What problem are you trying to solve? Is your feature request related to
+        a frustration or limitation? e.g. "I'm always frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+  - type: dropdown
+    id: module
+    attributes:
+      label: Relevant module
+      options:
+        - bloviate-core
+        - bloviate-junit
+        - bloviate-testcontainers
+        - bloviate-datafaker
+        - New module / not sure
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, examples, or screenshots about the request here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Thanks for contributing to Bloviate! A few quick reminders:
+
+• PR TITLES are validated by commitlint and must follow Conventional Commits
+  (e.g. "feat(generator): add UUIDv7 support", "fix: handle null FK columns").
+  See CONTRIBUTING.md for the full list of types and their version impact.
+• Run `./mvnw verify` locally before opening the PR.
+-->
+
+## Description
+
+<!-- What does this PR do and why? -->
+
+## Related Issues
+
+<!-- Link any related issues, e.g. "Closes #123" or "Relates to #456". -->
+
+## Type of Change
+
+<!-- Check all that apply. Should align with your Conventional Commit PR title. -->
+
+- [ ] `fix` — bug fix (patch)
+- [ ] `feat` — new feature (minor)
+- [ ] `perf` — performance improvement (patch)
+- [ ] `refactor` — code change that neither fixes a bug nor adds a feature (patch)
+- [ ] Breaking change (`feat!` / `BREAKING CHANGE:`) (major)
+- [ ] `docs` / `test` / `ci` / `chore` / `style` — no release
+
+## Affected Module(s)
+
+- [ ] `bloviate-core`
+- [ ] `bloviate-junit`
+- [ ] `bloviate-testcontainers`
+- [ ] `bloviate-datafaker`
+- [ ] Build / CI / tooling
+
+## How Has This Been Tested?
+
+<!-- Describe the tests you ran and any relevant configuration (database, version, etc.). -->
+
+## Checklist
+
+- [ ] My PR title follows the [Conventional Commits](https://conventionalcommits.org/) format
+- [ ] `./mvnw verify` passes locally (tests included)
+- [ ] I have added or updated tests covering my changes
+- [ ] I have updated documentation as needed (README, ARCHITECTURE, etc.)
+- [ ] My changes follow the existing code style and conventions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**tjveil@gmail.com**. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+Bloviate is a Java library for generating dummy test data for JDBC-compatible
+relational databases. It is intended for use in development, testing, and
+benchmarking environments. The maintainers take security seriously and
+appreciate responsible disclosure of any vulnerabilities.
+
+## Supported Versions
+
+Security fixes are released against the latest published version. We recommend
+always running the most recent release.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.15.x  | :white_check_mark: |
+| < 2.15  | :x:                |
+
+Because the project follows [semantic versioning](https://semver.org/) driven by
+[Conventional Commits](https://conventionalcommits.org/), fixes are shipped in a
+new patch or minor release rather than backported to older lines.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately using GitHub's built-in
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+
+1. Go to the [**Security** tab](https://github.com/timveil/bloviate/security)
+   of the repository.
+2. Click **Report a vulnerability** to open a private advisory.
+3. Provide the details described below.
+
+If you are unable to use GitHub's private reporting, you may contact the
+maintainer directly at **tjveil@gmail.com**.
+
+### What to Include
+
+A good report helps us triage and fix the issue quickly. Where possible, please
+include:
+
+- A description of the vulnerability and its potential impact.
+- The affected version(s) and module(s) (`bloviate-core`, `bloviate-junit`,
+  `bloviate-testcontainers`, `bloviate-datafaker`).
+- Steps to reproduce, ideally a minimal proof of concept.
+- Any relevant configuration, stack traces, or logs.
+- Suggested remediation, if you have one.
+
+## Disclosure Process
+
+- We will acknowledge your report within **5 business days**.
+- We will investigate, keep you informed of progress, and aim to provide an
+  initial assessment within **10 business days**.
+- Once a fix is available, we will publish a new release and, where warranted, a
+  [GitHub Security Advisory](https://github.com/timveil/bloviate/security/advisories)
+  with appropriate credit to the reporter (unless you prefer to remain
+  anonymous).
+- Please give us a reasonable opportunity to release a fix before any public
+  disclosure.
+
+## Scope
+
+Bloviate generates randomized data and executes SQL against databases you
+configure. Keep the following in mind:
+
+- **Use against test/throwaway databases only.** Bloviate writes generated data
+  into the tables you point it at. Do not run it against production systems or
+  databases containing real or sensitive data.
+- **Connection credentials and JDBC URLs are supplied by the caller.** Protect
+  these as you would any other database secret; never commit them to source
+  control.
+- Reports concerning the security of the library itself — for example, unsafe
+  SQL construction, dependency vulnerabilities, or unexpected data exfiltration —
+  are in scope and welcome.
+
+## Dependencies
+
+This repository uses [Dependabot](.github/dependabot.yml) to keep Maven and
+GitHub Actions dependencies up to date. If you spot a vulnerable transitive
+dependency that automated tooling has missed, please report it using the process
+above.


### PR DESCRIPTION
## Description

Adds the standard GitHub community health files to the repository, tuned to Bloviate's conventions (Apache-2.0, semantic-release / Conventional Commits, four published modules).

## What's included

- **`SECURITY.md`** — supported-versions table (`2.15.x`), private vulnerability reporting via GitHub Security Advisories with an email fallback, disclosure timeline, a scope note warning against running Bloviate on production/real data, and a pointer to the existing Dependabot config.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1, enforcement contact set to the maintainer.
- **Issue templates** (`.github/ISSUE_TEMPLATE/`) — `bug_report.yml` and `feature_request.yml` as GitHub issue forms with module dropdowns scoped to the four modules and Conventional Commit title prefixes; `config.yml` disables blank issues and routes questions to Discussions and security reports to advisories.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — aligned with Conventional Commits (commitlint) and `./mvnw verify`, with type/module checklists.

## Notes

- The `security/advisories/new` link in the issue config works once private vulnerability reporting is enabled in **Settings → Security**.

## Type of Change

- [x] `docs` — no release

## Checklist

- [x] My PR title follows the Conventional Commits format
- [x] My changes follow the existing code style and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)