### PR TITLE
docs(site): surface Architecture & Benchmarks on the home page

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -70,6 +70,23 @@ than replacing it.
 
 [Get started in five minutes →](/guides/quickstart/)
 
+## Under the hood
+
+How Bloviate actually works, and how fast it runs — the deep technical material behind the library.
+
+<CardGrid>
+	<LinkCard
+		title="Architecture"
+		href="/guides/architecture/"
+		description="The foreign-key dependency DAG and topological fill order, schema-identity seeding for reproducibility, parallel and partitioned fills, and the extension points — with diagrams."
+	/>
+	<LinkCard
+		title="Benchmarks"
+		href="/guides/benchmarks/"
+		description="How Bloviate performs filling real benchmark schemas (TPC-C and friends), how the harness works, and how to run it yourself."
+	/>
+</CardGrid>
+
 ## API reference
 
 The complete Javadoc for every public package is hosted right here — themed to match these docs,


### PR DESCRIPTION
## Description

The "Under the hood" docs (Architecture and Benchmarks) were only reachable through the sidebar, which collapses into the hamburger menu on mobile and never appears on the splash home page — making the deep technical material hard to discover on small screens.

This adds an **"Under the hood"** `CardGrid` to the home page, right before the API reference section, linking straight to the Architecture and Benchmarks guides. It mirrors the existing API-reference section's `LinkCard` pattern, so the deep technical content is discoverable without opening the nav drawer.

## Related Issues

<!-- None. -->

## Type of Change

- [x] `docs` / `test` / `ci` / `chore` / `style` — no release

## Affected Module(s)

- [x] Build / CI / tooling

<!-- Website docs only (website/src/content/docs/index.mdx); no Java module is touched. -->

## How Has This Been Tested?

`pnpm build` in `website/` completes successfully (all 12 pages built). Verified the rendered `dist/index.html` contains the new "Under the hood" heading and both cards linking to `/guides/architecture/` and `/guides/benchmarks/`. No Java code changed, so `./mvnw verify` is not relevant to this change.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://conventionalcommits.org/) format
- [ ] `./mvnw verify` passes locally (tests included) — N/A, website-docs-only change
- [ ] I have added or updated tests covering my changes — N/A, docs change
- [x] I have updated documentation as needed (README, ARCHITECTURE, etc.)
- [x] My changes follow the existing code style and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDYkyLSx2cFsXgZW52uTWz)_