### PR TITLE
fix(ci): use --squash for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Auto-merge Dependabot PRs
         if: contains(steps.metadata.outputs.dependency-names, 'com.zaxxer') || contains(steps.metadata.outputs.dependency-names, 'org.apache.commons') || contains(steps.metadata.outputs.dependency-names, 'com.fasterxml.jackson') || contains(steps.metadata.outputs.dependency-names, 'org.slf4j') || contains(steps.metadata.outputs.dependency-names, 'org.junit.jupiter') || contains(steps.metadata.outputs.dependency-names, 'org.testcontainers') || contains(steps.metadata.outputs.dependency-names, 'org.postgresql') || contains(steps.metadata.outputs.dependency-names, 'mysql') || contains(steps.metadata.outputs.dependency-names, 'org.jgrapht') || contains(steps.metadata.outputs.dependency-names, 'org.apache.maven.plugins') || contains(steps.metadata.outputs.dependency-names, 'org.codehaus.mojo')
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +37,7 @@ jobs:
       # check gates the merge.
       - name: Auto-merge website (npm) patch & minor updates
         if: steps.metadata.outputs.package-ecosystem == 'npm' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,4 +78,4 @@ jobs:
           # If checks are still pending the PR is "blocked" and --auto enables
           # auto-merge; if everything is already green the PR is "clean" and
           # --auto is rejected, so fall back to merging directly.
-          gh pr merge --auto --merge "$PR_URL" || gh pr merge --merge "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL" || gh pr merge --squash "$PR_URL"


### PR DESCRIPTION
## Problem

The repo only allows **squash** merges (`mergeCommitAllowed: false`, `rebaseMergeAllowed: false`, `squashMergeAllowed: true`), but the Dependabot auto-merge workflow added in #506 calls `gh pr merge --auto --merge`. Every attempt fails:

```
GraphQL: Merge method merge commits are not allowed on this repository (enablePullRequestAutoMerge)
```

This broke auto-merge for **all** Dependabot PRs (e.g. #507).

## Fix

Switch all three `--merge` calls in `dependabot-auto-merge.yml` to `--squash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)