### PR TITLE
refactor: de-duplicate distribution generators and clear static-analysis findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/
 
 # maven-shade-plugin output
 dependency-reduced-pom.xml
+/output/

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -202,13 +202,14 @@ public class DatabaseFiller implements Fillable {
         int widest = levels.stream()
                 .mapToInt(level -> level.stream().mapToInt(this::partitionsFor).sum())
                 .max().orElse(1);
-        int poolSize = Math.max(1, Math.min(threads, widest));
+        int poolSize = Math.clamp(threads, 1, widest);
 
         logger.info("filling {} tables across {} topological level(s) with {} worker thread(s)",
                 reversedGraph.vertexSet().size(), levels.size(), poolSize);
 
-        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
-        try {
+        // try-with-resources: ExecutorService#close() shuts the pool down and awaits termination
+        // (and shutdownNow()s on interrupt), so the pool is always cleanly torn down
+        try (ExecutorService executor = Executors.newFixedThreadPool(poolSize)) {
             for (List<Table> level : levels) {
                 List<Callable<Void>> tasks = new ArrayList<>(level.size());
                 for (Table table : level) {
@@ -223,8 +224,6 @@ public class DatabaseFiller implements Fillable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new SQLException("parallel table fill was interrupted", e);
-        } finally {
-            executor.shutdownNow();
         }
     }
 
@@ -292,9 +291,8 @@ public class DatabaseFiller implements Fillable {
             long end = start + size;
             if (size > 0) {
                 long rangeStart = start;
-                long rangeEnd = end;
                 tasks.add(() -> {
-                    fillTablePartition(database, table, rangeStart, rangeEnd);
+                    fillTablePartition(database, table, rangeStart, end);
                     return null;
                 });
             }

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -61,18 +61,6 @@ public class TableFiller implements Fillable {
     private final long rangeEndExclusive;
 
     /**
-     * Constructs a new TableFiller using the configuration's {@link CommitStrategy}.
-     *
-     * @param connection the database connection to use for filling the table
-     * @param database the database metadata containing table relationships
-     * @param databaseConfiguration the configuration settings for the fill operation
-     * @param table the table to be filled with data
-     */
-    public TableFiller(Connection connection, Database database, DatabaseConfiguration databaseConfiguration, Table table) {
-        this(connection, database, databaseConfiguration, table, databaseConfiguration.commitStrategy());
-    }
-
-    /**
      * Constructs a new TableFiller with an explicit {@link CommitStrategy} override.
      *
      * @param connection the database connection to use for filling the table
@@ -136,7 +124,7 @@ public class TableFiller implements Fillable {
 
         // value constraints (CHECK / enum) for this table's columns, so generated values conform
         // (issue #479). Empty for databases without support; keyed by lower-cased column name.
-        String schema = filteredColumns.isEmpty() ? null : filteredColumns.get(0).schema();
+        String schema = filteredColumns.isEmpty() ? null : filteredColumns.getFirst().schema();
         Map<String, ColumnConstraint> constraints = databaseSupport.readConstraints(connection, schema, table.name());
 
         for (int idx = 0; idx < columnCount; idx++) {
@@ -357,18 +345,6 @@ public class TableFiller implements Fillable {
             this.connection = connection;
             this.database = database;
             this.databaseConfiguration = databaseConfiguration;
-        }
-
-        /**
-         * Sets the table to fill by resolving its name against the database metadata (case-insensitive).
-         *
-         * @param tableName the name of the table to fill
-         * @return this builder
-         * @throws IllegalArgumentException if no table with the given name exists
-         */
-        public Builder table(String tableName) {
-            this.table = database.getTable(tableName);
-            return this;
         }
 
         /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
@@ -18,8 +18,6 @@ package io.bloviate.gen;
 
 import io.bloviate.util.RandomGenerators;
 import io.bloviate.util.SeededRandomUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -49,8 +47,6 @@ import java.util.random.RandomGenerator;
  * @see DataGenerator
  */
 public abstract class AbstractDataGenerator<T> implements DataGenerator<T> {
-
-    final Logger logger = LoggerFactory.getLogger(getClass());
 
     /** The random source backing all value generation; swapped out by {@link #reseed(long)}. */
     protected RandomGenerator random;

--- a/bloviate-core/src/main/java/io/bloviate/gen/Cdf.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/Cdf.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+/**
+ * Shared inverse-transform sampling over a cumulative-weight (CDF) array, used by the weighted
+ * distribution generators ({@link WeightedCategoricalGenerator}, {@link ZipfianIntegerGenerator}).
+ */
+final class Cdf {
+
+    private Cdf() {
+    }
+
+    /**
+     * Binary search for the index of the first cumulative-weight bucket strictly greater than
+     * {@code draw}. The array must be non-empty and non-decreasing, and {@code draw} is expected in
+     * {@code [0, cumulative[last])}.
+     *
+     * @param cumulative the non-decreasing cumulative-weight array
+     * @param draw       the sampled value in the total-weight range
+     * @return the index of the selected bucket
+     */
+    static int upperBound(double[] cumulative, double draw) {
+        int low = 0;
+        int high = cumulative.length - 1;
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (draw < cumulative[mid]) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+        return low;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/gen/ChildCardinality.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ChildCardinality.java
@@ -16,6 +16,8 @@
 
 package io.bloviate.gen;
 
+import io.bloviate.util.Mixers;
+
 /**
  * Deterministic mapping from a parent row's global (row-major) index to the number
  * of child rows it owns, drawn from the inclusive range {@code [minChildren, maxChildren]}.
@@ -69,7 +71,7 @@ public final class ChildCardinality {
         if (range == 1) {
             return minChildren;
         }
-        return minChildren + (int) Math.floorMod(mix(parentIndex + seed), range);
+        return minChildren + Math.floorMod(Mixers.splitmix64(parentIndex + seed), range);
     }
 
     /**
@@ -110,13 +112,5 @@ public final class ChildCardinality {
      */
     public int maxChildren() {
         return maxChildren;
-    }
-
-    // splitmix64 finalizer — a well-distributed, deterministic mix of a 64-bit input
-    private static long mix(long value) {
-        long z = value + 0x9E3779B97F4A7C15L;
-        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
-        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
-        return z ^ (z >>> 31);
     }
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/GroupedPermutationGenerator.java
@@ -16,6 +16,8 @@
 
 package io.bloviate.gen;
 
+import io.bloviate.util.Mixers;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -58,7 +60,7 @@ public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> 
         long n = counter.getAndIncrement();
         long group = n / groupSize;
         int position = (int) (n % groupSize);
-        long key = mix(seed + group);
+        long key = Mixers.splitmix64(seed + group);
         return start + permute(position, key);
     }
 
@@ -190,21 +192,13 @@ public class GroupedPermutationGenerator extends AbstractDataGenerator<Integer> 
         this.seed = builder.seed;
 
         // split point for a balanced Feistel whose domain (2^(2*halfBits)) covers groupSize
-        int bitsNeeded = groupSize <= 1 ? 0 : (32 - Integer.numberOfLeadingZeros(groupSize - 1));
+        int bitsNeeded = groupSize == 1 ? 0 : (32 - Integer.numberOfLeadingZeros(groupSize - 1));
         this.halfBits = (bitsNeeded + 1) / 2;
         this.halfMask = halfBits == 0 ? 0L : ((1L << halfBits) - 1);
     }
 
     private static long roundFunction(long right, int round, long key) {
         long z = right * 0x9E3779B97F4A7C15L + key + (round + 1L) * 0xBF58476D1CE4E5B9L;
-        z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
-        z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
-        return z ^ (z >>> 31);
-    }
-
-    // splitmix64 finalizer — a well-distributed, deterministic mix of a 64-bit input
-    private static long mix(long value) {
-        long z = value + 0x9E3779B97F4A7C15L;
         z = (z ^ (z >>> 30)) * 0xBF58476D1CE4E5B9L;
         z = (z ^ (z >>> 27)) * 0x94D049BB133111EBL;
         return z ^ (z >>> 31);

--- a/bloviate-core/src/main/java/io/bloviate/gen/NormalDoubleGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/NormalDoubleGenerator.java
@@ -44,7 +44,7 @@ public class NormalDoubleGenerator extends AbstractDataGenerator<Double> {
     @Override
     public Double generate() {
         double value = random.nextGaussian(mean, standardDeviation);
-        return Math.min(max, Math.max(min, value));
+        return Math.clamp(value, min, max);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/NormalIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/NormalIntegerGenerator.java
@@ -40,7 +40,7 @@ public class NormalIntegerGenerator extends AbstractDataGenerator<Integer> {
     @Override
     public Integer generate() {
         long rounded = Math.round(random.nextGaussian(mean, standardDeviation));
-        return (int) Math.min(max, Math.max(min, rounded));
+        return Math.clamp(rounded, min, max);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/WeightedCategoricalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/WeightedCategoricalGenerator.java
@@ -19,6 +19,7 @@ package io.bloviate.gen;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.random.RandomGenerator;
@@ -50,23 +51,7 @@ public class WeightedCategoricalGenerator<T> extends AbstractDataGenerator<T> {
     @SuppressWarnings("unchecked")
     public T generate() {
         double draw = randomUtils.nextDouble(0.0, totalWeight);
-        int index = indexFor(draw);
-        return (T) values[index];
-    }
-
-    /** Binary search for the first cumulative-weight bucket strictly greater than {@code draw}. */
-    private int indexFor(double draw) {
-        int low = 0;
-        int high = cumulativeWeights.length - 1;
-        while (low < high) {
-            int mid = (low + high) >>> 1;
-            if (draw < cumulativeWeights[mid]) {
-                high = mid;
-            } else {
-                low = mid + 1;
-            }
-        }
-        return low;
+        return (T) values[Cdf.upperBound(cumulativeWeights, draw)];
     }
 
     @Override
@@ -140,7 +125,7 @@ public class WeightedCategoricalGenerator<T> extends AbstractDataGenerator<T> {
         // stable canonical order (by string form) so the value for a given draw never depends on the
         // iteration order of the source map — the key to reproducibility across JVMs
         List<Builder.Entry<T>> sorted = new ArrayList<>(builder.entries);
-        sorted.sort((a, b) -> String.valueOf(a.value()).compareTo(String.valueOf(b.value())));
+        sorted.sort(Comparator.comparing(entry -> String.valueOf(entry.value())));
 
         this.values = new Object[sorted.size()];
         this.cumulativeWeights = new double[sorted.size()];

--- a/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
@@ -44,17 +44,7 @@ public class ZipfianIntegerGenerator extends AbstractDataGenerator<Integer> {
     @Override
     public Integer generate() {
         double draw = randomUtils.nextDouble(0.0, totalWeight);
-        int low = 0;
-        int high = cumulativeWeights.length - 1;
-        while (low < high) {
-            int mid = (low + high) >>> 1;
-            if (draw < cumulativeWeights[mid]) {
-                high = mid;
-            } else {
-                low = mid + 1;
-            }
-        }
-        return start + low;
+        return start + Cdf.upperBound(cumulativeWeights, draw);
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/tpcc/TPCCConfiguration.java
@@ -143,7 +143,7 @@ public final class TPCCConfiguration {
         final int d = districtsPerWarehouse;
         final int c = customersPerDistrict;
         final int o = customersPerDistrict; // one order per customer
-        final int no = Math.max(0, Math.min(newOrdersPerDistrict, o)); // new_order is a subset of orders
+        final int no = Math.clamp(newOrdersPerDistrict, 0, o); // new_order is a subset of orders
 
         // shared, deterministic per-order line counts so open_order.o_ol_cnt and order_line agree
         final ChildCardinality cardinality = new ChildCardinality(minLinesPerOrder, maxLinesPerOrder, LINE_COUNT_SEED);

--- a/bloviate-core/src/main/java/io/bloviate/util/DatabaseUtils.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/DatabaseUtils.java
@@ -17,8 +17,6 @@
 package io.bloviate.util;
 
 import io.bloviate.db.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.sql.*;
@@ -55,8 +53,6 @@ public class DatabaseUtils {
     /** Static utility holder — not instantiable. */
     private DatabaseUtils() {
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(DatabaseUtils.class);
 
     /**
      * Computes a stable, reproducible generation seed for a column.

--- a/bloviate-core/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/BaseDatabaseTestCase.java
@@ -19,8 +19,6 @@ package io.bloviate.db;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.bloviate.gen.tpcc.CustomerLastNameGenerator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import javax.sql.DataSource;
@@ -32,8 +30,6 @@ import java.sql.Statement;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BaseDatabaseTestCase {
-
-    protected static final Logger logger = LoggerFactory.getLogger(BaseDatabaseTestCase.class);
 
     protected static DataSource getDataSource(JdbcDatabaseContainer<?> container) {
         HikariConfig hikariConfig = new HikariConfig();

--- a/bloviate-core/src/test/java/io/bloviate/ext/PostgresConstraintsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/ext/PostgresConstraintsTest.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,8 +56,8 @@ class PostgresConstraintsTest {
         ColumnConstraint c = PostgresConstraints.parseCheck("CHECK ((x > 0) AND (x < 10))");
         assertEquals(0, new BigDecimal("0").compareTo(c.min()));
         assertEquals(0, new BigDecimal("10").compareTo(c.max()));
-        assertTrue(!c.minInclusive());
-        assertTrue(!c.maxInclusive());
+        assertFalse(c.minInclusive());
+        assertFalse(c.maxInclusive());
     }
 
     @Test

--- a/bloviate-core/src/test/java/io/bloviate/gen/DistributionGeneratorsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/DistributionGeneratorsTest.java
@@ -21,9 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -146,15 +144,11 @@ class DistributionGeneratorsTest {
         long startMs = start.toEpochMilli();
         long rangeMs = end.toEpochMilli() - startMs;
         double fractionSum = 0;
-        List<Timestamp> samples = new ArrayList<>();
         for (int i = 0; i < N; i++) {
             Timestamp ts = generator.generate();
             long ms = ts.getTime();
             assertTrue(ms >= startMs && ms <= end.toEpochMilli(), "timestamp out of window: " + ts);
             fractionSum += (ms - startMs) / (double) rangeMs;
-            if (i < 5) {
-                samples.add(ts);
-            }
         }
         // with skew 3.0 the average position should sit well past the midpoint (recent-weighted)
         double meanFraction = fractionSum / N;

--- a/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Places.java
+++ b/bloviate-datafaker/src/main/java/io/bloviate/datafaker/Places.java
@@ -68,7 +68,7 @@ public final class Places {
     public static RowContext<Geo> unitedStates(long seed) {
         List<Geo> tuples = UNITED_STATES;
         int size = tuples.size();
-        return new RowContext<>(rowIndex -> tuples.get((int) Math.floorMod(Mixers.splitmix64(seed + rowIndex), size)));
+        return new RowContext<>(rowIndex -> tuples.get(Math.floorMod(Mixers.splitmix64(seed + rowIndex), size)));
     }
 
     /** The loaded reference tuples (package-private; for tests). */

--- a/bloviate-datafaker/src/test/java/io/bloviate/datafaker/GeoRealismTest.java
+++ b/bloviate-datafaker/src/test/java/io/bloviate/datafaker/GeoRealismTest.java
@@ -22,6 +22,7 @@ import io.bloviate.util.RandomGenerators;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -41,7 +42,7 @@ class GeoRealismTest {
         var tuples = Places.unitedStatesTuples();
         assertTrue(tuples.size() >= 50, "expected a representative dataset but had " + tuples.size());
         for (Geo geo : tuples) {
-            assertTrue(!geo.city().isBlank(), "blank city");
+            assertFalse(geo.city().isBlank(), "blank city");
             assertEquals(2, geo.stateAbbreviation().length(), "state abbreviation must be 2 chars: " + geo);
             assertTrue(geo.zip().matches("\\d{5}"), "zip must be 5 digits: " + geo);
             assertTrue(geo.areaCode().matches("\\d{3}"), "area code must be 3 digits: " + geo);

--- a/bloviate-datafaker/src/test/java/io/bloviate/datafaker/ReferentialRealismTest.java
+++ b/bloviate-datafaker/src/test/java/io/bloviate/datafaker/ReferentialRealismTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -82,7 +83,7 @@ class ReferentialRealismTest {
     void differentSeedsDiffer() {
         Person a = People.context(1L, Locale.ENGLISH).at(0);
         Person b = People.context(2L, Locale.ENGLISH).at(0);
-        assertTrue(!a.equals(b), "different seeds should generally yield different identities");
+        assertFalse(a.equals(b), "different seeds should generally yield different identities");
     }
 
     @Test

--- a/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
+++ b/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
@@ -32,7 +32,6 @@ import java.lang.reflect.Modifier;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * JUnit Jupiter extension that fills a test database before each test, driven by
@@ -84,12 +83,10 @@ public class BloviateExtension implements BeforeEachCallback {
     }
 
     private FillDatabase resolveAnnotation(ExtensionContext context) {
-        Optional<FillDatabase> fromMethod = context.getTestMethod()
-                .flatMap(method -> AnnotationSupport.findAnnotation(method, FillDatabase.class));
-        if (fromMethod.isPresent()) {
-            return fromMethod.get();
-        }
-        return AnnotationSupport.findAnnotation(context.getRequiredTestClass(), FillDatabase.class).orElse(null);
+        return context.getTestMethod()
+                .flatMap(method -> AnnotationSupport.findAnnotation(method, FillDatabase.class))
+                .orElseGet(() -> AnnotationSupport.findAnnotation(
+                        context.getRequiredTestClass(), FillDatabase.class).orElse(null));
     }
 
     private Object readSource(ExtensionContext context) {


### PR DESCRIPTION
## Summary

Focused cleanup of the recent feature wave (non-uniform distributions, datafaker realism, check/enum constraints, parallel fill) plus the actionable findings from a JetBrains IntelliJ inspection run. **Behavior-preserving** — same seed ⇒ same output. Net **−30 lines**.

## DRY / design
- Extract the duplicated CDF binary search into `io.bloviate.gen.Cdf`; reused by `WeightedCategoricalGenerator` and `ZipfianIntegerGenerator`.
- Collapse two byte-identical `splitmix64` copies (`ChildCardinality`, `GroupedPermutationGenerator`) onto `Mixers.splitmix64` (the distinct Feistel `roundFunction` left alone).
- `Math.clamp(...)` for nested min/max (`Normal{Double,Integer}Generator`, `DatabaseFiller` pool sizing, `TPCCConfiguration`).
- `Comparator.comparing(...)` in `WeightedCategoricalGenerator`.

## Lifecycle / tests
- `DatabaseFiller.fillParallel` uses try-with-resources on the `ExecutorService` (Java 25 `AutoCloseable`) for deterministic shutdown.
- Removed a dead, never-asserted sample list in `DistributionGeneratorsTest` (the test already verifies in-window + recency).

## Dead code / nits
- Removed unused `TableFiller` 4-arg ctor and `Builder.table(String)`, three unused `logger` fields, redundant `(int)` casts on `Math.floorMod`, `get(0)` → `getFirst()`, `Optional.orElseGet`, and `assertFalse` in three tests.
- Gitignored the IntelliJ `output/` inspection dump.

## Deliberately kept
- Public library API (builder setters/getters, `Distributions` overloads, `ColumnConstraint.ofRange`) — unused internally but part of the consumer surface.
- `BloviateExtension` `NullableProblems` (would need a JSpecify dependency) and `TPCCConfiguration` sizing aliases (readability) left as-is.

## Verification
Full reactor `BUILD SUCCESS`; all tests pass including the Docker-backed `PostgresParallelFillTest` / `PostgresIntraTableFillTest` that exercise the executor change, and the reproducibility suites that guard the DRY refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)