### PR TITLE
docs(website): tighten benchmark copy and fix Semrush SEO issues

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -121,19 +121,18 @@ JDK, and the Docker/DB image next to the figures, exactly as the recorded result
 
 ## Fill throughput: stacking the optimizations
 
-This is the result of a multi-part optimization campaign on `DatabaseFiller.fill()`
-(tracked in [issue #447](https://github.com/timveil/bloviate/issues/447) and its follow-ups
-[#466](https://github.com/timveil/bloviate/issues/466),
-[#467](https://github.com/timveil/bloviate/issues/467),
-[#468](https://github.com/timveil/bloviate/issues/468)). Two views of the same campaign follow:
-a **cumulative progression** that stacks the strategies on one large table to a final speedup,
-and a **cross-schema** comparison of parallel table fill. The levers measured:
+`DatabaseFiller.fill()` applies four independent optimizations, each aimed at a different
+bottleneck — the JDBC wire, transaction overhead, single-table parallelism, and the per-cell hot
+loop. Because they target different costs, they stack: on one large table they compound to a
+**6.08× speedup**, and on a wide multi-table schema parallel fill alone delivers **3.26×**. The
+two views below quantify that — a cumulative progression on a single dominant table, and a
+cross-schema comparison of parallel table fill. The levers:
 
-- **driver batch rewrite** — `reWriteBatchedInserts` collapses each JDBC batch into one multi-row `INSERT`.
-- **commit strategy** — disable autocommit and commit once per table (or every N batches); see [Commit strategy](./ARCHITECTURE.md#commit-strategy).
-- **intra-table partitioning** — split one large table's rows across workers; the only lever for a single dominant table (one table, one topological level), which parallel table fill cannot help. See [Intra-table partitioning](./ARCHITECTURE.md#intra-table-partitioning--seeking-to-a-row-range).
+- **driver batch rewrite** — `reWriteBatchedInserts` collapses each JDBC batch into one multi-row `INSERT`, cutting round-trips to the database.
+- **commit strategy** — disable autocommit and commit once per table (or every N batches) instead of paying transaction overhead per batch; see [Commit strategy](./ARCHITECTURE.md#commit-strategy).
+- **intra-table partitioning** — split one large table's rows across workers. This is the only lever for a single dominant table (one table, one topological level), which parallel table fill cannot speed up. See [Intra-table partitioning](./ARCHITECTURE.md#intra-table-partitioning--seeking-to-a-row-range).
 - **parallel table fill** — `DataSource` + `threads`, one connection per worker; the lever for schemas with many *independent* tables. See [Parallel fill — topological levels](./ARCHITECTURE.md#parallel-fill--topological-levels).
-- **hot-loop micro-opt** — positional generator dispatch in `TableFiller` (within end-to-end noise; see CPU table).
+- **hot-loop micro-opt** — positional generator dispatch in `TableFiller`, which removes a HashMap lookup from the innermost loop (a clear CPU win in isolation; within end-to-end noise — see the CPU table).
 
 **Environment**
 
@@ -144,10 +143,11 @@ and a **cross-schema** comparison of parallel table fill. The levers measured:
 
 ### Removing the per-cell lookup (CPU, JMH, ops/us — higher is better)
 
-The micro-opt replaces the per-cell `HashMap.get(column)` (hashing the value-based `Column` record)
-with a positional array read. `dispatchRowIndexed` is the optimized variant of `dispatchRow` over the
-same 16-column row, so the delta isolates the lookup removed (the rest is the unavoidable
-`generate()` work, which dominates a row containing a 256-char varchar and a jsonb payload).
+The hot-loop micro-opt replaces the per-cell `HashMap.get(column)` (which hashes the value-based
+`Column` record on every cell) with a positional array read. `dispatchRowIndexed` runs the same
+16-column row as `dispatchRow`, so the delta isolates exactly the lookup that was removed — the rest
+is the unavoidable `generate()` work, which dominates a row containing a 256-char varchar and a jsonb
+payload.
 
 | Benchmark | Score | Notes |
 |-----------|------:|-------|
@@ -160,16 +160,16 @@ slowest types in the baseline run: `VARCHAR_LONG` 0.59, `JSONB` 2.2, `UUID` 8.7,
 ### Stacking the strategies on one large table
 
 A single 1,000,000-row table (`postgres/single`) is the clearest place to watch the optimizations
-**compound**: it sits alone in its topological level, so parallel *table* fill can't touch it, but it
-benefits from each follow-up in turn. Starting from a naive fill (sequential, autocommit, no driver
-batch rewrite) and adding one strategy at a time — **best of 5**:
+**compound**: it sits alone in its topological level, so parallel *table* fill can't touch it, yet it
+benefits from every other lever. Starting from a naive fill (sequential, autocommit, no driver batch
+rewrite) and adding one strategy at a time — **best of 5**:
 
 | Step | Added | rows/sec | Cumulative |
 |------|-------|---------:|-----------:|
 | Naive | sequential, autocommit, no batch rewrite | 125,228 | 1.00× |
-| + driver batch rewrite ([#468](https://github.com/timveil/bloviate/issues/468)) | `reWriteBatchedInserts` collapses each batch into one multi-row `INSERT` | 151,641 | 1.21× |
-| + per-table commit ([#467](https://github.com/timveil/bloviate/issues/467)) | one commit instead of one per batch | 160,867 | 1.28× |
-| + intra-table partitioning ×8 ([#466](https://github.com/timveil/bloviate/issues/466)) | the one table's rows split across 8 workers | **760,959** | **6.08×** |
+| + driver batch rewrite | `reWriteBatchedInserts` collapses each batch into one multi-row `INSERT` | 151,641 | 1.21× |
+| + per-table commit | one commit instead of one per batch | 160,867 | 1.28× |
+| + intra-table partitioning ×8 | the table's rows split across 8 workers | **760,959** | **6.08×** |
 
 ```mermaid
 xychart-beta
@@ -179,11 +179,10 @@ xychart-beta
     bar [125228, 151641, 160867, 760959]
 ```
 
-End to end, the three follow-ups take a single large table from **125k to 761k rows/sec — a 6.08×
-speedup**. Driver batch rewrite and intra-table partitioning do the heavy lifting;
-per-table commit is a small bump *here* — with batch rewrite on, a single table already commits
-cheaply — but it matters more on the many-table schemas below. Each step is reproducible from the
-harness knobs:
+Together these take a single large table from **125k to 761k rows/sec — a 6.08× speedup**. Driver
+batch rewrite and intra-table partitioning do the heavy lifting; per-table commit is a small bump
+*here* — with batch rewrite on, a single table already commits cheaply — but it matters more on the
+many-table schemas below. Each step is reproducible from the harness knobs:
 
 ```bash
 BASE="./mvnw -pl bloviate-benchmarks -am -Pbench test -Dtest='PostgresFillBenchmark#singleTable' -Dbench.rows=1000000"
@@ -237,12 +236,12 @@ non-deterministic. See [Reproducibility — deterministic seeds from schema iden
 
 ## Switching the RNG
 
-Bloviate replaced the legacy `java.util.Random` (a 48-bit LCG with a documented statistical defect and
-`synchronized` methods) with a `java.util.random.RandomGenerator` using the JDK general-purpose default
-**`L64X128MixRandom`** (`RandomGenerators.create(seed)`). The per-column seeding architecture is
-unchanged, so output stays reproducible; only the algorithm changes. (Tracked in
-[issue #471](https://github.com/timveil/bloviate/issues/471).) These numbers compare the two RNGs on
-the identical benchmark harness — old jar built from `HEAD`, new jar from the migration branch.
+Bloviate generates values with a `java.util.random.RandomGenerator` — the JDK general-purpose default
+**`L64X128MixRandom`** (`RandomGenerators.create(seed)`) — rather than the legacy `java.util.Random`,
+a 48-bit LCG with a documented statistical defect and `synchronized` methods. The payoff is twofold:
+faster draws (no lock, a better algorithm) and higher statistical quality, with no new dependency. The
+per-column seeding architecture is unchanged, so output stays reproducible; only the algorithm
+changes. The numbers below compare the two RNGs on an identical benchmark harness.
 
 **Environment**
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import sitemap from '@astrojs/sitemap';
 import rehypeDocIcons from './src/plugins/rehype-doc-icons.mjs';
 import rehypeMermaid from './src/plugins/rehype-mermaid.mjs';
 import rehypeGraphviz from './src/plugins/rehype-graphviz.mjs';
@@ -144,5 +145,8 @@ export default defineConfig({
 				},
 			],
 		}),
+		// Emits sitemap-index.xml + sitemap-0.xml at build (uses `site` above);
+		// referenced from public/robots.txt so crawlers discover every page.
+		sitemap(),
 	],
 });

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "@astrojs/starlight": "^0.41.1",
     "astro": "^7.0.3",
     "sharp": "^0.35.2"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.3
+        version: 3.7.3
       '@astrojs/starlight':
         specifier: ^0.41.1
         version: 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))

--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,0 +1,5 @@
+# Cloudflare Pages headers (https://developers.cloudflare.com/pages/configuration/headers/)
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,29 @@
+# Bloviate
+
+> Bloviate is a Java library that fills JDBC-compatible relational databases with realistic, reproducible dummy data. It auto-discovers your schema, infers a generator for every column from its JDBC type, respects foreign keys via topological ordering, and can also emit flat files (CSV, TSV, pipe-delimited). It never touches production data and is deterministic by seed.
+
+Key facts:
+
+- Java 25, multi-module Maven build: `bloviate-core` (dependency-free engine), `bloviate-junit` (JUnit 5 `@FillDatabase`/`@FillSource`), `bloviate-testcontainers` (fills a started `JdbcDatabaseContainer`).
+- First-class support for PostgreSQL, MySQL, and CockroachDB, plus a generic default for other JDBC drivers.
+- Deterministic output: per-column seeds derived from schema identity, backed by the JDK `L64X128MixRandom` generator.
+
+## Guides
+
+- [Quick Start](https://bloviate.io/guides/quickstart/): Install Bloviate and fill a database or flat file in a few lines.
+- [Database Support](https://bloviate.io/guides/database-support/): Per-database type handling and how vendor-specific types are resolved.
+- [Configuration](https://bloviate.io/guides/configuration/): Control row counts, batch size, and per-column generators.
+- [Generators](https://bloviate.io/guides/generators/): Built-in generators and how to apply custom ones across columns or whole types.
+- [Testing Integrations](https://bloviate.io/guides/integrations/): JUnit 5 and Testcontainers integrations for reproducible test data.
+- [File Generation](https://bloviate.io/guides/file-generation/): Generate CSV, TSV, or pipe-delimited files with no database involved.
+- [Why Bloviate](https://bloviate.io/guides/comparison/): Where Bloviate fits among test-data tools and when to use it.
+
+## Under the hood
+
+- [Architecture](https://bloviate.io/guides/architecture/): Schema discovery, foreign-key ordering, parallel fill, and deterministic seeding.
+- [Benchmarks](https://bloviate.io/guides/benchmarks/): CPU micro-benchmarks (JMH) and end-to-end fill throughput against real databases.
+
+## Reference
+
+- [API Reference](https://bloviate.io/reference/): Browse the Java API by package.
+- [Full Javadoc](https://bloviate.io/apidocs/index.html): Complete generated Javadoc for the core engine and integrations.

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,5 @@
+# https://bloviate.io
+User-agent: *
+Allow: /
+
+Sitemap: https://bloviate.io/sitemap-index.xml

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -53,9 +53,51 @@ function rewriteGuideLinks(md) {
 }
 
 /**
+ * Derive a meta description from the first prose paragraph of a doc.
+ *
+ * Starlight otherwise falls back to the site-wide description on every page,
+ * which SEO crawlers flag as duplicate meta descriptions. We take the first
+ * real paragraph (skipping headings, lists, tables, blockquotes, HTML and code
+ * fences), strip Markdown to plain text, and truncate at a word boundary.
+ */
+function deriveDescription(bodyLines) {
+	const para = [];
+	let inFence = false;
+	for (const raw of bodyLines) {
+		const line = raw.trim();
+		if (line.startsWith('```')) {
+			inFence = !inFence;
+			if (para.length) break;
+			continue;
+		}
+		if (inFence) continue;
+		if (line === '') {
+			if (para.length) break;
+			continue;
+		}
+		// Skip non-prose blocks (headings, tables, lists, quotes, raw HTML).
+		if (/^(#{1,6}\s|[|>]|[-*+]\s|\d+\.\s|<)/.test(line)) {
+			if (para.length) break;
+			continue;
+		}
+		para.push(line);
+	}
+	let text = para
+		.join(' ')
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
+		.replace(/[`*_]/g, '') // inline code / emphasis markers
+		.replace(/\s+/g, ' ')
+		.trim();
+	if (text.length > 160) {
+		text = `${text.slice(0, 157).replace(/\s+\S*$/, '')}…`;
+	}
+	return text;
+}
+
+/**
  * Build the Starlight page: strip a leading comment, pull the first H1 out to
- * use as the frontmatter title (avoiding a duplicate heading), prepend
- * frontmatter.
+ * use as the frontmatter title (avoiding a duplicate heading), derive a
+ * per-page meta description from the first paragraph, prepend frontmatter.
  */
 function toStarlightPage(md, fallbackTitle) {
 	const lines = stripLeadingComment(md).split('\n');
@@ -69,7 +111,12 @@ function toStarlightPage(md, fallbackTitle) {
 		}
 	}
 	const body = lines.join('\n').replace(/^\n+/, '');
-	return `---\ntitle: ${JSON.stringify(title)}\n---\n\n${body}`;
+	const description = deriveDescription(lines);
+	const frontmatter = [`title: ${JSON.stringify(title)}`];
+	if (description) {
+		frontmatter.push(`description: ${JSON.stringify(description)}`);
+	}
+	return `---\n${frontmatter.join('\n')}\n---\n\n${body}`;
 }
 
 function resetDir(dir) {


### PR DESCRIPTION
## Summary

Two website improvements, both landing in tracked source files.

### 1. Benchmark guide reads as marketing, not a changelog
The `Benchmarks` guide had changelog-style prose — "optimization campaign", "follow-ups", inline issue links in every table row, and "old jar built from `HEAD`, new jar from the migration branch". Reworked into outcome-first technical copy:
- **Fill throughput** section now leads with the result (6.08× / 3.26×) and explains *why* each lever matters, with no issue-tracker narration.
- **RNG** section states what Bloviate uses and the payoff, dropping the branch/issue history.

Edits land in the canonical `docs/BENCHMARKS.md`; the `website/src/content/docs/guides/` copy is a gitignored artifact regenerated by `sync-docs.mjs`.

### 2. Fix actionable Semrush crawl findings
| Issue | Fix |
|---|---|
| Invalid robots.txt (ERROR) | Added `public/robots.txt` with a `Sitemap:` line |
| Sitemap not found / not in robots.txt (2× WARNING) | Added `@astrojs/sitemap`; emits `sitemap-index.xml` covering all 12 routes |
| Duplicate meta descriptions (ERROR, 10 pages) | `sync-docs.mjs` derives a per-page description from each doc's first paragraph |
| Llms.txt not found (NOTICE) | Added spec-formatted `public/llms.txt` |
| No HSTS (NOTICE) | Added `public/_headers` with HSTS (+ `X-Content-Type-Options`, `Referrer-Policy`) |

## Notes
- `pnpm install` reconciled a stale lockfile: `astro` 6.4.8→7.0.3, `@astrojs/starlight` 0.40→0.41.1, `sharp` 0.33.5→0.35.2 (matching what `package.json` already declared). `pnpm build` is green.
- **Not addressed** (need the per-URL Semrush export): temporary redirects (42), 4xx (1), DNS (1), links with no anchor text (12). Thin-content / unminified-asset notices are almost entirely the committed `public/apidocs` Javadoc (Pagefind indexed 390 HTML files).

## Test plan
- [x] `pnpm build` succeeds; `sitemap-index.xml` + `sitemap-0.xml` emitted
- [x] `robots.txt`, `llms.txt`, `_headers` present in `dist/`
- [x] Each guide renders a unique `<meta name="description">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)