### PR TITLE
fix(website): repair Cloudflare deploy + add dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,13 @@ updates:
       interval: "daily"
     assignees:
       - "timveil"
+  # docs site (Astro/Starlight). The npm ecosystem reads the committed
+  # pnpm-lock.yaml. Patch/minor bumps here are auto-merged once the website
+  # build passes (see .github/workflows/dependabot-auto-merge.yml); majors open
+  # a PR for manual review.
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "timveil"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,6 +32,16 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Website (npm/pnpm) deps: auto-merge patch & minor only; majors are left
+      # for manual review. --auto waits for required checks, so the Build website
+      # check gates the merge.
+      - name: Auto-merge website (npm) patch & minor updates
+        if: steps.metadata.outputs.package-ecosystem == 'npm' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Fallback: re-attempt auto-merge after the CI workflow completes successfully.
   # fetch-metadata can't run on workflow_run events (no pull_request payload), so
   # the allowlist is re-applied by matching the Dependabot branch name, which

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -1,0 +1,48 @@
+name: Build website
+
+# Verifies the docs site builds. Runs on PRs that touch the site or its content
+# so a dependency bump (or content change) can't merge — or auto-merge — if it
+# breaks the build. Cloudflare deploys the same `pnpm build` on push to main.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/website-build.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'website/**'
+      - 'docs/**'
+      - '.github/workflows/website-build.yml'
+
+permissions:
+  contents: read
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: website/.node-version
+
+      # pnpm version comes from the `packageManager` pin in website/package.json.
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site
+        run: pnpm build

