### PR TITLE
test(coverage): cover util and junit gaps, then raise the floors

### DIFF
--- a/bloviate-core/src/test/java/io/bloviate/util/JdbcUrlsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/util/JdbcUrlsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JdbcUrlsTest {
@@ -66,5 +67,25 @@ class JdbcUrlsTest {
         // null/blank parameter name (database has no such parameter) leaves the URL untouched
         assertEquals("jdbc:foo://host/db", JdbcUrls.withBatchRewrite("jdbc:foo://host/db", null));
         assertEquals("jdbc:foo://host/db", JdbcUrls.withBatchRewrite("jdbc:foo://host/db", "  "));
+    }
+
+    @Test
+    void appendParameterRejectsBlankOrNullArguments() {
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrls.appendParameter(null, "a", "b"));
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrls.appendParameter("  ", "a", "b"));
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrls.appendParameter("jdbc:x://h/d", null, "b"));
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrls.appendParameter("jdbc:x://h/d", " ", "b"));
+        assertThrows(IllegalArgumentException.class, () -> JdbcUrls.appendParameter("jdbc:x://h/d", "a", null));
+    }
+
+    @Test
+    void parameterParsingHandlesQueryStringEdgeCases() {
+        // a trailing '?' with no query content is treated as having no parameters
+        assertFalse(JdbcUrls.hasParameter("jdbc:postgresql://host/db?", "a"));
+        // an empty pair (a stray '&') is skipped while later pairs still match
+        assertTrue(JdbcUrls.hasParameter("jdbc:postgresql://host/db?a=1&&b=2", "b"));
+        // a valueless key is present and resolves to an empty (but non-null) value
+        assertTrue(JdbcUrls.hasParameter("jdbc:postgresql://host/db?ssl&a=1", "ssl"));
+        assertTrue(JdbcUrls.parameterEquals("jdbc:postgresql://host/db?ssl&a=1", "ssl", ""));
     }
 }

