### PR TITLE
docs(website): exclude Javadoc from SEO crawl and clean up customer-facing copy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -531,5 +531,4 @@ principles above are what let it stay simple to *use* while remaining genuinely 
 
 ---
 
-*See also: the [README](/guides/quickstart/) for usage, and [issue #455](https://github.com/timveil/bloviate/issues/455)
-for the docs-site effort this content feeds into.*
+*See also: [Quick Start](./QUICKSTART.md) to start filling databases.*

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -19,8 +19,9 @@ The work being optimized spans two regimes, so there are two suites:
 | **CPU micro-benchmarks** | raw value generation and per-cell generator dispatch, no database | hot-loop micro-opts, generator-level changes | JMH |
 | **End-to-end fill** | `DatabaseFiller.fill()` throughput (rows/sec) against a real DB | parallel table fill, commit tuning, batch rewrite | plain JUnit runner |
 
-The `bloviate-benchmarks` module is never published (deploy, install, source, javadoc and
-JaCoCo are all skipped) and nothing in `bloviate-core` depends on it.
+The `bloviate-benchmarks` module isn't published to Maven Central and nothing in
+`bloviate-core` depends on it — running the benchmarks is entirely opt-in and adds no weight
+to the library.
 
 ## CPU micro-benchmarks (JMH)
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -113,13 +113,13 @@ synth (dormant), Snowfakery (Python, recipe-authored, no schema introspection), 
 
 Verified 2026-06 via web survey + codebase analysis.
 
-- Benerator CE — <https://github.com/rapiddweller/rapiddweller-benerator-ce> · <https://benerator.de/faq/>
-- Snowfakery — <https://github.com/SFDO-Tooling/Snowfakery>
-- synth (releases) — <https://github.com/shuttle-hq/synth/releases>
-- DBeaver Mock Data — <https://dbeaver.com/docs/dbeaver/Mock-Data-Generation/>
-- SDV license (BSL) — <https://datacebo.com/blog/sdv-bsl-license/> · <https://github.com/sdv-dev/SDV/blob/main/LICENSE>
-- Gretel → NVIDIA — <https://techcrunch.com/2025/03/19/nvidia-reportedly-acquires-synthetic-data-startup-gretel/>
-- MOSTLY AI (powered by Syntho) — <https://mostly.ai/>
-- Datafaker — <https://github.com/datafaker-net/datafaker>
-- Jailer — <https://github.com/Wisser/Jailer>
-- pgbench — <https://www.postgresql.org/docs/current/pgbench.html>
+- Benerator CE — [GitHub repo](https://github.com/rapiddweller/rapiddweller-benerator-ce) · [FAQ](https://benerator.de/faq/)
+- Snowfakery — [GitHub repo](https://github.com/SFDO-Tooling/Snowfakery)
+- synth — [GitHub releases](https://github.com/shuttle-hq/synth/releases)
+- DBeaver Mock Data — [documentation](https://dbeaver.com/docs/dbeaver/Mock-Data-Generation/)
+- SDV license (BSL) — [announcement post](https://datacebo.com/blog/sdv-bsl-license/) · [LICENSE file](https://github.com/sdv-dev/SDV/blob/main/LICENSE)
+- Gretel → NVIDIA — [TechCrunch report](https://techcrunch.com/2025/03/19/nvidia-reportedly-acquires-synthetic-data-startup-gretel/)
+- MOSTLY AI (powered by Syntho) — [product site](https://mostly.ai/)
+- Datafaker — [GitHub repo](https://github.com/datafaker-net/datafaker)
+- Jailer — [GitHub repo](https://github.com/Wisser/Jailer)
+- pgbench — [PostgreSQL documentation](https://www.postgresql.org/docs/current/pgbench.html)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -191,8 +191,8 @@ seed produce byte-for-byte the same data as a sequential fill.
 
 How much this helps depends on the schema. A wide schema of independent tables sees a large speedup
 (~3× with 8 workers on a 10-table, 1M-row fixture); a deep, narrow foreign-key chain (each table
-depending on the previous) has little to parallelize. See
-[BENCHMARKS.md](https://github.com/timveil/bloviate/blob/main/BENCHMARKS.md) for numbers.
+depending on the previous) has little to parallelize. See [the benchmarks](./BENCHMARKS.md) for
+numbers.
 
 The single-`Connection` constructor is unchanged and remains the default sequential path — `threads`
 only applies to the `DataSource` form.

--- a/docs/GENERATORS.md
+++ b/docs/GENERATORS.md
@@ -263,8 +263,8 @@ Set<TableConfiguration> tpcc = TPCCConfiguration.build(
 );
 ```
 
-The corresponding DDL lives in
-`bloviate-core/src/test/resources/create_tpcc.{postgres,mysql,cockroachdb}.sql`. The reusable
+The matching `create_tpcc.{postgres,mysql,cockroachdb}.sql` DDL is available in the
+[Bloviate repository](https://github.com/timveil/bloviate). The reusable
 building blocks behind `TPCCConfiguration` — `CompositeKeyComponentGenerator`, `ChildCardinality`,
 `GroupedPermutationGenerator` (per-group shuffles), and `GroupedPrefixGenerator` (nullable/sparse
 columns) — live in `io.bloviate.gen` and can be composed for other benchmark schemas (TPC-H,

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -140,7 +140,10 @@ export default defineConfig({
 						// Brand-themed Javadoc, generated locally and committed under
 						// public/apidocs (Cloudflare can't run Java). Regenerate with
 						// `./mvnw -Pjavadoc-site javadoc:aggregate`.
-						{ label: 'Full Javadoc', link: '/apidocs/index.html', attrs: { target: '_blank' } },
+						// Link the canonical directory URL, not /apidocs/index.html: Starlight
+						// strips the .html, and Cloudflare then 307-redirects the bare path to
+						// /apidocs/. Pointing straight at /apidocs/ avoids that per-page redirect.
+						{ label: 'Full Javadoc', link: '/apidocs/', attrs: { target: '_blank' } },
 					],
 				},
 			],

--- a/website/public/_headers
+++ b/website/public/_headers
@@ -3,3 +3,8 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
+
+# Keep the generated Javadoc out of search indexes (belt-and-suspenders alongside
+# the robots.txt Disallow; covers crawlers that fetch it anyway).
+/apidocs/*
+  X-Robots-Tag: noindex

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,5 +1,7 @@
 # https://bloviate.io
 User-agent: *
-Allow: /
+# Generated API reference (Javadoc) is reference material, not indexable content
+# — kept reachable from the site but excluded from crawlers. Mirrored on javadoc.io.
+Disallow: /apidocs/
 
 Sitemap: https://bloviate.io/sitemap-index.xml

--- a/website/src/content/docs/reference/index.mdx
+++ b/website/src/content/docs/reference/index.mdx
@@ -8,13 +8,12 @@ next: false
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
-The complete **Javadoc** for every public package is hosted right here on the site.
-It's generated from source with the JDK's own `javadoc` tool, so signatures, type
-links, and inheritance are exactly what the compiler sees — then themed to match
-these docs.
+The complete **API reference** for every public package — full method signatures, type
+links, and class hierarchies. It's generated straight from the library source, so it
+always matches the released API.
 
 <Card title="Browse the full Javadoc" icon="open-book">
-	The complete API reference, with its own per-class search.
+	Every public class and method, with built-in search.
 
 	<a href="/apidocs/" target="_blank" rel="noopener noreferrer">Open the API reference →</a>
 </Card>
@@ -88,9 +87,3 @@ The package links open the Javadoc in a new tab.
 		description="Datafaker-backed generators for realistic semantic values (names, emails, addresses)."
 	/>
 </CardGrid>
-
-:::note[Keeping it current]
-The reference is committed static HTML (Cloudflare Pages can't run Java). Regenerate it
-after public-API changes with `./mvnw -Pjavadoc-site javadoc:aggregate` and commit the
-updated `website/public/apidocs/` — see the [website README](https://github.com/timveil/bloviate/blob/main/website/README.md).
-:::

--- a/website/src/content/docs/reference/index.mdx
+++ b/website/src/content/docs/reference/index.mdx
@@ -16,7 +16,7 @@ these docs.
 <Card title="Browse the full Javadoc" icon="open-book">
 	The complete API reference, with its own per-class search.
 
-	<a href="/apidocs/index.html" target="_blank" rel="noopener noreferrer">Open the API reference →</a>
+	<a href="/apidocs/" target="_blank" rel="noopener noreferrer">Open the API reference →</a>
 </Card>
 
 ## By package


### PR DESCRIPTION
## Summary

Two related rounds of website work, driven by a Semrush site audit and a copy review. Both land in the canonical `docs/*.md` sources (synced into the site) and the site config.

### 1. SEO fixes (commit 1)
The per-URL Semrush export showed **755 of 771 crawled URLs are the generated `/apidocs/` Javadoc**, accounting for ~95% of all flagged issues (the bulk of temporary redirects, all unminified JS/CSS, all "only one internal link", etc.) — issues intrinsic to machine-generated API reference docs. Rather than chase unfixable per-page heuristics, exclude the tree from crawlers (the standard treatment; Javadoc stays reachable on-site and is mirrored on javadoc.io):

- `robots.txt`: `Disallow: /apidocs/` (also replaces the `Allow`-only form Semrush flagged as invalid)
- `_headers`: `X-Robots-Tag: noindex` on `/apidocs/*`

Plus link hygiene on the real pages:
- `astro.config.mjs` + reference page: link `/apidocs/` instead of `/apidocs/index.html` (Starlight strips `.html` → `/apidocs/index`, which Cloudflare 307-redirects — one redirect on every page)
- `COMPARISON.md`: give the 12 bare `<https://…>` source autolinks descriptive anchor text

### 2. Customer-facing copy cleanup (commit 2)
Audited every published page for maintainer/internal voice and rewrote it to address the reader as a user:

- **Reference**: removed the "Keeping it current" maintainer note (regenerate-and-commit instructions) and the "themed to match these docs / its own per-class search" framing
- **ARCHITECTURE**: closing line cited issue #455 and "the docs-site effort this content feeds into" → plain Quick Start pointer
- **CONFIGURATION**: benchmarks link was a raw GitHub blob URL → now the on-site `/guides/benchmarks/`
- **GENERATORS**: dropped the internal `bloviate-core/src/test/resources/...` path → repository link, keeping the filename
- **BENCHMARKS**: tightened the "never published (deploy, install, source, javadoc, JaCoCo all skipped)" Maven plumbing → plain opt-in statement

COMPARISON, DATABASE_SUPPORT, FILE_GENERATION, INTEGRATIONS, QUICKSTART, and the homepage were clean. The 57 ARCHITECTURE class→source GitHub links are intentionally kept (implementation deep-dive).

## Out of scope (manual, not a repo change)
`www.bloviate.io` doesn't resolve (the audit's "DNS resolution issue") — needs a Cloudflare DNS record for `www` + a `www`→apex 301 redirect.

## Test plan
- [x] `pnpm --dir website build` succeeds; `dist/robots.txt` has the Disallow, `dist/_headers` has the `/apidocs/*` noindex block
- [x] Sidebar "Full Javadoc" href is `/apidocs/` (0 occurrences of the old `/apidocs/index` form)
- [x] Comparison source links render as text labels; doc-to-doc links resolve to `/guides/…` routes
- [x] None of the removed internal phrases remain in the rebuilt `dist`
- [ ] After deploy: re-run Semrush — `/apidocs/` drops out, temporary redirects → ~0, no-anchor-text → 0, invalid-robots.txt cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)