### PR TITLE
build(coverage): enforce a per-package JaCoCo coverage floor

### DIFF
--- a/bloviate-junit/pom.xml
+++ b/bloviate-junit/pom.xml
@@ -33,6 +33,13 @@
     <name>Bloviate JUnit</name>
     <description>JUnit Jupiter integration for Bloviate: declaratively fill a test database</description>
 
+    <properties>
+        <!-- thin SPI extension exercised only through Testcontainers; relaxed below the parent floor
+             to lock in no-regression. Ratchet up as coverage improves. -->
+        <jacoco.line.min>0.60</jacoco.line.min>
+        <jacoco.branch.min>0.25</jacoco.branch.min>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/bloviate-testcontainers/pom.xml
+++ b/bloviate-testcontainers/pom.xml
@@ -33,6 +33,13 @@
     <name>Bloviate Testcontainers</name>
     <description>Testcontainers integration for Bloviate: fill a JdbcDatabaseContainer with generated data</description>
 
+    <properties>
+        <!-- thin integration layer with a single end-to-end test; relaxed below the parent floor to
+             lock in no-regression. Ratchet up as coverage improves. -->
+        <jacoco.line.min>0.70</jacoco.line.min>
+        <jacoco.branch.min>0.45</jacoco.branch.min>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
+
+        <!-- Per-package test-coverage floor enforced by jacoco:check (bound to verify). Set just
+             below current coverage to lock in no-regression; ratchet upward over time. Modules that
+             cannot yet meet the default override these properties in their own pom. -->
+        <jacoco.line.min>0.78</jacoco.line.min>
+        <jacoco.branch.min>0.55</jacoco.branch.min>
     </properties>
 
     <distributionManagement>
@@ -264,6 +270,35 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <!-- every package in the module must meet the floor; thresholds are
+                                     properties so weak modules can relax them in their own pom -->
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.line.min}</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.branch.min}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Establishes a minimum test-coverage floor that **must be met per package**, enforced in the build (follow-up to the JaCoCo baseline analysis).

## How
- Adds a `jacoco:check` execution (bound to `verify`, `haltOnFailure=true`) with a per-`PACKAGE` rule on LINE and BRANCH coverage. CI already runs `mvn -B verify`, so PRs are gated — **no workflow change needed**.
- Thresholds are Maven properties, so weak modules relax them in their own pom and everything is easy to ratchet up later.

## Floors (set just below current coverage to lock in no-regression)
| Module | line | branch | current |
|---|---|---|---|
| parent default (core, datafaker) | 0.78 | 0.55 | core 0.88/0.74 (util is the floor at 0.80/0.58), datafaker 0.88/0.71 |
| bloviate-junit | 0.60 | 0.25 | 0.62/0.27 — thin SPI, Testcontainers-only |
| bloviate-testcontainers | 0.70 | 0.45 | 0.72/0.50 — single e2e test |
| bloviate-benchmarks | — | — | excluded via existing `jacoco.skip=true` |

## Verification
`mvn verify` passes on every module. Forcing the floor to `0.999` produces `BUILD FAILURE` with a per-package `Rule violated ...` line, confirming the rule enforces rather than no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)