--- a/bloviate-core/src/test/java/io/bloviate/util/SeededRandomUtilsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/util/SeededRandomUtilsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link SeededRandomUtils} — the pool fast paths, the general {@code [start, end)}
+ * code-point path, and the bounded numeric helpers including their equal-bounds and validation edges.
+ */
+class SeededRandomUtilsTest {
+
+    private static SeededRandomUtils utils(long seed) {
+        return new SeededRandomUtils(RandomGenerators.create(seed));
+    }
+
+    @Test
+    void poolFastPathsDrawOnlyFromTheirCharacterSet() {
+        SeededRandomUtils u = utils(1L);
+        assertTrue(u.random(200, true, false).matches("[A-Za-z]+"), "letters only");
+        assertTrue(u.random(200, false, true).matches("[0-9]+"), "digits only");
+        assertTrue(u.random(200, true, true).matches("[A-Za-z0-9]+"), "alphanumeric");
+        assertTrue(u.randomAlphabetic(50).matches("[A-Za-z]+"));
+        assertTrue(u.randomNumeric(50).matches("[0-9]+"));
+    }
+
+    @Test
+    void zeroLengthAndNegativeLengthAreHandled() {
+        SeededRandomUtils u = utils(2L);
+        assertEquals("", u.random(0, true, true));
+        assertEquals("", u.random(0, ' ', 'z' + 1, true, false));
+        assertThrows(IllegalArgumentException.class, () -> u.random(-1, true, true));
+        assertThrows(IllegalArgumentException.class, () -> u.random(-1, ' ', 'z' + 1, true, false));
+    }
+
+    @Test
+    void noFlagsDelegatesToTheGeneralAnyCodePointPath() {
+        // !letters && !numbers routes through random(count, 0, 0, false, false) which spans all code
+        // points; count is the number of UTF-16 chars, so the result length is exactly count
+        String s = utils(3L).random(64, false, false);
+        assertEquals(64, s.length());
+    }
+
+    @Test
+    void generalPathDefaultRangeFiltersLettersAndDigits() {
+        SeededRandomUtils u = utils(4L);
+        // start==end==0 with a flag selects the printable ' '..'z' window, then keeps only matches
+        assertTrue(u.random(100, 0, 0, true, false).matches("[A-Za-z]+"), "letters kept from default window");
+        assertTrue(u.random(100, 0, 0, false, true).matches("[0-9]+"), "digits kept from default window");
+    }
+
+    @Test
+    void generalPathExplicitRangeAndSupplementaryCodePoints() {
+        SeededRandomUtils u = utils(5L);
+        // an explicit letter window keeps only letters
+        assertTrue(u.random(80, 'a', 'z' + 1, true, false).matches("[a-z]+"));
+        // a supplementary-plane window (chars that need a surrogate pair) exercises the charCount==2
+        // path: count is in UTF-16 chars, so 40 chars == 20 supplementary code points
+        String supplementary = u.random(40, 0x10000, 0x10010, false, false);
+        assertEquals(40, supplementary.length());
+        assertEquals(20, supplementary.codePointCount(0, supplementary.length()), "all code points are supplementary");
+    }
+
+    @Test
+    void generalPathRejectsInvalidRanges() {
+        SeededRandomUtils u = utils(6L);
+        assertThrows(IllegalArgumentException.class, () -> u.random(5, 100, 50, false, false), "end <= start");
+        assertThrows(IllegalArgumentException.class, () -> u.random(5, -1, 50, false, false), "negative start");
+        // end above the max code point is clamped rather than rejected
+        String clamped = u.random(20, 32, Character.MAX_CODE_POINT + 100, false, false);
+        assertEquals(20, clamped.length());
+    }
+
+    @Test
+    void boundedNumericHelpersStayInRange() {
+        SeededRandomUtils u = utils(7L);
+        for (int i = 0; i < 1_000; i++) {
+            int n = u.nextInt(5, 10);
+            assertTrue(n >= 5 && n < 10);
+            double d = u.nextDouble(1.0, 2.0);
+            assertTrue(d >= 1.0 && d < 2.0);
+            float f = u.nextFloat(1.0f, 2.0f);
+            assertTrue(f >= 1.0f && f < 2.0f);
+            long l = u.nextLong(100L, 200L);
+            assertTrue(l >= 100L && l < 200L);
+        }
+    }
+
+    @Test
+    void boundedNumericHelpersReturnStartWhenBoundsAreEqual() {
+        SeededRandomUtils u = utils(8L);
+        assertEquals(5, u.nextInt(5, 5));
+        assertEquals(2.5, u.nextDouble(2.5, 2.5));
+        assertEquals(2.5f, u.nextFloat(2.5f, 2.5f));
+        assertEquals(42L, u.nextLong(42L, 42L));
+    }
+
+    @Test
+    void boundedNumericHelpersRejectInvalidBounds() {
+        SeededRandomUtils u = utils(9L);
+        assertThrows(IllegalArgumentException.class, () -> u.nextInt(10, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextInt(-1, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextDouble(10, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextDouble(-1, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextFloat(10, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextFloat(-1, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextLong(10, 5));
+        assertThrows(IllegalArgumentException.class, () -> u.nextLong(-1, 5));
+    }
+}

--- a/bloviate-junit/pom.xml
+++ b/bloviate-junit/pom.xml
@@ -34,10 +34,10 @@
     <description>JUnit Jupiter integration for Bloviate: declaratively fill a test database</description>
 
     <properties>
-        <!-- thin SPI extension exercised only through Testcontainers; relaxed below the parent floor
-             to lock in no-regression. Ratchet up as coverage improves. -->
-        <jacoco.line.min>0.60</jacoco.line.min>
-        <jacoco.branch.min>0.25</jacoco.branch.min>
+        <!-- the SPI extension's resolution/validation branches are unit-tested directly
+             (BloviateExtensionErrorPathsTest) on top of the end-to-end fill test -->
+        <jacoco.line.min>0.85</jacoco.line.min>
+        <jacoco.branch.min>0.85</jacoco.branch.min>
     </properties>
 
     <dependencies>

--- a/bloviate-junit/src/test/java/io/bloviate/junit/BloviateExtensionErrorPathsTest.java
+++ b/bloviate-junit/src/test/java/io/bloviate/junit/BloviateExtensionErrorPathsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.junit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers {@link BloviateExtension}'s source-resolution and validation branches without a database by
+ * driving {@code beforeEach} with a minimal {@link ExtensionContext} stub against fixture classes that
+ * misconfigure their {@link FillSource}. Each path is expected to fail before any fill is attempted.
+ */
+class BloviateExtensionErrorPathsTest {
+
+    /** A tiny {@link ExtensionContext} that answers only the three methods the extension calls. */
+    private static ExtensionContext context(Class<?> testClass, Object instance) {
+        InvocationHandler handler = (proxy, method, args) -> switch (method.getName()) {
+            case "getTestMethod" -> Optional.empty();
+            case "getRequiredTestClass" -> testClass;
+            case "getRequiredTestInstance" -> {
+                if (instance == null) {
+                    throw new IllegalStateException("no test instance available");
+                }
+                yield instance;
+            }
+            case "toString" -> "stubExtensionContext";
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> proxy == args[0];
+            default -> throw new UnsupportedOperationException(method.getName());
+        };
+        return (ExtensionContext) Proxy.newProxyInstance(
+                ExtensionContext.class.getClassLoader(), new Class<?>[]{ExtensionContext.class}, handler);
+    }
+
+    private static String failureMessage(Class<?> testClass, Object instance) {
+        BloviateExtension extension = new BloviateExtension();
+        ExtensionConfigurationException thrown = assertThrows(ExtensionConfigurationException.class,
+                () -> extension.beforeEach(context(testClass, instance)));
+        return thrown.getMessage();
+    }
+
+    @FillDatabase
+    static class NoSource {
+    }
+
+    @FillDatabase
+    static class WrongType {
+        @FillSource
+        static String notASource = "nope";
+    }
+
+    @FillDatabase
+    static class NullSource {
+        @FillSource
+        static Connection connection;
+    }
+
+    @FillDatabase
+    static class MultipleAnnotated {
+        @FillSource
+        static Connection a;
+        @FillSource
+        static Connection b;
+    }
+
+    @FillDatabase
+    static class MultipleCandidates {
+        static DataSource dataSource;   // no @FillSource → ambiguous fallback
+        static Connection connection;
+    }
+
+    @FillDatabase
+    static class FallbackSingleNull {
+        static String unrelated = "ignored"; // exercises the candidate predicate's negative branch
+        static Connection only;              // the lone fallback candidate, but null
+    }
+
+    @FillDatabase
+    static class InstanceNullSource {
+        @FillSource
+        Connection connection;   // non-static and null: read from the test instance, then rejected
+    }
+
+    @Test
+    void noFillSourceAndNoCandidateFails() {
+        assertTrue(failureMessage(NoSource.class, null).contains("no fill source"));
+    }
+
+    @Test
+    void nonDataSourceOrConnectionFieldFails() {
+        assertTrue(failureMessage(WrongType.class, null).contains("DataSource or java.sql.Connection"));
+    }
+
+    @Test
+    void nullSourceFails() {
+        assertTrue(failureMessage(NullSource.class, null).contains("is null"));
+    }
+
+    @Test
+    void multipleAnnotatedFieldsFail() {
+        assertTrue(failureMessage(MultipleAnnotated.class, null).contains("exactly one"));
+    }
+
+    @Test
+    void multipleFallbackCandidatesFail() {
+        assertTrue(failureMessage(MultipleCandidates.class, null).contains("multiple"));
+    }
+
+    @Test
+    void fallbackToSingleCandidateThenNull() {
+        assertTrue(failureMessage(FallbackSingleNull.class, null).contains("is null"));
+    }
+
+    @Test
+    void nonStaticFieldIsReadFromTheTestInstance() {
+        assertTrue(failureMessage(InstanceNullSource.class, new InstanceNullSource()).contains("is null"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
         <!-- Per-package test-coverage floor enforced by jacoco:check (bound to verify). Set just
              below current coverage to lock in no-regression; ratchet upward over time. Modules that
              cannot yet meet the default override these properties in their own pom. -->
-        <jacoco.line.min>0.78</jacoco.line.min>
-        <jacoco.branch.min>0.55</jacoco.branch.min>
+        <jacoco.line.min>0.83</jacoco.line.min>
+        <jacoco.branch.min>0.68</jacoco.branch.min>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Raises coverage on the two weak spots the per-package floor (#503) exposed, then ratchets the floors up to lock the gains in.

## bloviate-core `util` — line 80.3 → **98.8%**, branch 58.2 → **94.7%**
- New **`SeededRandomUtilsTest`** (the dominant gap, was 47.6% line / 31.2% branch → **97.6 / 97.5**): pool fast paths, the general `[start, end)` code-point path (default window, explicit ranges, supplementary code points, invalid-range + clamp edges), and the bounded numeric helpers' equal-bounds and validation branches.
- **`JdbcUrlsTest`** gains the `appendParameter` null/blank guards and the query-string parsing edges (trailing `?`, empty pair, valueless key).

## bloviate-junit `BloviateExtension` — line 61.5 → **89.1%**, branch 27.3 → **90.9%**
- New **`BloviateExtensionErrorPathsTest`** drives `beforeEach` with a minimal `ExtensionContext` stub (no Mockito, no DB) to cover the source-resolution/validation branches: missing / duplicate / wrong-type / null `@FillSource`, the DataSource/Connection fallback candidates, and the non-static instance-field read path.

## Ratcheted floors
| Scope | before | after |
|---|---|---|
| parent default (core, datafaker) | 0.78 / 0.55 | **0.83 / 0.68** |
| bloviate-junit | 0.60 / 0.25 | **0.85 / 0.85** |
| bloviate-testcontainers | 0.70 / 0.45 | unchanged (not targeted) |

`util` was the old binding constraint, so its rise is what lets the parent **branch** floor jump from 0.55 to 0.68 (now bounded by datafaker's branch and core `db`/`gen`).

## Verification
`mvn verify` passes with the new floors on current `main` (which already includes #501/#502/#503). Forcing a floor to `0.999` still fails per package, confirming enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)