### PR TITLE
refactor(logging): consistent idiom, sane levels, and generator-resolution visibility

### DIFF
--- a/bloviate-core/pom.xml
+++ b/bloviate-core/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -80,7 +80,7 @@ import java.util.concurrent.Future;
  */
 public class DatabaseFiller implements Fillable {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseFiller.class);
 
     /** A caller-managed connection for the sequential path; null when filling from a {@link DataSource}. */
     private final Connection connection;
@@ -120,7 +120,7 @@ public class DatabaseFiller implements Fillable {
                 : DatabaseUtils.getMetadata(dataSource);
         metadataWatch.stop();
 
-        logger.info(metadataWatch.toString());
+        logger.debug("{}", metadataWatch);
 
         StopWatch databaseWatch = new StopWatch(String.format("filled database [%s] in", database.catalog()));
         databaseWatch.start();
@@ -155,7 +155,7 @@ public class DatabaseFiller implements Fillable {
 
         databaseWatch.stop();
 
-        logger.info(databaseWatch.toString());
+        logger.info("{}", databaseWatch);
 
     }
 
@@ -456,13 +456,20 @@ public class DatabaseFiller implements Fillable {
                     }
 
                     if (table.equals(referencedTable)) {
-                        logger.warn("this key is self referencing... will likely cause problems");
+                        // a self-referencing foreign key adds no inter-table ordering constraint; skip
+                        // the self-edge (a self-loop would also be rejected by the DAG) and warn so the
+                        // user knows intra-table parent/child ordering is their responsibility
+                        logger.warn("table [{}] has a self-referencing foreign key on column(s) {}; it imposes no "
+                                + "fill order and rows may reference not-yet-inserted parents",
+                                table.name(), key.foreignKeyColumns());
+                        continue;
                     }
 
                     try {
                         graph.addEdge(table, referencedTable);
                     } catch (IllegalArgumentException e) {
-                        logger.error("error adding edge between {} and {}: {}", table.name(), referencedTable.name(), e.getMessage(), e);
+                        logger.error("could not add dependency edge from [{}] to [{}]: {}",
+                                table.name(), referencedTable.name(), e.getMessage(), e);
                     }
                 }
             }

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -45,7 +45,7 @@ import java.util.random.RandomGenerator;
  */
 public class TableFiller implements Fillable {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(TableFiller.class);
 
     private final Connection connection;
     private final Database database;
@@ -100,7 +100,7 @@ public class TableFiller implements Fillable {
 
         String sql = table.insertString();
 
-        logger.trace(sql);
+        logger.trace("{}", sql);
 
         // The fill loop is the hot path: it runs once per cell (rowCount * columnCount times).
         // To keep it allocation- and lookup-free, everything is resolved up front into arrays
@@ -162,12 +162,15 @@ public class TableFiller implements Fillable {
                     : null;
 
             DataGenerator<?> dataGenerator;
+            String source;
             if (columnConfiguration != null) {
                 dataGenerator = columnConfiguration.generatorFactory().create(random);
+                source = "column-config";
             } else {
                 DataGenerator<?> custom = registry != null ? registry.resolve(column, random) : null;
                 if (custom != null) {
                     dataGenerator = custom;
+                    source = "registry";
                 } else {
                     // honor a CHECK/enum constraint when one applies and the user hasn't overridden the column
                     ColumnConstraint constraint = constraints.get(column.name().toLowerCase(Locale.ROOT));
@@ -176,9 +179,20 @@ public class TableFiller implements Fillable {
                         logger.warn("constraint on column [{}.{}] could not be applied to its {} type; using the type default",
                                 table.name(), column.name(), column.jdbcType());
                     }
-                    dataGenerator = constrained != null ? constrained : databaseSupport.getDataGenerator(column, random);
+                    if (constrained != null) {
+                        dataGenerator = constrained;
+                        source = "constraint";
+                    } else {
+                        dataGenerator = databaseSupport.getDataGenerator(column, random);
+                        source = "support-default";
+                    }
                 }
             }
+
+            // per-column resolution is the most useful diagnostic for a data-gen library: it reveals
+            // which generator (incl. semantic/datafaker matches) each column got, and by which path
+            logger.debug("column [{}.{}] ({}) resolved to generator [{}] via {}",
+                    table.name(), column.name(), column.jdbcType(), dataGenerator.getClass().getSimpleName(), source);
 
             generators[idx] = dataGenerator;
             reseedSeeds[idx] = seed;
@@ -197,9 +211,9 @@ public class TableFiller implements Fillable {
         long endRow = partitioned ? Math.min(rangeEndExclusive, totalRowCount) : totalRowCount;
 
         if (partitioned) {
-            logger.info("filling table [{}] rows [{}, {}) of [{}]", table.name(), startRow, endRow, totalRowCount);
+            logger.debug("filling table [{}] rows [{}, {}) of [{}]", table.name(), startRow, endRow, totalRowCount);
         } else {
-            logger.info("filling table [{}] with [{}] rows", table.name(), totalRowCount);
+            logger.debug("filling table [{}] with [{}] rows", table.name(), totalRowCount);
         }
 
         StopWatch tableWatch = new StopWatch(String.format("filled table [%s] in", table.name()));
@@ -274,7 +288,7 @@ public class TableFiller implements Fillable {
 
         tableWatch.stop();
 
-        logger.info(tableWatch.toString());
+        logger.debug("{}", tableWatch);
 
     }
 

--- a/bloviate-core/src/main/java/io/bloviate/file/FileGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/FileGenerator.java
@@ -27,12 +27,16 @@ public interface FileGenerator {
     /**
      * Generates the output data file, writing one header row followed by the configured
      * number of data rows.
+     *
+     * @throws java.io.UncheckedIOException if the file cannot be written
      */
     void generate();
 
     /**
      * Exports this generator's configuration to a YAML file (named after the generator's
      * base file name with a {@code .yaml} extension).
+     *
+     * @throws java.io.UncheckedIOException if the file cannot be written
      */
     void yaml();
 }

--- a/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -71,7 +72,7 @@ import java.util.List;
  */
 public class FlatFileGenerator implements FileGenerator {
 
-    final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(FlatFileGenerator.class);
 
 
     private static final YAMLFactory yamlFactory = new YAMLFactory()
@@ -112,7 +113,7 @@ public class FlatFileGenerator implements FileGenerator {
 
             csvPrinter.flush();
         } catch (IOException e) {
-            logger.error(e.getMessage(), e);
+            throw new UncheckedIOException("failed to write file [" + output + "]", e);
         }
 
     }
@@ -122,7 +123,7 @@ public class FlatFileGenerator implements FileGenerator {
         try {
             mapper.writeValue(new File(fileName + ".yaml"), this);
         } catch (IOException e) {
-            logger.error(e.getMessage(), e);
+            throw new UncheckedIOException("failed to write YAML file [" + fileName + ".yaml]", e);
         }
     }
 

--- a/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
+++ b/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ReflectionSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
@@ -47,6 +49,8 @@ import java.util.List;
  * @see FillSource
  */
 public class BloviateExtension implements BeforeEachCallback {
+
+    private static final Logger logger = LoggerFactory.getLogger(BloviateExtension.class);
 
     /** Creates the extension; instantiated by JUnit via {@code @ExtendWith}. */
     public BloviateExtension() {
@@ -77,6 +81,8 @@ public class BloviateExtension implements BeforeEachCallback {
 
     private void fill(Connection connection, FillDatabase fill) throws SQLException {
         DatabaseSupport support = DatabaseSupport.forConnection(connection);
+        logger.debug("@FillDatabase filling via {} (rows={}, batchSize={}, seed={})",
+                support.getClass().getSimpleName(), fill.rows(), fill.batchSize(), fill.seed());
         DatabaseConfiguration configuration =
                 new DatabaseConfiguration(fill.batchSize(), fill.rows(), support, null, fill.seed());
         new DatabaseFiller.Builder(connection, configuration).build().fill();

--- a/bloviate-testcontainers/src/main/java/io/bloviate/testcontainers/BloviateContainers.java
+++ b/bloviate-testcontainers/src/main/java/io/bloviate/testcontainers/BloviateContainers.java
@@ -20,6 +20,8 @@ import io.bloviate.db.DatabaseConfiguration;
 import io.bloviate.db.DatabaseFiller;
 import io.bloviate.db.TableConfiguration;
 import io.bloviate.ext.DatabaseSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.sql.Connection;
@@ -46,6 +48,8 @@ import java.util.Set;
  * }</pre>
  */
 public final class BloviateContainers {
+
+    private static final Logger logger = LoggerFactory.getLogger(BloviateContainers.class);
 
     private BloviateContainers() {
     }
@@ -144,6 +148,9 @@ public final class BloviateContainers {
                 DatabaseSupport support = databaseSupport != null
                         ? databaseSupport
                         : DatabaseSupport.forConnection(connection);
+
+                logger.debug("filling container [{}] via {} (rows={}, batchSize={}, seed={})",
+                        container.getDockerImageName(), support.getClass().getSimpleName(), rows, batchSize, seed);
 
                 DatabaseConfiguration configuration =
                         new DatabaseConfiguration(batchSize, rows, support, tableConfigurations, seed);


### PR DESCRIPTION
Acts on the internal logging review (follow-up to #501).

## Stop swallowing failures
- `FlatFileGenerator.generate()`/`.yaml()` now throw `UncheckedIOException` instead of logging the message and returning normally — previously a failed write produced a silent partial/empty file and a `void` return. Documented on the `FileGenerator` interface.
- `DatabaseFiller` skips the meaningless self-edge for a self-referencing FK with a clear, named **WARN**, instead of letting `addEdge` throw and logging **ERROR + stacktrace** on every such key.

## Consistent idiom
- Standardize on `private static final Logger logger = getLogger(ClassName.class)` (was instance + `getClass()`, plus one package-private field).
- core `slf4j-simple` → `test` scope (was `provided`), matching the other modules. No binding is exposed to consumers.

## Level policy — INFO = whole-DB milestones, DEBUG = per-table / timings
- Demote per-table fill lines + per-table StopWatch and metadata-fetch timing to DEBUG.
- Pass `"{}", stopWatch` / `sql` instead of eager `toString()`.
- The GraphvizOnline link stays at **INFO** as a per-fill convenience.

## New visibility (DEBUG, off by default)
- `TableFiller` logs **which generator each column resolved to and the path that chose it** (`column-config` / `registry` / `constraint` / `support-default`) — the most useful diagnostic for a data-gen library, and it surfaces datafaker semantic-inference matches that were previously invisible.
- `BloviateExtension` and `BloviateContainers` (silent before) log a fill line (rows / batchSize / seed).

## Verification
Full reactor `BUILD SUCCESS`; all tests pass, including `FlatFileTest`, `DatabaseFillerOrderTest` (self-ref ordering), and the Docker-backed fill/extension/container tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)