### PR TITLE
ci: harden GitHub Actions (token permissions + SHA pinning)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
       with:
         java-version: '25'
         distribution: 'temurin'
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         languages: ${{ matrix.language }}
 
@@ -41,4 +41,4 @@ jobs:
        mvn clean package -DskipTests
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '25'
           cache: 'maven'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,12 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least privilege: this workflow only builds and tests, so read-only access is
+# all it needs. Declared explicitly so it keeps working once the repository
+# default workflow token is set to read-only.
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "RELEASE_PAT is configured."
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           # PAT (not GITHUB_TOKEN) so the release commit can be pushed back to the
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: true
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -58,7 +58,7 @@ jobs:
           server-password: MAVEN_TOKEN
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -72,7 +72,7 @@ jobs:
           echo "GitHub actor: ${{ github.actor }}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           

--- a/.github/workflows/update-maven-wrapper.yml
+++ b/.github/workflows/update-maven-wrapper.yml
@@ -15,10 +15,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: '25'
           distribution: 'temurin'


### PR DESCRIPTION
## Description

GitHub Actions supply-chain hardening, in two parts.

### 1. Least-privilege token permissions

Audited all six workflows; only `maven.yml` relied on the implicit default token scope. Added `contents: read` to it so the repository default workflow token can be (and now is) read-only without breaking the build. Every other workflow already declared its own `permissions:`.

> The repo default workflow token has already been set to **read-only** (with "create and approve PRs" kept on for `update-maven-wrapper.yml`'s `gh pr create`). The privileged workflows keep working because they request their own scopes.

### 2. SHA-pinned actions

Pinned every third-party action to a full commit SHA (with a trailing `# vX` comment) instead of a mutable tag, closing the tag-hijack vector:

| Action | Pinned SHA (`# v`) |
| --- | --- |
| `actions/checkout` | `9c091bb` # v7 |
| `actions/setup-java` | `1bcf9fb` # v5 |
| `actions/setup-node` | `48b55a0` # v6 |
| `actions/cache` | `55cc834` # v6 |
| `dependabot/fetch-metadata` | `25dd0e3` # v3 |
| `github/codeql-action/{init,analyze}` | `8aad20d` # v4 |

Dependabot's existing `github-actions` ecosystem config keeps the pins current and updates the `# vX` comment on new releases.

## Type of Change

- [x] `ci` — no release

## Checklist

- [x] My PR title follows the Conventional Commits format
- [x] My changes follow the existing code style and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)