--- a/website/README.md
+++ b/website/README.md
@@ -72,27 +72,39 @@ breadcrumb strip (`-top`) linking back to the docs. Keep it in sync with `src/st
 > Search isn't polluted: Starlight marks its own pages with `data-pagefind-body`, so Pagefind indexes
 > only the guides/landing pages — the Javadoc uses its own built-in search.
 
-## Deploy — Cloudflare Pages (Git integration, no CI)
+## Deploy — Cloudflare Workers (Git-connected build, no GitHub CI)
 
-The site deploys via **Cloudflare Pages' native Git integration** — Cloudflare watches the repo and
-builds on push. There is deliberately **no GitHub Actions workflow, no `wrangler`, and no GitHub
-secrets**. One-time dashboard setup:
+The site deploys via **Cloudflare's Git-connected Workers build** — Cloudflare watches the repo,
+runs the build on push, and deploys with `wrangler deploy`. There is deliberately **no GitHub
+Actions workflow and no GitHub secrets**; the only Cloudflare-side config is committed here as
+[`wrangler.jsonc`](wrangler.jsonc).
 
-1. **Cloudflare Pages → Create → Connect to Git →** select the `timveil/bloviate` repo, production
-   branch `main`.
-2. **Build settings:**
-   - Framework preset: **Astro**
-   - **Root directory:** `website`
-   - **Build command:** `pnpm build`
-   - **Build output directory:** `dist`
+Because the site is **fully static**, `wrangler.jsonc` declares a [Workers Static
+Assets](https://developers.cloudflare.com/workers/static-assets/) deployment — `assets.directory`
+points at `dist`, with **no Worker script**. Committing that config is what keeps `wrangler deploy`
+from auto-detecting Astro and trying to provision the SSR adapter (which fails for a static site).
+It also sets:
 
-   Cloudflare auto-detects the package manager from the committed `pnpm-lock.yaml` and runs
-   `pnpm install` before the build.
-3. **Environment variables:** add `NODE_VERSION` = `22` (Astro 6 needs Node ≥ 18.20 / 20.3 / 22;
-   also pinned via `website/.node-version`).
-4. **Custom domain:** add `bloviate.io` (and a `www` → apex redirect) under the Pages project's
+- `workers_dev: false` — no `*.workers.dev` URL; the site is served only from the custom domain.
+- `observability.enabled: true` — Workers Logs on.
+- `assets.html_handling: auto-trailing-slash` — serves `/foo/` from `/foo/index.html` (so `/apidocs/`
+  resolves), and `assets.not_found_handling: 404-page` — serves the generated `404.html`.
+
+One-time Cloudflare dashboard setup:
+
+1. **Workers & Pages → Create → Connect to Git →** select `timveil/bloviate`, production branch
+   `main`, **root directory** `website`.
+2. **Build command:** `pnpm build` (Cloudflare auto-detects pnpm from `pnpm-lock.yaml`); **deploy
+   command:** `npx wrangler deploy`. `NODE_VERSION` is pinned via `website/.node-version`.
+3. **Custom domain:** add `bloviate.io` (and a `www` → apex redirect) under the Worker's
    *Custom domains*.
 
-On each push to `main`, Cloudflare checks out the repo, runs `pnpm build` inside `website/`
-(which first runs `sync-docs.mjs` against `../docs`), and publishes `website/dist`. Path filters
-aren't needed — a rebuild is cheap and always reflects the latest `docs/`, `website/`, and content.
+On each push to `main`, Cloudflare runs `pnpm build` inside `website/` (which first runs
+`sync-docs.mjs` against `../docs`) and `wrangler deploy` publishes `website/dist`.
+
+To validate the deploy config locally without deploying:
+
+```bash
+pnpm build
+npx wrangler deploy --dry-run   # reads wrangler.jsonc, bundles dist, exits
+```

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+	// Cloudflare Workers Static Assets config for the (fully static) Astro site.
+	// Its presence makes `wrangler deploy` upload ./dist directly instead of
+	// auto-provisioning the Astro SSR adapter (which is wrong for a static site
+	// and was failing the Cloudflare deploy). No Worker script — assets only.
+	"name": "bloviate",
+	"compatibility_date": "2026-06-28",
+	// Don't expose a *.workers.dev URL — the site is served from the custom
+	// domain (bloviate.io) configured on the Cloudflare project.
+	"workers_dev": false,
+	// Workers Logs.
+	"observability": {
+		"enabled": true
+	},
+	"assets": {
+		"directory": "./dist",
+		// Serve /foo/ from /foo/index.html (also makes /apidocs/ resolve).
+		"html_handling": "auto-trailing-slash",
+		// Serve the generated 404.html for unknown paths.
+		"not_found_handling": "404-page"
+	}
+}


### PR DESCRIPTION
Follow-up to #505. **Urgent:** main's Cloudflare deploy is currently failing — this fixes it.

## The deploy failure
With no Wrangler config, Cloudflare's `wrangler deploy` auto-detected Astro and tried to provision the SSR adapter (installing `wrangler`/`workerd` via pnpm, which pnpm blocked — `ERR_PNPM_IGNORED_BUILDS: workerd`). The build succeeded; only the deploy step failed.

## Fix
Add `website/wrangler.jsonc` declaring a **Workers Static Assets** deployment (assets only, no Worker script) so `wrangler deploy` uploads `./dist` directly and skips framework provisioning. Also:
- `workers_dev: false` — no `*.workers.dev` URL (custom domain only)
- `observability.enabled: true` — Workers Logs on
- `html_handling: auto-trailing-slash` (so `/apidocs/` resolves) + `not_found_handling: 404-page`

Verified locally with `wrangler deploy --dry-run` (reads 496 files from `dist`). README deploy section updated (Pages → Workers).

## Dependabot + auto-merge for /website
- Dependabot now watches the **npm** ecosystem in `/website` (reads `pnpm-lock.yaml`).
- New **Build website** workflow (SHA-pinned actions, corepack pnpm) builds the site on PRs touching `website/`/`docs/` — a gate so a bad bump can't merge.
- Auto-merge enabled for website **patch & minor** updates; **majors** are held for manual review. `--auto` waits for required checks.

### One manual step
For the build to actually gate auto-merge, add **Build website** to the required status checks for `main` (branch protection / ruleset). Until then, website patch/minor auto-merge gates only on the existing required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)