### PR TITLE
feat(core): add UNORDERED_BULK fill strategy (disable constraints, fill barrier-free, re-enable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 - [ ] [Additional database support (Oracle, SQL Server)](https://github.com/timveil/bloviate/issues/445)
 - [x] [Custom data generation plugins](https://github.com/timveil/bloviate/issues/446)
-- [x] [Performance optimizations for large datasets](https://github.com/timveil/bloviate/issues/447) — _parallel table fill, intra-table partitioning, configurable commit strategy, batch-rewrite surfacing, and hot-loop dispatch ([benchmarks](https://bloviate.io/guides/benchmarks/))_
+- [x] [Performance optimizations for large datasets](https://github.com/timveil/bloviate/issues/447) — _parallel table fill, intra-table partitioning, unordered bulk load, configurable commit strategy, batch-rewrite surfacing, and hot-loop dispatch ([benchmarks](https://bloviate.io/guides/benchmarks/))_
 - [ ] GUI for configuration management
 - [x] [Integration with popular testing frameworks](https://github.com/timveil/bloviate/issues/448) — _JUnit 5 (`bloviate-junit`) and Testcontainers (`bloviate-testcontainers`)_
 

--- a/bloviate-benchmarks/src/test/java/io/bloviate/bench/AbstractFillBenchmark.java
+++ b/bloviate-benchmarks/src/test/java/io/bloviate/bench/AbstractFillBenchmark.java
@@ -18,6 +18,7 @@ package io.bloviate.bench;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.db.BulkLoadStrategy;
 import io.bloviate.db.Database;
 import io.bloviate.db.DatabaseConfiguration;
 import io.bloviate.db.DatabaseFiller;
@@ -48,7 +49,8 @@ import java.util.Set;
  *
  * <p>Tunable via system properties: {@code bench.warmup} (default 1), {@code bench.iterations}
  * (3), {@code bench.rows} (default-row-count for the wide schema, 50,000), {@code bench.warehouses}
- * (TPC-C scale factor, 1), {@code bench.batch} (JDBC batch size, 1000).
+ * (TPC-C scale factor, 1), {@code bench.batch} (JDBC batch size, 1000), {@code bench.threads}
+ * (parallel workers, 1), {@code bench.bulk} (unordered bulk load, false).
  */
 abstract class AbstractFillBenchmark {
 
@@ -66,6 +68,15 @@ abstract class AbstractFillBenchmark {
      * tables concurrently from the pool, one connection per worker. Set with {@code -Dbench.threads}.
      */
     protected static final int THREADS = Integer.getInteger("bench.threads", 1);
+
+    /**
+     * Whether to use the unordered bulk-load path (disable foreign-key enforcement, fill every table
+     * at once with no topological barrier, re-enable). Only effective with {@code bench.threads > 1}
+     * on a database whose support reports {@code supportsBulkLoad()} (PostgreSQL, MySQL). Set with
+     * {@code -Dbench.bulk=true}. The win is largest on deep/narrow FK chains (TPC-C); the FK-free wide
+     * and single-table fixtures are negative controls expected to stay roughly flat.
+     */
+    protected static final boolean BULK = Boolean.getBoolean("bench.bulk");
 
     // TPC-C cardinalities; modest defaults (~60k rows) keep a casual run quick, scale up via -D
     protected static final int WAREHOUSES = Integer.getInteger("bench.warehouses", 1);
@@ -103,6 +114,7 @@ abstract class AbstractFillBenchmark {
      * best/mean throughput. The container must already be started with its schema applied.
      */
     protected void runBenchmark(String label, JdbcDatabaseContainer<?> container, DatabaseConfiguration configuration) throws SQLException {
+        configuration = applyBulk(configuration);
         try (HikariDataSource dataSource = dataSource(container);
              Connection connection = dataSource.getConnection()) {
 
@@ -139,6 +151,21 @@ abstract class AbstractFillBenchmark {
      * single-connection path; with more threads it is the {@link javax.sql.DataSource}-based
      * parallel path, filling independent tables concurrently — the issue #447 headline optimization.
      */
+    /**
+     * Returns a copy of {@code configuration} with {@link BulkLoadStrategy#unorderedBulk()} applied when
+     * {@code -Dbench.bulk=true}, otherwise the configuration unchanged. Rebuilds the record so the bulk
+     * flag is honored by every benchmark fixture without per-test wiring.
+     */
+    private static DatabaseConfiguration applyBulk(DatabaseConfiguration configuration) {
+        if (!BULK) {
+            return configuration;
+        }
+        return new DatabaseConfiguration(
+                configuration.batchSize(), configuration.defaultRowCount(), configuration.databaseSupport(),
+                configuration.tableConfigurations(), configuration.generatorRegistry(), configuration.seed(),
+                configuration.commitStrategy(), BulkLoadStrategy.unorderedBulk());
+    }
+
     private static void fill(HikariDataSource dataSource, Connection connection, DatabaseConfiguration configuration) throws SQLException {
         if (THREADS > 1) {
             new DatabaseFiller.Builder(dataSource, configuration).threads(THREADS).build().fill();

--- a/bloviate-core/src/main/java/io/bloviate/db/BulkLoadStrategy.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/BulkLoadStrategy.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.ext.DatabaseSupport;
+
+/**
+ * How {@link DatabaseFiller} orders table fills relative to foreign-key dependencies.
+ *
+ * <p>By default ({@link #ordered()}) the fill engine respects the foreign-key dependency graph:
+ * a child table is never filled before its parent. On the parallel path this means filling one
+ * topological <em>level</em> at a time with a barrier between levels, which serializes deep, narrow
+ * dependency chains (e.g. TPC-C's {@code warehouse → district → customer → open_order → order_line}).
+ *
+ * <p>{@link #unorderedBulk()} trades that ordering for speed on chained schemas. Bloviate's generated
+ * data is referentially consistent <em>by construction</em> — a foreign-key column's generator is
+ * seeded from the referenced primary-key column's seed, so child and parent produce identical key
+ * values regardless of insert order (see
+ * {@link io.bloviate.util.DatabaseUtils#columnSeed(Column, long)}). That makes it safe to disable
+ * foreign-key enforcement for the duration of the fill, insert <em>all</em> tables concurrently with
+ * no topological barrier, then re-enable enforcement. The resulting data is byte-for-byte identical to
+ * an ordered fill of the same seed.
+ *
+ * <p>Bulk mode only takes effect on the parallel path (a {@link javax.sql.DataSource} with
+ * {@link DatabaseFiller.Builder#threads(int)} {@code > 1}) and only when the active
+ * {@link DatabaseSupport} reports {@link DatabaseSupport#supportsBulkLoad()}. Otherwise the engine
+ * logs a warning and uses the ordered path. PostgreSQL and MySQL support it; CockroachDB does not and
+ * falls back.
+ *
+ * @param mode       the ordering mode
+ * @param revalidate whether {@link DatabaseSupport#enableConstraints} should re-validate existing rows
+ *                   when re-enabling enforcement (only meaningful for vendor mechanisms that can do so;
+ *                   the session-based PostgreSQL/MySQL mechanisms cannot and ignore it)
+ * @since 2.17.0
+ * @see DatabaseConfiguration
+ * @see DatabaseSupport#supportsBulkLoad()
+ */
+public record BulkLoadStrategy(Mode mode, boolean revalidate) {
+
+    /** The available ordering modes. */
+    public enum Mode {
+        /** Respect the topological level barrier; never disable constraints (the default). */
+        ORDERED,
+        /** Disable foreign-key enforcement, fill all tables at once with no barrier, then re-enable. */
+        UNORDERED_BULK
+    }
+
+    /**
+     * Validates the mode.
+     *
+     * @throws IllegalArgumentException if {@code mode} is null
+     */
+    public BulkLoadStrategy {
+        if (mode == null) {
+            throw new IllegalArgumentException("mode must not be null");
+        }
+    }
+
+    /**
+     * The back-compatible default: fill in foreign-key dependency order, never disabling constraints.
+     *
+     * @return an {@link Mode#ORDERED} strategy
+     */
+    public static BulkLoadStrategy ordered() {
+        return new BulkLoadStrategy(Mode.ORDERED, false);
+    }
+
+    /**
+     * Disable foreign-key enforcement, fill every table concurrently with no topological barrier, then
+     * re-enable enforcement without re-validating (safe because the data is consistent by construction).
+     *
+     * @return an {@link Mode#UNORDERED_BULK} strategy
+     */
+    public static BulkLoadStrategy unorderedBulk() {
+        return new BulkLoadStrategy(Mode.UNORDERED_BULK, false);
+    }
+
+    /**
+     * Whether this strategy is {@link Mode#UNORDERED_BULK}.
+     *
+     * @return {@code true} for unordered bulk loading
+     */
+    public boolean isUnordered() {
+        return mode == Mode.UNORDERED_BULK;
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/db/BulkLoadStrategy.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/BulkLoadStrategy.java
@@ -32,8 +32,10 @@ import io.bloviate.ext.DatabaseSupport;
  * values regardless of insert order (see
  * {@link io.bloviate.util.DatabaseUtils#columnSeed(Column, long)}). That makes it safe to disable
  * foreign-key enforcement for the duration of the fill, insert <em>all</em> tables concurrently with
- * no topological barrier, then re-enable enforcement. The resulting data is byte-for-byte identical to
- * an ordered fill of the same seed.
+ * no topological barrier, then re-enable enforcement. For the same seed, the resulting row content is
+ * identical to an ordered fill across every deterministic column — physical (on-disk) row order may
+ * differ, and columns whose generator is non-deterministic (e.g. wall-clock temporal values, or a
+ * custom plugin that reads external state) are reproducible only to the extent that generator is.
  *
  * <p>Bulk mode only takes effect on the parallel path (a {@link javax.sql.DataSource} with
  * {@link DatabaseFiller.Builder#threads(int)} {@code > 1}) and only when the active

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseConfiguration.java
@@ -54,23 +54,30 @@ import java.util.Set;
  * @param seed the base seed for reproducible generation; vary it for a different dataset
  * @param commitStrategy how the engine commits inserted rows; defaults to
  *        {@link CommitStrategy#connectionDefault()} (autocommit untouched) when null
+ * @param bulkLoadStrategy how the engine orders fills relative to foreign-key dependencies; defaults to
+ *        {@link BulkLoadStrategy#ordered()} (dependency-ordered) when null
  *
  * @author Tim Veil
  * @see DatabaseSupport
  * @see TableConfiguration
  * @see GeneratorRegistry
  * @see CommitStrategy
+ * @see BulkLoadStrategy
  * @see DatabaseFiller
  */
-public record DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed, CommitStrategy commitStrategy) {
+public record DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed, CommitStrategy commitStrategy, BulkLoadStrategy bulkLoadStrategy) {
 
     /**
-     * Normalizes a null {@code commitStrategy} to {@link CommitStrategy#connectionDefault()} so the
-     * back-compatible behavior applies whenever a caller does not specify one.
+     * Normalizes a null {@code commitStrategy} to {@link CommitStrategy#connectionDefault()} and a null
+     * {@code bulkLoadStrategy} to {@link BulkLoadStrategy#ordered()} so the back-compatible behavior
+     * applies whenever a caller does not specify them.
      */
     public DatabaseConfiguration {
         if (commitStrategy == null) {
             commitStrategy = CommitStrategy.connectionDefault();
+        }
+        if (bulkLoadStrategy == null) {
+            bulkLoadStrategy = BulkLoadStrategy.ordered();
         }
     }
 
@@ -84,7 +91,7 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param tableConfigurations optional per-table configuration overrides
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, 0L, null);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, 0L, null, null);
     }
 
     /**
@@ -98,7 +105,7 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param generatorRegistry optional registry of custom generator rules; may be null
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, 0L, null);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, 0L, null, null);
     }
 
     /**
@@ -112,7 +119,7 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param seed the base seed for reproducible generation
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, long seed) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, null);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, null, null);
     }
 
     /**
@@ -127,7 +134,23 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param commitStrategy how the engine commits inserted rows; may be null for the default
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, long seed, CommitStrategy commitStrategy) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, commitStrategy);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, commitStrategy, null);
+    }
+
+    /**
+     * Creates a configuration with the given base {@code seed}, {@link CommitStrategy} and
+     * {@link BulkLoadStrategy}, and no custom {@link GeneratorRegistry}.
+     *
+     * @param batchSize the number of rows to include in each batch INSERT operation
+     * @param defaultRowCount the default number of rows to generate for each table
+     * @param databaseSupport the database-specific support implementation
+     * @param tableConfigurations optional per-table configuration overrides
+     * @param seed the base seed for reproducible generation
+     * @param commitStrategy how the engine commits inserted rows; may be null for the default
+     * @param bulkLoadStrategy how the engine orders fills; may be null for the default
+     */
+    public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, long seed, CommitStrategy commitStrategy, BulkLoadStrategy bulkLoadStrategy) {
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, null, seed, commitStrategy, bulkLoadStrategy);
     }
 
     /**
@@ -142,7 +165,24 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * @param seed the base seed for reproducible generation
      */
     public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed) {
-        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, seed, null);
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, seed, null, null);
+    }
+
+    /**
+     * Creates a configuration with a custom {@link GeneratorRegistry}, base {@code seed} and
+     * {@link CommitStrategy}, and the default {@link BulkLoadStrategy} (preserves the original
+     * seven-argument signature).
+     *
+     * @param batchSize the number of rows to include in each batch INSERT operation
+     * @param defaultRowCount the default number of rows to generate for each table
+     * @param databaseSupport the database-specific support implementation
+     * @param tableConfigurations optional per-table configuration overrides
+     * @param generatorRegistry optional registry of custom generator rules; may be null
+     * @param seed the base seed for reproducible generation
+     * @param commitStrategy how the engine commits inserted rows; may be null for the default
+     */
+    public DatabaseConfiguration(int batchSize, long defaultRowCount, DatabaseSupport databaseSupport, Set<TableConfiguration> tableConfigurations, GeneratorRegistry generatorRegistry, long seed, CommitStrategy commitStrategy) {
+        this(batchSize, defaultRowCount, databaseSupport, tableConfigurations, generatorRegistry, seed, commitStrategy, null);
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -151,7 +151,7 @@ public class DatabaseFiller implements Fillable {
             // disables constraints and fills every table at once (when configured and supported)
             BulkLoadStrategy bulkLoadStrategy = configuration.bulkLoadStrategy();
             if (bulkLoadStrategy.isUnordered() && configuration.databaseSupport().supportsBulkLoad()) {
-                fillBulkUnordered(database, reversedGraph);
+                fillUnordered(database, reversedGraph);
             } else {
                 if (bulkLoadStrategy.isUnordered()) {
                     logger.warn("UNORDERED_BULK requested but {} does not support bulk load; using the ordered level-parallel path",
@@ -228,7 +228,7 @@ public class DatabaseFiller implements Fillable {
             for (List<Table> level : levels) {
                 List<Callable<Void>> tasks = new ArrayList<>(level.size());
                 for (Table table : level) {
-                    addTableTasks(tasks, database, table);
+                    addTableTasks(tasks, database, table, false);
                 }
 
                 // barrier: every table in this level must finish before the next level may start
@@ -262,7 +262,7 @@ public class DatabaseFiller implements Fillable {
      * @param graph    the reversed dependency graph (used only for its vertex set here)
      * @throws SQLException if any table fill fails or the run is interrupted
      */
-    private void fillBulkUnordered(Database database, Graph<Table, DefaultEdge> graph) throws SQLException {
+    private void fillUnordered(Database database, Graph<Table, DefaultEdge> graph) throws SQLException {
         DatabaseSupport support = configuration.databaseSupport();
 
         // probe once: if we can't disable+re-enable constraints on a borrowed connection, fall back to
@@ -277,9 +277,11 @@ public class DatabaseFiller implements Fillable {
             return;
         }
 
+        // one wave: every table (and partition) becomes a task with no topological barrier; the
+        // worker bodies disable/restore constraints per connection (see fillTableInOwnTransaction)
         List<Callable<Void>> tasks = new ArrayList<>();
         for (Table table : graph.vertexSet()) {
-            addBulkTableTasks(tasks, database, table);
+            addTableTasks(tasks, database, table, true);
         }
 
         int poolSize = Math.clamp(threads, 1, Math.max(1, tasks.size()));
@@ -340,13 +342,15 @@ public class DatabaseFiller implements Fillable {
      * Adds the worker task(s) for one table to {@code tasks}. A table with the default single
      * partition contributes one whole-table task; a table configured with {@code partitions > 1}
      * contributes one task per contiguous row range, so the ranges fill concurrently (intra-table
-     * parallelism) alongside the other tables in the same topological level.
+     * parallelism). When {@code bulk} is true the worker disables foreign-key enforcement on its
+     * connection for the duration of the fill (the unordered bulk path); otherwise it fills with
+     * enforcement intact (the ordered level-parallel path).
      */
-    private void addTableTasks(List<Callable<Void>> tasks, Database database, Table table) {
+    private void addTableTasks(List<Callable<Void>> tasks, Database database, Table table, boolean bulk) {
         int partitions = partitionsFor(table);
         if (partitions <= 1) {
             tasks.add(() -> {
-                fillTableInOwnTransaction(database, table);
+                fillTableInOwnTransaction(database, table, bulk);
                 return null;
             });
             return;
@@ -362,7 +366,7 @@ public class DatabaseFiller implements Fillable {
             if (size > 0) {
                 long rangeStart = start;
                 tasks.add(() -> {
-                    fillTablePartition(database, table, rangeStart, end);
+                    fillTablePartition(database, table, rangeStart, end, bulk);
                     return null;
                 });
             }
@@ -371,109 +375,62 @@ public class DatabaseFiller implements Fillable {
     }
 
     /**
-     * Fills a whole table on its own pooled connection inside a single transaction — the original,
-     * proven per-table parallel path (no row range, so generation is byte-for-byte identical to a
-     * sequential fill). The transaction is managed by {@link TableFiller} via the effective commit
-     * strategy (see {@link #effectiveParallelCommitStrategy()}).
+     * Fills a whole table on its own pooled connection inside a single transaction (no row range, so
+     * generation is byte-for-byte identical to a sequential fill). The transaction is managed by
+     * {@link TableFiller} via the effective commit strategy (see {@link #effectiveParallelCommitStrategy()}).
+     * When {@code bulk} is true, foreign-key enforcement is disabled for the fill and restored before
+     * the connection returns to the pool.
      */
-    private void fillTableInOwnTransaction(Database database, Table table) throws SQLException {
-        try (Connection conn = dataSource.getConnection()) {
-            new TableFiller.Builder(conn, database, configuration)
-                    .table(table)
-                    .commitStrategy(effectiveParallelCommitStrategy())
-                    .build().fill();
-        }
+    private void fillTableInOwnTransaction(Database database, Table table, boolean bulk) throws SQLException {
+        fillOnPooledConnection(database, bulk, conn ->
+                new TableFiller.Builder(conn, database, configuration)
+                        .table(table)
+                        .commitStrategy(effectiveParallelCommitStrategy())
+                        .build().fill());
     }
 
     /**
      * Fills one contiguous row range of a table on its own pooled connection inside a single
      * transaction. The transaction is managed by {@link TableFiller} via the effective commit
      * strategy (see {@link #effectiveParallelCommitStrategy()}): autocommit off, committed when the
-     * range is complete (or every N batches), and rolled back on failure.
+     * range is complete (or every N batches), and rolled back on failure. When {@code bulk} is true,
+     * foreign-key enforcement is disabled for the fill and restored before the connection returns to
+     * the pool.
      */
-    private void fillTablePartition(Database database, Table table, long startInclusive, long endExclusive) throws SQLException {
-        try (Connection conn = dataSource.getConnection()) {
-            new TableFiller.Builder(conn, database, configuration)
-                    .table(table)
-                    .commitStrategy(effectiveParallelCommitStrategy())
-                    .rowRange(startInclusive, endExclusive)
-                    .build().fill();
-        }
-    }
-
-    /**
-     * Adds the bulk worker task(s) for one table to {@code tasks}, mirroring {@link #addTableTasks} but
-     * routing to the constraint-disabling variants ({@link #fillTableBulk} /
-     * {@link #fillTablePartitionBulk}) used by the unordered bulk path.
-     */
-    private void addBulkTableTasks(List<Callable<Void>> tasks, Database database, Table table) {
-        int partitions = partitionsFor(table);
-        if (partitions <= 1) {
-            tasks.add(() -> {
-                fillTableBulk(database, table);
-                return null;
-            });
-            return;
-        }
-
-        long rowCount = rowCountFor(table);
-        long base = rowCount / partitions;
-        long remainder = rowCount % partitions;
-        long start = 0;
-        for (int p = 0; p < partitions; p++) {
-            long size = base + (p < remainder ? 1 : 0);
-            long end = start + size;
-            if (size > 0) {
-                long rangeStart = start;
-                tasks.add(() -> {
-                    fillTablePartitionBulk(database, table, rangeStart, end);
-                    return null;
-                });
-            }
-            start = end;
-        }
-    }
-
-    /**
-     * Fills a whole table on its own pooled connection with foreign-key enforcement disabled for the
-     * duration. Enforcement is disabled before the fill and restored in a {@code finally} before the
-     * connection is returned to the pool, so a disabled session never leaks to other pool users even if
-     * the fill throws.
-     */
-    private void fillTableBulk(Database database, Table table) throws SQLException {
-        DatabaseSupport support = configuration.databaseSupport();
-        try (Connection conn = dataSource.getConnection()) {
-            BulkLoadHandle handle = support.disableConstraints(conn, database);
-            try {
-                new TableFiller.Builder(conn, database, configuration)
-                        .table(table)
-                        .commitStrategy(effectiveParallelCommitStrategy())
-                        .build().fill();
-            } finally {
-                support.enableConstraints(conn, database, handle);
-            }
-        }
-    }
-
-    /**
-     * Fills one contiguous row range of a table on its own pooled connection with foreign-key
-     * enforcement disabled for the duration, restoring it in a {@code finally} before the connection is
-     * returned to the pool. The bulk-path twin of {@link #fillTablePartition}.
-     */
-    private void fillTablePartitionBulk(Database database, Table table, long startInclusive, long endExclusive) throws SQLException {
-        DatabaseSupport support = configuration.databaseSupport();
-        try (Connection conn = dataSource.getConnection()) {
-            BulkLoadHandle handle = support.disableConstraints(conn, database);
-            try {
+    private void fillTablePartition(Database database, Table table, long startInclusive, long endExclusive, boolean bulk) throws SQLException {
+        fillOnPooledConnection(database, bulk, conn ->
                 new TableFiller.Builder(conn, database, configuration)
                         .table(table)
                         .commitStrategy(effectiveParallelCommitStrategy())
                         .rowRange(startInclusive, endExclusive)
-                        .build().fill();
+                        .build().fill());
+    }
+
+    /**
+     * Borrows a connection from the pool and runs {@code body} on it. When {@code bulk} is true,
+     * foreign-key enforcement is disabled on the connection's session before {@code body} and restored
+     * in a {@code finally} <em>before</em> the connection returns to the pool — so a constraint-disabled
+     * connection never leaks to other pool users, even if the fill throws. The disable/enable mechanism
+     * is database-specific (see {@link DatabaseSupport#disableConstraints}).
+     */
+    private void fillOnPooledConnection(Database database, boolean bulk, ConnectionFill body) throws SQLException {
+        DatabaseSupport support = configuration.databaseSupport();
+        try (Connection conn = dataSource.getConnection()) {
+            BulkLoadHandle handle = bulk ? support.disableConstraints(conn, database) : null;
+            try {
+                body.fill(conn);
             } finally {
-                support.enableConstraints(conn, database, handle);
+                if (bulk) {
+                    support.enableConstraints(conn, database, handle);
+                }
             }
         }
+    }
+
+    /** A fill action against a borrowed connection; see {@link #fillOnPooledConnection}. */
+    @FunctionalInterface
+    private interface ConnectionFill {
+        void fill(Connection connection) throws SQLException;
     }
 
     /** The configured intra-table partition count for a table, or {@code 1} when not configured. */

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -202,8 +202,10 @@ public class DatabaseFiller implements Fillable {
      * connection to the pool. JDBC connections are not thread-safe, so they are never shared.
      *
      * <p>Reproducibility is preserved: a table's generated data depends only on its own per-column
-     * seeds and its own sequential row counter, never on the order in which tables are filled, so a
-     * parallel fill yields byte-for-byte the same data as the sequential fill for the same seed.
+     * seeds and its own sequential row counter, never on the order in which tables are filled, so for
+     * the same seed a parallel fill yields the same row content as the sequential fill across every
+     * deterministic column (physical row order and non-deterministic columns aside; see
+     * {@link BulkLoadStrategy}).
      *
      * @param database     the database metadata
      * @param reversedGraph the reversed dependency graph (parents before children)
@@ -252,7 +254,9 @@ public class DatabaseFiller implements Fillable {
      *
      * <p>This is only correct because Bloviate's data is referentially consistent by construction (a
      * foreign-key column is seeded from its referenced primary-key column), so insert order does not
-     * affect validity and the result is byte-for-byte identical to an ordered fill of the same seed.
+     * affect validity and, for the same seed, the result has the same row content as an ordered fill
+     * across every deterministic column (physical row order and non-deterministic columns aside; see
+     * {@link BulkLoadStrategy}).
      *
      * <p>Privilege is probed once up front on a throwaway connection; if constraints cannot be disabled
      * (e.g. the role lacks privilege for {@code session_replication_role}), the engine logs a warning
@@ -376,7 +380,8 @@ public class DatabaseFiller implements Fillable {
 
     /**
      * Fills a whole table on its own pooled connection inside a single transaction (no row range, so
-     * generation is byte-for-byte identical to a sequential fill). The transaction is managed by
+     * each generator is driven through the same call sequence as a sequential fill, producing identical
+     * values for every deterministic column). The transaction is managed by
      * {@link TableFiller} via the effective commit strategy (see {@link #effectiveParallelCommitStrategy()}).
      * When {@code bulk} is true, foreign-key enforcement is disabled for the fill and restored before
      * the connection returns to the pool.

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -16,6 +16,9 @@
 
 package io.bloviate.db;
 
+import io.bloviate.ext.BulkLoadHandle;
+import io.bloviate.ext.BulkLoadUnsupportedException;
+import io.bloviate.ext.DatabaseSupport;
 import io.bloviate.util.DatabaseUtils;
 import io.bloviate.util.JdbcUrls;
 import org.apache.commons.lang3.time.StopWatch;
@@ -141,13 +144,25 @@ public class DatabaseFiller implements Fillable {
         if (connection != null) {
             // back-compat path: fill sequentially on the caller's single connection (unchanged)
             warnIfPartitionsIgnored();
+            warnIfBulkIgnored();
             fillSequential(connection, database, reversedGraph);
         } else if (threads > 1) {
-            // parallel path: fill independent tables within each topological level concurrently
-            fillParallel(database, reversedGraph);
+            // parallel path: either the ordered level-by-level walk, or the unordered bulk path that
+            // disables constraints and fills every table at once (when configured and supported)
+            BulkLoadStrategy bulkLoadStrategy = configuration.bulkLoadStrategy();
+            if (bulkLoadStrategy.isUnordered() && configuration.databaseSupport().supportsBulkLoad()) {
+                fillBulkUnordered(database, reversedGraph);
+            } else {
+                if (bulkLoadStrategy.isUnordered()) {
+                    logger.warn("UNORDERED_BULK requested but {} does not support bulk load; using the ordered level-parallel path",
+                            configuration.databaseSupport().getClass().getSimpleName());
+                }
+                fillParallel(database, reversedGraph);
+            }
         } else {
             // DataSource supplied but no parallelism requested: borrow one connection, fill in order
             warnIfPartitionsIgnored();
+            warnIfBulkIgnored();
             try (Connection conn = dataSource.getConnection()) {
                 fillSequential(conn, database, reversedGraph);
             }
@@ -224,6 +239,61 @@ public class DatabaseFiller implements Fillable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new SQLException("parallel table fill was interrupted", e);
+        }
+    }
+
+    /**
+     * Fills every table concurrently with foreign-key enforcement disabled and <strong>no</strong>
+     * topological barrier — the {@link BulkLoadStrategy#unorderedBulk()} path. Each worker borrows its
+     * own connection, disables constraints on that session (see
+     * {@link DatabaseSupport#disableConstraints}), fills its table/partition, and restores enforcement
+     * in a {@code finally} before the connection returns to the pool. Collapsing all topological levels
+     * into a single wave removes the serialization cost of deep, narrow dependency chains.
+     *
+     * <p>This is only correct because Bloviate's data is referentially consistent by construction (a
+     * foreign-key column is seeded from its referenced primary-key column), so insert order does not
+     * affect validity and the result is byte-for-byte identical to an ordered fill of the same seed.
+     *
+     * <p>Privilege is probed once up front on a throwaway connection; if constraints cannot be disabled
+     * (e.g. the role lacks privilege for {@code session_replication_role}), the engine logs a warning
+     * and falls back to {@link #fillParallel} rather than risk a half-disabled run.
+     *
+     * @param database the database metadata
+     * @param graph    the reversed dependency graph (used only for its vertex set here)
+     * @throws SQLException if any table fill fails or the run is interrupted
+     */
+    private void fillBulkUnordered(Database database, Graph<Table, DefaultEdge> graph) throws SQLException {
+        DatabaseSupport support = configuration.databaseSupport();
+
+        // probe once: if we can't disable+re-enable constraints on a borrowed connection, fall back to
+        // the ordered path instead of fanning out into a partially-disabled state
+        try (Connection conn = dataSource.getConnection()) {
+            BulkLoadHandle handle = support.disableConstraints(conn, database);
+            support.enableConstraints(conn, database, handle);
+        } catch (BulkLoadUnsupportedException e) {
+            logger.warn("UNORDERED_BULK requested but constraints could not be disabled ({}); "
+                    + "falling back to the ordered level-parallel path", e.getMessage());
+            fillParallel(database, graph);
+            return;
+        }
+
+        List<Callable<Void>> tasks = new ArrayList<>();
+        for (Table table : graph.vertexSet()) {
+            addBulkTableTasks(tasks, database, table);
+        }
+
+        int poolSize = Math.clamp(threads, 1, Math.max(1, tasks.size()));
+
+        logger.info("bulk-filling {} table(s) with constraints disabled across {} worker thread(s) (no topological barrier)",
+                graph.vertexSet().size(), poolSize);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(poolSize)) {
+            for (Future<Void> future : executor.invokeAll(tasks)) {
+                awaitFuture(future);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SQLException("bulk table fill was interrupted", e);
         }
     }
 
@@ -331,6 +401,81 @@ public class DatabaseFiller implements Fillable {
         }
     }
 
+    /**
+     * Adds the bulk worker task(s) for one table to {@code tasks}, mirroring {@link #addTableTasks} but
+     * routing to the constraint-disabling variants ({@link #fillTableBulk} /
+     * {@link #fillTablePartitionBulk}) used by the unordered bulk path.
+     */
+    private void addBulkTableTasks(List<Callable<Void>> tasks, Database database, Table table) {
+        int partitions = partitionsFor(table);
+        if (partitions <= 1) {
+            tasks.add(() -> {
+                fillTableBulk(database, table);
+                return null;
+            });
+            return;
+        }
+
+        long rowCount = rowCountFor(table);
+        long base = rowCount / partitions;
+        long remainder = rowCount % partitions;
+        long start = 0;
+        for (int p = 0; p < partitions; p++) {
+            long size = base + (p < remainder ? 1 : 0);
+            long end = start + size;
+            if (size > 0) {
+                long rangeStart = start;
+                tasks.add(() -> {
+                    fillTablePartitionBulk(database, table, rangeStart, end);
+                    return null;
+                });
+            }
+            start = end;
+        }
+    }
+
+    /**
+     * Fills a whole table on its own pooled connection with foreign-key enforcement disabled for the
+     * duration. Enforcement is disabled before the fill and restored in a {@code finally} before the
+     * connection is returned to the pool, so a disabled session never leaks to other pool users even if
+     * the fill throws.
+     */
+    private void fillTableBulk(Database database, Table table) throws SQLException {
+        DatabaseSupport support = configuration.databaseSupport();
+        try (Connection conn = dataSource.getConnection()) {
+            BulkLoadHandle handle = support.disableConstraints(conn, database);
+            try {
+                new TableFiller.Builder(conn, database, configuration)
+                        .table(table)
+                        .commitStrategy(effectiveParallelCommitStrategy())
+                        .build().fill();
+            } finally {
+                support.enableConstraints(conn, database, handle);
+            }
+        }
+    }
+
+    /**
+     * Fills one contiguous row range of a table on its own pooled connection with foreign-key
+     * enforcement disabled for the duration, restoring it in a {@code finally} before the connection is
+     * returned to the pool. The bulk-path twin of {@link #fillTablePartition}.
+     */
+    private void fillTablePartitionBulk(Database database, Table table, long startInclusive, long endExclusive) throws SQLException {
+        DatabaseSupport support = configuration.databaseSupport();
+        try (Connection conn = dataSource.getConnection()) {
+            BulkLoadHandle handle = support.disableConstraints(conn, database);
+            try {
+                new TableFiller.Builder(conn, database, configuration)
+                        .table(table)
+                        .commitStrategy(effectiveParallelCommitStrategy())
+                        .rowRange(startInclusive, endExclusive)
+                        .build().fill();
+            } finally {
+                support.enableConstraints(conn, database, handle);
+            }
+        }
+    }
+
     /** The configured intra-table partition count for a table, or {@code 1} when not configured. */
     private int partitionsFor(Table table) {
         TableConfiguration tableConfiguration = configuration.tableConfiguration(table.name());
@@ -360,6 +505,19 @@ public class DatabaseFiller implements Fillable {
                                 + "use the DataSource constructor with threads(n) > 1 for intra-table parallelism",
                         tableConfiguration.partitions(), tableConfiguration.tableName());
             }
+        }
+    }
+
+    /**
+     * Logs a warning when an {@link BulkLoadStrategy#unorderedBulk()} fill was requested but the fill
+     * will not run on the parallel path (single connection, or a {@link DataSource} with one thread).
+     * Bulk loading needs per-worker session control, so it only applies to the {@code threads > 1}
+     * {@link DataSource} path; elsewhere the engine fills in dependency order.
+     */
+    private void warnIfBulkIgnored() {
+        if (configuration.bulkLoadStrategy().isUnordered()) {
+            logger.warn("UNORDERED_BULK is ignored on the sequential fill path; use the DataSource "
+                    + "constructor with threads(n) > 1 for unordered bulk loading");
         }
     }
 

--- a/bloviate-core/src/main/java/io/bloviate/ext/BulkLoadHandle.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/BulkLoadHandle.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+/**
+ * An opaque token returned by {@link DatabaseSupport#disableConstraints} describing what was disabled,
+ * so {@link DatabaseSupport#enableConstraints} can restore it.
+ *
+ * <p>The session-based PostgreSQL ({@code session_replication_role}) and MySQL
+ * ({@code FOREIGN_KEY_CHECKS}) mechanisms restore state with a fixed {@code SET} statement and carry no
+ * per-table state, so the handle is purely informational (a short {@code description} used for logging).
+ * It exists so a future catalog-level mechanism (e.g. dropping and recreating constraints) can carry the
+ * list of objects it must restore without changing the SPI signatures.
+ *
+ * @param description a short human-readable description of what was disabled, for logging
+ * @since 2.17.0
+ * @see DatabaseSupport#disableConstraints
+ * @see DatabaseSupport#enableConstraints
+ */
+public record BulkLoadHandle(String description) {
+
+    /**
+     * Creates a handle with the given description.
+     *
+     * @param description a short human-readable description of what was disabled
+     * @return the handle
+     */
+    public static BulkLoadHandle of(String description) {
+        return new BulkLoadHandle(description);
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/ext/BulkLoadUnsupportedException.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/BulkLoadUnsupportedException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.ext;
+
+import java.sql.SQLException;
+
+/**
+ * Signals that a {@link DatabaseSupport} could not disable constraint enforcement for an
+ * {@code UNORDERED_BULK} fill — for example, the connecting role lacks the privilege to set
+ * PostgreSQL's {@code session_replication_role}.
+ *
+ * <p>{@link io.bloviate.db.DatabaseFiller} probes for this once before fanning out and, when it is
+ * thrown, gracefully falls back to the ordered level-parallel fill path rather than running with
+ * constraints half-disabled. It extends {@link SQLException} so it propagates naturally through the
+ * fill API while remaining catchable as a distinct type.
+ *
+ * @since 2.17.0
+ * @see DatabaseSupport#disableConstraints
+ */
+public class BulkLoadUnsupportedException extends SQLException {
+
+    /**
+     * Creates the exception with a message and underlying cause.
+     *
+     * @param message the detail message
+     * @param cause   the underlying SQL failure (e.g. an insufficient-privilege error)
+     */
+    public BulkLoadUnsupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java
@@ -59,4 +59,20 @@ public class CockroachDBSupport extends PostgresSupport {
     public java.util.Map<String, io.bloviate.db.ColumnConstraint> readConstraints(java.sql.Connection connection, String schema, String table) {
         return java.util.Map.of();
     }
+
+    /**
+     * CockroachDB does not support the unordered bulk-load path. It has no
+     * {@code session_replication_role} switch, and its foreign keys and secondary indexes are
+     * maintained transactionally across a distributed cluster, so there is no cheap session-level way
+     * to disable enforcement. An {@code UNORDERED_BULK} request therefore falls back to the ordered
+     * level-parallel fill path. Overrides {@link PostgresSupport#supportsBulkLoad()} back to
+     * {@code false}.
+     *
+     * @return {@code false}
+     * @since 2.17.0
+     */
+    @Override
+    public boolean supportsBulkLoad() {
+        return false;
+    }
 }

--- a/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java
@@ -18,6 +18,7 @@ package io.bloviate.ext;
 
 import io.bloviate.db.Column;
 import io.bloviate.db.ColumnConstraint;
+import io.bloviate.db.Database;
 import io.bloviate.gen.DataGenerator;
 
 import java.sql.Connection;
@@ -95,6 +96,64 @@ public interface DatabaseSupport {
      */
     default Map<String, ColumnConstraint> readConstraints(Connection connection, String schema, String table) {
         return Map.of();
+    }
+
+    /**
+     * Whether this support can disable and re-enable foreign-key enforcement for an
+     * {@code UNORDERED_BULK} fill (see {@link io.bloviate.db.BulkLoadStrategy}). The default is
+     * {@code false}; callers must check this before invoking {@link #disableConstraints} and fall back
+     * to the ordered fill path when it returns {@code false}.
+     *
+     * <p>PostgreSQL and MySQL override this to {@code true}; CockroachDB leaves it {@code false}
+     * (no {@code session_replication_role}, distributed foreign-key/index handling).
+     *
+     * @return whether unordered bulk loading with disabled constraints is supported
+     * @since 2.17.0
+     */
+    default boolean supportsBulkLoad() {
+        return false;
+    }
+
+    /**
+     * Disables foreign-key (and, where applicable, unique) enforcement for the duration of a bulk load,
+     * on the <strong>given connection's session</strong>. Returns a {@link BulkLoadHandle} describing
+     * what was disabled so {@link #enableConstraints} can restore it.
+     *
+     * <p>The session-based mechanisms used by PostgreSQL and MySQL are <em>per connection</em>: this
+     * must be called on every connection that will insert. {@link io.bloviate.db.DatabaseFiller}
+     * applies it inside each worker task and restores it in a {@code finally} before returning the
+     * connection to the pool, so no constraint-disabled connection ever leaks back to the pool.
+     *
+     * <p>The default throws {@link UnsupportedOperationException}; only override it alongside
+     * {@link #supportsBulkLoad()} returning {@code true}.
+     *
+     * @param connection an open connection whose session enforcement should be disabled
+     * @param database   the database metadata (for mechanisms that need per-table information)
+     * @return a handle describing what was disabled, for use by {@link #enableConstraints}
+     * @throws BulkLoadUnsupportedException if enforcement cannot be disabled (e.g. missing privilege)
+     * @throws SQLException                 if the underlying statement fails
+     * @since 2.17.0
+     */
+    default BulkLoadHandle disableConstraints(Connection connection, Database database) throws SQLException {
+        throw new UnsupportedOperationException("bulk load not supported");
+    }
+
+    /**
+     * Re-enables what {@link #disableConstraints} turned off, on the same connection. Must be safe to
+     * call from a {@code finally} block.
+     *
+     * <p>The session-based PostgreSQL/MySQL mechanisms simply restore the session setting; they cannot
+     * cheaply re-validate already-inserted rows, which is acceptable because bulk-loaded data is
+     * referentially consistent by construction.
+     *
+     * @param connection the same connection passed to {@link #disableConstraints}
+     * @param database   the database metadata
+     * @param handle     the handle returned by {@link #disableConstraints}
+     * @throws SQLException if the underlying statement fails
+     * @since 2.17.0
+     */
+    default void enableConstraints(Connection connection, Database database, BulkLoadHandle handle) throws SQLException {
+        throw new UnsupportedOperationException("bulk load not supported");
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java
@@ -16,10 +16,14 @@
 
 package io.bloviate.ext;
 
+import io.bloviate.db.Database;
 import io.bloviate.gen.JsonbGenerator;
 import io.bloviate.gen.SimpleStringGenerator;
 
+import java.sql.Connection;
 import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Map;
 
 /**
@@ -58,6 +62,54 @@ public class MySQLSupport extends AbstractDatabaseSupport {
     @Override
     public String batchRewriteUrlParameter() {
         return "rewriteBatchedStatements";
+    }
+
+    /**
+     * MySQL supports unordered bulk loading by disabling the session's foreign-key and unique checks.
+     *
+     * @return {@code true}
+     * @since 2.17.0
+     */
+    @Override
+    public boolean supportsBulkLoad() {
+        return true;
+    }
+
+    /**
+     * Disables {@code FOREIGN_KEY_CHECKS} and {@code UNIQUE_CHECKS} for the session. These are ordinary
+     * session variables that need no special privilege. MySQL does not re-validate existing rows when
+     * the checks are turned back on, which is acceptable because bulk-loaded data is referentially
+     * consistent by construction.
+     *
+     * @param connection an open connection whose session variables are changed
+     * @param database   the database metadata (unused by this mechanism)
+     * @return a handle recording the disabled checks
+     * @throws SQLException if a statement fails
+     */
+    @Override
+    public BulkLoadHandle disableConstraints(Connection connection, Database database) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET FOREIGN_KEY_CHECKS=0");
+            statement.execute("SET UNIQUE_CHECKS=0");
+        }
+        return BulkLoadHandle.of("FOREIGN_KEY_CHECKS=0, UNIQUE_CHECKS=0");
+    }
+
+    /**
+     * Restores {@code UNIQUE_CHECKS} and {@code FOREIGN_KEY_CHECKS} to {@code 1} for the session before
+     * the connection is returned to the pool.
+     *
+     * @param connection the same connection passed to {@link #disableConstraints}
+     * @param database   the database metadata (unused by this mechanism)
+     * @param handle     the handle returned by {@link #disableConstraints}
+     * @throws SQLException if a statement fails
+     */
+    @Override
+    public void enableConstraints(Connection connection, Database database, BulkLoadHandle handle) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET UNIQUE_CHECKS=1");
+            statement.execute("SET FOREIGN_KEY_CHECKS=1");
+        }
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java
@@ -17,6 +17,7 @@
 package io.bloviate.ext;
 
 import io.bloviate.db.Column;
+import io.bloviate.db.Database;
 import io.bloviate.gen.BitStringGenerator;
 import io.bloviate.gen.BooleanGenerator;
 import io.bloviate.gen.CidrGenerator;
@@ -29,7 +30,10 @@ import io.bloviate.gen.StringArrayGenerator;
 import io.bloviate.gen.UUIDGenerator;
 import io.bloviate.gen.XmlGenerator;
 
+import java.sql.Connection;
 import java.sql.JDBCType;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Map;
 
 /**
@@ -89,6 +93,59 @@ public class PostgresSupport extends AbstractDatabaseSupport {
     @Override
     public java.util.Map<String, io.bloviate.db.ColumnConstraint> readConstraints(java.sql.Connection connection, String schema, String table) {
         return PostgresConstraints.read(connection, schema, table);
+    }
+
+    /**
+     * PostgreSQL supports unordered bulk loading by suppressing foreign-key trigger firing for the
+     * session via {@code SET session_replication_role = replica}.
+     *
+     * @return {@code true}
+     * @since 2.17.0
+     */
+    @Override
+    public boolean supportsBulkLoad() {
+        return true;
+    }
+
+    /**
+     * Sets {@code session_replication_role = replica} on the connection, which stops user and
+     * foreign-key triggers (including referential-integrity checks) from firing for the session. This
+     * is the cheapest bulk-load mechanism — no catalog churn and nothing to rebuild — but it requires a
+     * superuser (or {@code rds_superuser}) role. A privilege failure is reported as a
+     * {@link BulkLoadUnsupportedException} so the engine can fall back to the ordered path.
+     *
+     * @param connection an open connection whose session role is changed
+     * @param database   the database metadata (unused by this mechanism)
+     * @return a handle recording that {@code session_replication_role} was changed
+     * @throws BulkLoadUnsupportedException if the role lacks privilege to change the setting
+     * @throws SQLException                 if the statement otherwise fails
+     */
+    @Override
+    public BulkLoadHandle disableConstraints(Connection connection, Database database) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET session_replication_role = replica");
+        } catch (SQLException e) {
+            throw new BulkLoadUnsupportedException(
+                    "could not set session_replication_role=replica (a superuser/rds_superuser role is required): "
+                            + e.getMessage(), e);
+        }
+        return BulkLoadHandle.of("session_replication_role=replica");
+    }
+
+    /**
+     * Restores {@code session_replication_role = origin}, re-enabling trigger and foreign-key firing
+     * for the session before the connection is returned to the pool.
+     *
+     * @param connection the same connection passed to {@link #disableConstraints}
+     * @param database   the database metadata (unused by this mechanism)
+     * @param handle     the handle returned by {@link #disableConstraints}
+     * @throws SQLException if the statement fails
+     */
+    @Override
+    public void enableConstraints(Connection connection, Database database, BulkLoadHandle handle) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET session_replication_role = origin");
+        }
     }
 
     @Override

--- a/bloviate-core/src/test/java/io/bloviate/db/BulkLoadStrategyTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/BulkLoadStrategyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.ext.CockroachDBSupport;
+import io.bloviate.ext.DefaultSupport;
+import io.bloviate.ext.MySQLSupport;
+import io.bloviate.ext.PostgresSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BulkLoadStrategyTest {
+
+    @Test
+    void factoriesProduceExpectedModes() {
+        assertEquals(BulkLoadStrategy.Mode.ORDERED, BulkLoadStrategy.ordered().mode());
+        assertEquals(BulkLoadStrategy.Mode.UNORDERED_BULK, BulkLoadStrategy.unorderedBulk().mode());
+    }
+
+    @Test
+    void onlyUnorderedBulkIsUnordered() {
+        assertFalse(BulkLoadStrategy.ordered().isUnordered());
+        assertTrue(BulkLoadStrategy.unorderedBulk().isUnordered());
+    }
+
+    @Test
+    void nullModeIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new BulkLoadStrategy(null, false));
+    }
+
+    @Test
+    void databaseConfigurationDefaultsToOrderedWhenUnset() {
+        DatabaseConfiguration configuration =
+                new DatabaseConfiguration(100, 10, new DefaultSupport(), Set.of());
+        assertEquals(BulkLoadStrategy.ordered(), configuration.bulkLoadStrategy());
+    }
+
+    @Test
+    void databaseConfigurationNormalizesNullStrategy() {
+        DatabaseConfiguration configuration =
+                new DatabaseConfiguration(100, 10, new DefaultSupport(), Set.of(), 42L, null, null);
+        assertEquals(BulkLoadStrategy.ordered(), configuration.bulkLoadStrategy());
+    }
+
+    @Test
+    void databaseConfigurationRetainsExplicitStrategy() {
+        DatabaseConfiguration configuration =
+                new DatabaseConfiguration(100, 10, new DefaultSupport(), Set.of(), 42L, null, BulkLoadStrategy.unorderedBulk());
+        assertTrue(configuration.bulkLoadStrategy().isUnordered());
+    }
+
+    @Test
+    void onlyPostgresAndMySqlSupportBulkLoad() {
+        assertTrue(new PostgresSupport().supportsBulkLoad());
+        assertTrue(new MySQLSupport().supportsBulkLoad());
+        // CockroachDB extends PostgresSupport but cannot bulk load; it must override back to false
+        assertFalse(new CockroachDBSupport().supportsBulkLoad());
+        assertFalse(new DefaultSupport().supportsBulkLoad());
+    }
+
+    @Test
+    void defaultSupportRejectsConstraintDisabling() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> new DefaultSupport().disableConstraints(null, null));
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/MySqlBulkLoadFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/MySqlBulkLoadFillTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.MySQLSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
+import io.bloviate.util.DatabaseUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the {@link BulkLoadStrategy#unorderedBulk()} path on MySQL: it disables enforcement
+ * ({@code FOREIGN_KEY_CHECKS=0}, {@code UNIQUE_CHECKS=0}) per worker session, fills every table at
+ * once with no topological barrier, and restores the checks.
+ *
+ * <p>As on PostgreSQL, the load-bearing guarantee is that the unordered bulk fill produces
+ * <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of the same
+ * seed; this test asserts that table by table over a deep TPC-C chain. It also confirms no foreign-key
+ * is left orphaned (an explicit anti-join) and that no pooled connection is left with
+ * {@code FOREIGN_KEY_CHECKS} disabled.
+ */
+class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
+
+    private static final int W = 2;
+    private static final int I = 100;
+    private static final int D = 5;
+    private static final int C = 10;
+    private static final int MIN_LINES = 5;
+    private static final int MAX_LINES = 15;
+    private static final int NEW_ORDERS = 5;
+    private static final int THREADS = 4;
+
+    @Test
+    void bulkFillMatchesOrderedFillExactly() throws SQLException {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+
+        DatabaseConfiguration ordered = new DatabaseConfiguration(
+                256, 0, new MySQLSupport(), tables, 42L, null, BulkLoadStrategy.ordered());
+        DatabaseConfiguration bulk = new DatabaseConfiguration(
+                256, 0, new MySQLSupport(), tables, 42L, null, BulkLoadStrategy.unorderedBulk());
+
+        try (MySQLContainer<?> database = new MySQLContainer<>("mysql:9.7")
+                .withConfigurationOverride("mysql-conf")
+                .withDatabaseName("bloviate")
+                .withUrlParam("rewriteBatchedStatements", "true")
+                .withInitScript("create_tpcc.mysql.sql")) {
+
+            database.start();
+
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
+
+                List<String> tableNames;
+                Map<String, List<String>> orderedDump;
+
+                // traditional dependency-ordered parallel fill — the reference result
+                new DatabaseFiller.Builder(dataSource, ordered).threads(THREADS).build().fill();
+
+                try (Connection connection = dataSource.getConnection()) {
+                    tableNames = tableNames(connection);
+                    assertRowCount(connection, "customer", (long) W * D * C);
+                    orderedDump = dump(connection, tableNames);
+                    truncateAll(connection, tableNames);
+                }
+
+                // unordered bulk fill — checks disabled, no barrier
+                new DatabaseFiller.Builder(dataSource, bulk).threads(THREADS).build().fill();
+
+                try (Connection connection = dataSource.getConnection()) {
+                    assertRowCount(connection, "customer", (long) W * D * C);
+
+                    Map<String, List<String>> bulkDump = dump(connection, tableNames);
+                    for (String table : tableNames) {
+                        assertEquals(orderedDump.get(table), bulkDump.get(table),
+                                "table [" + table + "] must be identical between the ordered and bulk fills");
+                    }
+
+                    // no order_line row references a missing order (would be impossible if data is valid)
+                    assertCount(connection, "select count(*) from order_line l left join open_order o "
+                            + "on l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id "
+                            + "where o.o_id is null", 0);
+
+                    // the bulk path restored each worker's session
+                    assertForeignKeyChecksRestored(dataSource);
+                }
+            }
+        }
+    }
+
+    /** Borrows a handful of connections and asserts each reports {@code @@SESSION.foreign_key_checks = 1}. */
+    private static void assertForeignKeyChecksRestored(HikariDataSource dataSource) throws SQLException {
+        for (int i = 0; i < THREADS + 1; i++) {
+            try (Connection connection = dataSource.getConnection();
+                 Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery("select @@SESSION.foreign_key_checks")) {
+                resultSet.next();
+                assertEquals(1, resultSet.getLong(1),
+                        "a pooled connection must not be left with foreign-key checks disabled");
+            }
+        }
+    }
+
+    private static List<String> tableNames(Connection connection) throws SQLException {
+        List<String> names = new ArrayList<>();
+        for (Table table : DatabaseUtils.getMetadata(connection).tables()) {
+            names.add(table.name());
+        }
+        return names;
+    }
+
+    /**
+     * Dumps each table ordered by every (non-temporal) column, producing a canonical row list
+     * independent of the physical insert order the barrier-free bulk path may use.
+     */
+    private static Map<String, List<String>> dump(Connection connection, List<String> tables) throws SQLException {
+        Map<String, List<String>> dump = new LinkedHashMap<>();
+        try (Statement statement = connection.createStatement()) {
+            for (String table : tables) {
+                List<Integer> columns = deterministicColumns(statement, table);
+                if (columns.isEmpty()) {
+                    dump.put(table, List.of());
+                    continue;
+                }
+
+                StringJoiner order = new StringJoiner(",");
+                for (int column : columns) {
+                    order.add(String.valueOf(column));
+                }
+
+                List<String> rows = new ArrayList<>();
+                try (ResultSet resultSet = statement.executeQuery("select * from " + table + " order by " + order)) {
+                    while (resultSet.next()) {
+                        StringJoiner row = new StringJoiner("|");
+                        for (int column : columns) {
+                            row.add(String.valueOf(resultSet.getString(column)));
+                        }
+                        rows.add(row.toString());
+                    }
+                }
+                dump.put(table, rows);
+            }
+        }
+        return dump;
+    }
+
+    /** The 1-based indexes of a table's columns, excluding temporal types (which may use wall-clock time). */
+    private static List<Integer> deterministicColumns(Statement statement, String table) throws SQLException {
+        List<Integer> columns = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("select * from " + table + " where false")) {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                if (!isTemporal(metaData.getColumnType(i))) {
+                    columns.add(i);
+                }
+            }
+        }
+        return columns;
+    }
+
+    private static boolean isTemporal(int sqlType) {
+        return sqlType == Types.DATE
+                || sqlType == Types.TIME
+                || sqlType == Types.TIME_WITH_TIMEZONE
+                || sqlType == Types.TIMESTAMP
+                || sqlType == Types.TIMESTAMP_WITH_TIMEZONE;
+    }
+
+    private static void truncateAll(Connection connection, List<String> tables) throws SQLException {
+        if (tables.isEmpty()) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("SET FOREIGN_KEY_CHECKS=0");
+            for (String table : tables) {
+                statement.execute("TRUNCATE TABLE " + table);
+            }
+            statement.execute("SET FOREIGN_KEY_CHECKS=1");
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/MySqlBulkLoadFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/MySqlBulkLoadFillTest.java
@@ -17,6 +17,8 @@
 package io.bloviate.db;
 
 import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.BulkLoadHandle;
+import io.bloviate.ext.BulkLoadUnsupportedException;
 import io.bloviate.ext.MySQLSupport;
 import io.bloviate.gen.tpcc.TPCCConfiguration;
 import io.bloviate.util.DatabaseUtils;
@@ -30,6 +32,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,11 +46,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * ({@code FOREIGN_KEY_CHECKS=0}, {@code UNIQUE_CHECKS=0}) per worker session, fills every table at
  * once with no topological barrier, and restores the checks.
  *
- * <p>As on PostgreSQL, the load-bearing guarantee is that the unordered bulk fill produces
- * <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of the same
- * seed; this test asserts that table by table over a deep TPC-C chain. It also confirms no foreign-key
- * is left orphaned (an explicit anti-join) and that no pooled connection is left with
- * {@code FOREIGN_KEY_CHECKS} disabled.
+ * <p>The load-bearing guarantee — and the reason bulk loading is safe — is that an unordered bulk fill
+ * produces <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of
+ * the same seed. This is asserted both unpartitioned and partitioned. The remaining cases cover the
+ * fallback behaviors (unsupported support, privilege failure, and the single-connection path), each of
+ * which must still produce a correct, fully-populated database.
+ *
+ * <p>All cases share one container for speed, truncating between fills.
  */
 class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
 
@@ -59,15 +64,15 @@ class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
     private static final int MAX_LINES = 15;
     private static final int NEW_ORDERS = 5;
     private static final int THREADS = 4;
+    private static final int PARTITIONS = 3;
+    private static final Set<String> PARTITIONED = Set.of("customer", "order_line");
+
+    private static final long CUSTOMERS = (long) W * D * C;
 
     @Test
-    void bulkFillMatchesOrderedFillExactly() throws SQLException {
+    void bulkPathsMatchOrderedAndFallBackCorrectly() throws SQLException {
         Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
-
-        DatabaseConfiguration ordered = new DatabaseConfiguration(
-                256, 0, new MySQLSupport(), tables, 42L, null, BulkLoadStrategy.ordered());
-        DatabaseConfiguration bulk = new DatabaseConfiguration(
-                256, 0, new MySQLSupport(), tables, 42L, null, BulkLoadStrategy.unorderedBulk());
+        Set<TableConfiguration> partitioned = withPartitions(tables, PARTITIONS, PARTITIONED);
 
         try (MySQLContainer<?> database = new MySQLContainer<>("mysql:9.7")
                 .withConfigurationOverride("mysql-conf")
@@ -80,39 +85,96 @@ class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
             try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
 
                 List<String> tableNames;
-                Map<String, List<String>> orderedDump;
-
-                // traditional dependency-ordered parallel fill — the reference result
-                new DatabaseFiller.Builder(dataSource, ordered).threads(THREADS).build().fill();
-
                 try (Connection connection = dataSource.getConnection()) {
                     tableNames = tableNames(connection);
-                    assertRowCount(connection, "customer", (long) W * D * C);
-                    orderedDump = dump(connection, tableNames);
-                    truncateAll(connection, tableNames);
                 }
 
-                // unordered bulk fill — checks disabled, no barrier
-                new DatabaseFiller.Builder(dataSource, bulk).threads(THREADS).build().fill();
+                // 1) headline: unpartitioned ordered vs bulk must be byte-identical
+                Map<String, List<String>> orderedDump = fillAndDump(dataSource, config(tables, BulkLoadStrategy.ordered()), tableNames);
+                Map<String, List<String>> bulkDump = fillAndDump(dataSource, config(tables, BulkLoadStrategy.unorderedBulk()), tableNames);
+                assertIdentical(orderedDump, bulkDump, tableNames, "unpartitioned ordered vs bulk");
+                assertForeignKeyChecksRestored(dataSource);
 
+                // 2) partitioned ordered vs partitioned bulk (same partition count) must be byte-identical
+                Map<String, List<String>> pOrdered = fillAndDump(dataSource, config(partitioned, BulkLoadStrategy.ordered()), tableNames);
+                Map<String, List<String>> pBulk = fillAndDump(dataSource, config(partitioned, BulkLoadStrategy.unorderedBulk()), tableNames);
+                assertIdentical(pOrdered, pBulk, tableNames, "partitioned ordered vs bulk");
+
+                // 3) bulk requested but the support reports no bulk capability -> ordered fallback, still correct
+                DatabaseConfiguration unsupported = new DatabaseConfiguration(
+                        256, 0, new NoBulkSupport(), tables, 42L, null, BulkLoadStrategy.unorderedBulk());
+                fill(dataSource, unsupported);
+                assertCustomerCount(dataSource);
+
+                // 4) bulk supported but disabling constraints fails -> probe catches, ordered fallback, still correct
+                DatabaseConfiguration privilegeDenied = new DatabaseConfiguration(
+                        256, 0, new DenyDisableSupport(), tables, 42L, null, BulkLoadStrategy.unorderedBulk());
+                fill(dataSource, privilegeDenied);
+                assertCustomerCount(dataSource);
+
+                // 5) single-connection path ignores bulk with a warning and fills in dependency order
+                truncate(dataSource, tableNames);
                 try (Connection connection = dataSource.getConnection()) {
-                    assertRowCount(connection, "customer", (long) W * D * C);
-
-                    Map<String, List<String>> bulkDump = dump(connection, tableNames);
-                    for (String table : tableNames) {
-                        assertEquals(orderedDump.get(table), bulkDump.get(table),
-                                "table [" + table + "] must be identical between the ordered and bulk fills");
-                    }
-
-                    // no order_line row references a missing order (would be impossible if data is valid)
-                    assertCount(connection, "select count(*) from order_line l left join open_order o "
-                            + "on l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id "
-                            + "where o.o_id is null", 0);
-
-                    // the bulk path restored each worker's session
-                    assertForeignKeyChecksRestored(dataSource);
+                    new DatabaseFiller.Builder(connection, config(tables, BulkLoadStrategy.unorderedBulk())).build().fill();
                 }
+                assertCustomerCount(dataSource);
             }
+        }
+    }
+
+    private static DatabaseConfiguration config(Set<TableConfiguration> tables, BulkLoadStrategy bulk) {
+        return new DatabaseConfiguration(256, 0, new MySQLSupport(), tables, 42L, null, bulk);
+    }
+
+    /** A MySQL support that declares no bulk-load capability, exercising the unsupported fallback. */
+    private static final class NoBulkSupport extends MySQLSupport {
+        @Override
+        public boolean supportsBulkLoad() {
+            return false;
+        }
+    }
+
+    /** A MySQL support whose constraint disabling always fails, exercising the privilege-failure fallback. */
+    private static final class DenyDisableSupport extends MySQLSupport {
+        @Override
+        public BulkLoadHandle disableConstraints(Connection connection, Database database) throws SQLException {
+            throw new BulkLoadUnsupportedException("simulated privilege failure", new SQLException("denied"));
+        }
+    }
+
+    /** Runs a parallel fill, then dumps every table; truncates first so each fill starts clean. */
+    private static Map<String, List<String>> fillAndDump(HikariDataSource dataSource, DatabaseConfiguration configuration, List<String> tableNames) throws SQLException {
+        truncate(dataSource, tableNames);
+        new DatabaseFiller.Builder(dataSource, configuration).threads(THREADS).build().fill();
+        try (Connection connection = dataSource.getConnection()) {
+            return dump(connection, tableNames);
+        }
+    }
+
+    private static void fill(HikariDataSource dataSource, DatabaseConfiguration configuration) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            tableNamesTruncate(connection);
+        }
+        new DatabaseFiller.Builder(dataSource, configuration).threads(THREADS).build().fill();
+    }
+
+    private static void tableNamesTruncate(Connection connection) throws SQLException {
+        truncate(connection, tableNames(connection));
+    }
+
+    private static void assertIdentical(Map<String, List<String>> a, Map<String, List<String>> b, List<String> tableNames, String label) {
+        for (String table : tableNames) {
+            assertEquals(a.get(table), b.get(table), "table [" + table + "] must be identical (" + label + ")");
+        }
+    }
+
+    private static void assertCustomerCount(HikariDataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            assertRowCount(connection, "customer", CUSTOMERS);
+            // no order_line row references a missing order — proves referential validity after the fill
+            assertCount(connection, "select count(*) from order_line l left join open_order o "
+                    + "on l.ol_w_id = o.o_w_id and l.ol_d_id = o.o_d_id and l.ol_o_id = o.o_id "
+                    + "where o.o_id is null", 0);
         }
     }
 
@@ -127,6 +189,19 @@ class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
                         "a pooled connection must not be left with foreign-key checks disabled");
             }
         }
+    }
+
+    /** Returns a copy of the table set with {@code partitions} applied to the named tables. */
+    private static Set<TableConfiguration> withPartitions(Set<TableConfiguration> tables, int partitions, Set<String> names) {
+        Set<TableConfiguration> result = new HashSet<>();
+        for (TableConfiguration table : tables) {
+            if (names.contains(table.tableName().toLowerCase())) {
+                result.add(new TableConfiguration(table.tableName(), table.rowCount(), table.columnConfigurations(), partitions));
+            } else {
+                result.add(table);
+            }
+        }
+        return result;
     }
 
     private static List<String> tableNames(Connection connection) throws SQLException {
@@ -194,7 +269,13 @@ class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
                 || sqlType == Types.TIMESTAMP_WITH_TIMEZONE;
     }
 
-    private static void truncateAll(Connection connection, List<String> tables) throws SQLException {
+    private static void truncate(HikariDataSource dataSource, List<String> tables) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            truncate(connection, tables);
+        }
+    }
+
+    private static void truncate(Connection connection, List<String> tables) throws SQLException {
         if (tables.isEmpty()) {
             return;
         }

--- a/bloviate-core/src/test/java/io/bloviate/db/MySqlBulkLoadFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/MySqlBulkLoadFillTest.java
@@ -47,8 +47,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * once with no topological barrier, and restores the checks.
  *
  * <p>The load-bearing guarantee — and the reason bulk loading is safe — is that an unordered bulk fill
- * produces <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of
- * the same seed. This is asserted both unpartitioned and partitioned. The remaining cases cover the
+ * produces <strong>identical row content</strong> to a traditional dependency-ordered fill of the same
+ * seed. This is asserted both unpartitioned and partitioned over a canonical row dump (rows sorted by
+ * every column, temporal columns excluded), i.e. row-content equality independent of physical insert
+ * order rather than on-disk byte equality. The remaining cases cover the
  * fallback behaviors (unsupported support, privilege failure, and the single-connection path), each of
  * which must still produce a correct, fully-populated database.
  *
@@ -89,13 +91,13 @@ class MySqlBulkLoadFillTest extends BaseDatabaseTestCase {
                     tableNames = tableNames(connection);
                 }
 
-                // 1) headline: unpartitioned ordered vs bulk must be byte-identical
+                // 1) headline: unpartitioned ordered vs bulk must have identical row content
                 Map<String, List<String>> orderedDump = fillAndDump(dataSource, config(tables, BulkLoadStrategy.ordered()), tableNames);
                 Map<String, List<String>> bulkDump = fillAndDump(dataSource, config(tables, BulkLoadStrategy.unorderedBulk()), tableNames);
                 assertIdentical(orderedDump, bulkDump, tableNames, "unpartitioned ordered vs bulk");
                 assertForeignKeyChecksRestored(dataSource);
 
-                // 2) partitioned ordered vs partitioned bulk (same partition count) must be byte-identical
+                // 2) partitioned ordered vs partitioned bulk (same partition count) must have identical row content
                 Map<String, List<String>> pOrdered = fillAndDump(dataSource, config(partitioned, BulkLoadStrategy.ordered()), tableNames);
                 Map<String, List<String>> pBulk = fillAndDump(dataSource, config(partitioned, BulkLoadStrategy.unorderedBulk()), tableNames);
                 assertIdentical(pOrdered, pBulk, tableNames, "partitioned ordered vs bulk");

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadFillTest.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,13 +44,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * enforcement ({@code session_replication_role = replica}), fills every table at once with no
  * topological barrier, and re-enables enforcement.
  *
- * <p>The central guarantee — and the reason bulk loading is safe here — is that it must produce
+ * <p>The central guarantee — and the reason bulk loading is safe here — is that it produces
  * <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of the same
- * seed. This test asserts exactly that by running an ordered parallel fill and an unordered bulk fill
- * with the same configuration and comparing every table. A deep TPC-C chain
- * ({@code warehouse → district → customer → open_order → order_line}) is used because it is precisely
- * the shape the barrier-free path is meant to accelerate, and its foreign keys make an orphaned row
- * impossible to miss.
+ * seed, asserted both unpartitioned and partitioned. It also confirms foreign keys remain valid and
+ * that no pooled connection is left with enforcement suppressed. A deep TPC-C chain
+ * ({@code warehouse → district → customer → open_order → order_line}) is used because it is exactly
+ * the shape the barrier-free path is meant to accelerate.
  */
 class PostgresBulkLoadFillTest extends BaseDatabaseTestCase {
 
@@ -61,15 +61,13 @@ class PostgresBulkLoadFillTest extends BaseDatabaseTestCase {
     private static final int MAX_LINES = 15;
     private static final int NEW_ORDERS = 5;
     private static final int THREADS = 4;
+    private static final int PARTITIONS = 3;
+    private static final Set<String> PARTITIONED = Set.of("customer", "order_line");
 
     @Test
     void bulkFillMatchesOrderedFillExactly() throws SQLException {
         Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
-
-        DatabaseConfiguration ordered = new DatabaseConfiguration(
-                256, 0, new PostgresSupport(), tables, 42L, null, BulkLoadStrategy.ordered());
-        DatabaseConfiguration bulk = new DatabaseConfiguration(
-                256, 0, new PostgresSupport(), tables, 42L, null, BulkLoadStrategy.unorderedBulk());
+        Set<TableConfiguration> partitioned = withPartitions(tables, PARTITIONS, PARTITIONED);
 
         try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
                 .withDatabaseName("bloviate")
@@ -82,48 +80,58 @@ class PostgresBulkLoadFillTest extends BaseDatabaseTestCase {
             try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
 
                 List<String> tableNames;
-                Map<String, List<String>> orderedDump;
-
-                // traditional, dependency-ordered parallel fill — the reference result (every FK is
-                // enforced at insert time, so completing proves the data is referentially valid)
-                new DatabaseFiller.Builder(dataSource, ordered).threads(THREADS).build().fill();
-
                 try (Connection connection = dataSource.getConnection()) {
                     tableNames = tableNames(connection);
-                    assertRowCount(connection, "customer", (long) W * D * C);
-                    assertRowCount(connection, "open_order", (long) W * D * C);
-                    orderedDump = dump(connection, tableNames);
-                    truncateAll(connection, tableNames);
                 }
 
-                // unordered bulk fill — constraints disabled, no barrier
-                new DatabaseFiller.Builder(dataSource, bulk).threads(THREADS).build().fill();
+                // headline: unpartitioned ordered (FK-enforced) vs bulk (FK-disabled) must be identical
+                Map<String, List<String>> orderedDump = fillAndDump(dataSource, config(tables, BulkLoadStrategy.ordered()), tableNames);
+                assertRowCount(dataSource, "customer", (long) W * D * C);
+                Map<String, List<String>> bulkDump = fillAndDump(dataSource, config(tables, BulkLoadStrategy.unorderedBulk()), tableNames);
+                assertIdentical(orderedDump, bulkDump, tableNames, "unpartitioned ordered vs bulk");
 
-                try (Connection connection = dataSource.getConnection()) {
-                    // identical row counts and identical data, table by table
-                    assertRowCount(connection, "customer", (long) W * D * C);
-                    assertRowCount(connection, "open_order", (long) W * D * C);
+                // every foreign-key constraint is still present and validated after the bulk fill, and
+                // no pooled connection is left with enforcement suppressed
+                assertNoInvalidForeignKeys(dataSource);
+                assertSessionReplicationRoleRestored(dataSource);
 
-                    Map<String, List<String>> bulkDump = dump(connection, tableNames);
-                    for (String table : tableNames) {
-                        assertEquals(orderedDump.get(table), bulkDump.get(table),
-                                "table [" + table + "] must be identical between the ordered and bulk fills");
-                    }
-
-                    // every foreign-key constraint is still present and validated after the bulk fill
-                    assertNoInvalidForeignKeys(connection);
-
-                    // the bulk path restored each worker's session; nothing borrowed from the pool is
-                    // left with foreign-key enforcement suppressed
-                    assertSessionReplicationRoleRestored(dataSource);
-                }
+                // partitioned ordered vs partitioned bulk (same partition count) must also be identical
+                Map<String, List<String>> pOrdered = fillAndDump(dataSource, config(partitioned, BulkLoadStrategy.ordered()), tableNames);
+                Map<String, List<String>> pBulk = fillAndDump(dataSource, config(partitioned, BulkLoadStrategy.unorderedBulk()), tableNames);
+                assertIdentical(pOrdered, pBulk, tableNames, "partitioned ordered vs bulk");
+                assertNoInvalidForeignKeys(dataSource);
             }
         }
     }
 
+    private static DatabaseConfiguration config(Set<TableConfiguration> tables, BulkLoadStrategy bulk) {
+        return new DatabaseConfiguration(256, 0, new PostgresSupport(), tables, 42L, null, bulk);
+    }
+
+    private static Map<String, List<String>> fillAndDump(HikariDataSource dataSource, DatabaseConfiguration configuration, List<String> tableNames) throws SQLException {
+        truncate(dataSource, tableNames);
+        new DatabaseFiller.Builder(dataSource, configuration).threads(THREADS).build().fill();
+        try (Connection connection = dataSource.getConnection()) {
+            return dump(connection, tableNames);
+        }
+    }
+
+    private static void assertIdentical(Map<String, List<String>> a, Map<String, List<String>> b, List<String> tableNames, String label) {
+        for (String table : tableNames) {
+            assertEquals(a.get(table), b.get(table), "table [" + table + "] must be identical (" + label + ")");
+        }
+    }
+
+    private static void assertRowCount(HikariDataSource dataSource, String table, long expected) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            assertRowCount(connection, table, expected);
+        }
+    }
+
     /** Fails if any foreign-key constraint is left un-validated (NOT VALID) after the fill. */
-    private static void assertNoInvalidForeignKeys(Connection connection) throws SQLException {
-        try (Statement statement = connection.createStatement();
+    private static void assertNoInvalidForeignKeys(HikariDataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
              ResultSet resultSet = statement.executeQuery(
                      "select count(*) from pg_constraint where contype = 'f' and not convalidated")) {
             resultSet.next();
@@ -142,6 +150,19 @@ class PostgresBulkLoadFillTest extends BaseDatabaseTestCase {
                         "a pooled connection must not be left with constraints disabled");
             }
         }
+    }
+
+    /** Returns a copy of the table set with {@code partitions} applied to the named tables. */
+    private static Set<TableConfiguration> withPartitions(Set<TableConfiguration> tables, int partitions, Set<String> names) {
+        Set<TableConfiguration> result = new HashSet<>();
+        for (TableConfiguration table : tables) {
+            if (names.contains(table.tableName().toLowerCase())) {
+                result.add(new TableConfiguration(table.tableName(), table.rowCount(), table.columnConfigurations(), partitions));
+            } else {
+                result.add(table);
+            }
+        }
+        return result;
     }
 
     private static List<String> tableNames(Connection connection) throws SQLException {
@@ -210,11 +231,12 @@ class PostgresBulkLoadFillTest extends BaseDatabaseTestCase {
                 || sqlType == Types.TIMESTAMP_WITH_TIMEZONE;
     }
 
-    private static void truncateAll(Connection connection, List<String> tables) throws SQLException {
+    private static void truncate(HikariDataSource dataSource, List<String> tables) throws SQLException {
         if (tables.isEmpty()) {
             return;
         }
-        try (Statement statement = connection.createStatement()) {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
             statement.execute("TRUNCATE " + String.join(", ", tables) + " CASCADE");
         }
     }

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadFillTest.java
@@ -45,9 +45,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * topological barrier, and re-enables enforcement.
  *
  * <p>The central guarantee — and the reason bulk loading is safe here — is that it produces
- * <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of the same
- * seed, asserted both unpartitioned and partitioned. It also confirms foreign keys remain valid and
- * that no pooled connection is left with enforcement suppressed. A deep TPC-C chain
+ * <strong>identical row content</strong> to a traditional dependency-ordered fill of the same seed,
+ * asserted both unpartitioned and partitioned. The comparison is over a canonical row dump (rows
+ * sorted by every column, temporal columns excluded since they may use wall-clock time), so it asserts
+ * row-content equality independent of physical insert order — not on-disk byte equality. It also
+ * confirms foreign keys remain valid and that no pooled connection is left with enforcement
+ * suppressed. A deep TPC-C chain
  * ({@code warehouse → district → customer → open_order → order_line}) is used because it is exactly
  * the shape the barrier-free path is meant to accelerate.
  */

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadFillTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.gen.tpcc.TPCCConfiguration;
+import io.bloviate.util.DatabaseUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the {@link BulkLoadStrategy#unorderedBulk()} path on PostgreSQL: it disables foreign-key
+ * enforcement ({@code session_replication_role = replica}), fills every table at once with no
+ * topological barrier, and re-enables enforcement.
+ *
+ * <p>The central guarantee — and the reason bulk loading is safe here — is that it must produce
+ * <strong>byte-for-byte identical</strong> data to a traditional dependency-ordered fill of the same
+ * seed. This test asserts exactly that by running an ordered parallel fill and an unordered bulk fill
+ * with the same configuration and comparing every table. A deep TPC-C chain
+ * ({@code warehouse → district → customer → open_order → order_line}) is used because it is precisely
+ * the shape the barrier-free path is meant to accelerate, and its foreign keys make an orphaned row
+ * impossible to miss.
+ */
+class PostgresBulkLoadFillTest extends BaseDatabaseTestCase {
+
+    private static final int W = 2;
+    private static final int I = 100;
+    private static final int D = 5;
+    private static final int C = 10;
+    private static final int MIN_LINES = 5;
+    private static final int MAX_LINES = 15;
+    private static final int NEW_ORDERS = 5;
+    private static final int THREADS = 4;
+
+    @Test
+    void bulkFillMatchesOrderedFillExactly() throws SQLException {
+        Set<TableConfiguration> tables = TPCCConfiguration.build(W, I, D, C, MIN_LINES, MAX_LINES, NEW_ORDERS);
+
+        DatabaseConfiguration ordered = new DatabaseConfiguration(
+                256, 0, new PostgresSupport(), tables, 42L, null, BulkLoadStrategy.ordered());
+        DatabaseConfiguration bulk = new DatabaseConfiguration(
+                256, 0, new PostgresSupport(), tables, 42L, null, BulkLoadStrategy.unorderedBulk());
+
+        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
+                .withDatabaseName("bloviate")
+                .withUrlParam("rewriteBatchedInserts", "true")
+                .withUrlParam("stringtype", "unspecified")
+                .withInitScript("create_tpcc.postgres.sql")) {
+
+            database.start();
+
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
+
+                List<String> tableNames;
+                Map<String, List<String>> orderedDump;
+
+                // traditional, dependency-ordered parallel fill — the reference result (every FK is
+                // enforced at insert time, so completing proves the data is referentially valid)
+                new DatabaseFiller.Builder(dataSource, ordered).threads(THREADS).build().fill();
+
+                try (Connection connection = dataSource.getConnection()) {
+                    tableNames = tableNames(connection);
+                    assertRowCount(connection, "customer", (long) W * D * C);
+                    assertRowCount(connection, "open_order", (long) W * D * C);
+                    orderedDump = dump(connection, tableNames);
+                    truncateAll(connection, tableNames);
+                }
+
+                // unordered bulk fill — constraints disabled, no barrier
+                new DatabaseFiller.Builder(dataSource, bulk).threads(THREADS).build().fill();
+
+                try (Connection connection = dataSource.getConnection()) {
+                    // identical row counts and identical data, table by table
+                    assertRowCount(connection, "customer", (long) W * D * C);
+                    assertRowCount(connection, "open_order", (long) W * D * C);
+
+                    Map<String, List<String>> bulkDump = dump(connection, tableNames);
+                    for (String table : tableNames) {
+                        assertEquals(orderedDump.get(table), bulkDump.get(table),
+                                "table [" + table + "] must be identical between the ordered and bulk fills");
+                    }
+
+                    // every foreign-key constraint is still present and validated after the bulk fill
+                    assertNoInvalidForeignKeys(connection);
+
+                    // the bulk path restored each worker's session; nothing borrowed from the pool is
+                    // left with foreign-key enforcement suppressed
+                    assertSessionReplicationRoleRestored(dataSource);
+                }
+            }
+        }
+    }
+
+    /** Fails if any foreign-key constraint is left un-validated (NOT VALID) after the fill. */
+    private static void assertNoInvalidForeignKeys(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                     "select count(*) from pg_constraint where contype = 'f' and not convalidated")) {
+            resultSet.next();
+            assertEquals(0, resultSet.getLong(1), "no foreign-key constraint should be left NOT VALID");
+        }
+    }
+
+    /** Borrows a handful of connections and asserts none reports {@code session_replication_role = replica}. */
+    private static void assertSessionReplicationRoleRestored(HikariDataSource dataSource) throws SQLException {
+        for (int i = 0; i < THREADS + 1; i++) {
+            try (Connection connection = dataSource.getConnection();
+                 Statement statement = connection.createStatement();
+                 ResultSet resultSet = statement.executeQuery("show session_replication_role")) {
+                resultSet.next();
+                assertEquals("origin", resultSet.getString(1),
+                        "a pooled connection must not be left with constraints disabled");
+            }
+        }
+    }
+
+    private static List<String> tableNames(Connection connection) throws SQLException {
+        List<String> names = new ArrayList<>();
+        for (Table table : DatabaseUtils.getMetadata(connection).tables()) {
+            names.add(table.name());
+        }
+        return names;
+    }
+
+    /**
+     * Dumps each table ordered by every (non-temporal) column, producing a canonical row list
+     * independent of the physical insert order (which the barrier-free bulk path may legitimately
+     * change relative to the ordered fill).
+     */
+    private static Map<String, List<String>> dump(Connection connection, List<String> tables) throws SQLException {
+        Map<String, List<String>> dump = new LinkedHashMap<>();
+        try (Statement statement = connection.createStatement()) {
+            for (String table : tables) {
+                List<Integer> columns = deterministicColumns(statement, table);
+                if (columns.isEmpty()) {
+                    dump.put(table, List.of());
+                    continue;
+                }
+
+                StringJoiner order = new StringJoiner(",");
+                for (int column : columns) {
+                    order.add(String.valueOf(column));
+                }
+
+                List<String> rows = new ArrayList<>();
+                try (ResultSet resultSet = statement.executeQuery("select * from " + table + " order by " + order)) {
+                    while (resultSet.next()) {
+                        StringJoiner row = new StringJoiner("|");
+                        for (int column : columns) {
+                            row.add(String.valueOf(resultSet.getString(column)));
+                        }
+                        rows.add(row.toString());
+                    }
+                }
+                dump.put(table, rows);
+            }
+        }
+        return dump;
+    }
+
+    /** The 1-based indexes of a table's columns, excluding temporal types (which may use wall-clock time). */
+    private static List<Integer> deterministicColumns(Statement statement, String table) throws SQLException {
+        List<Integer> columns = new ArrayList<>();
+        try (ResultSet resultSet = statement.executeQuery("select * from " + table + " where false")) {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+            for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                if (!isTemporal(metaData.getColumnType(i))) {
+                    columns.add(i);
+                }
+            }
+        }
+        return columns;
+    }
+
+    private static boolean isTemporal(int sqlType) {
+        return sqlType == Types.DATE
+                || sqlType == Types.TIME
+                || sqlType == Types.TIME_WITH_TIMEZONE
+                || sqlType == Types.TIMESTAMP
+                || sqlType == Types.TIMESTAMP_WITH_TIMEZONE;
+    }
+
+    private static void truncateAll(Connection connection, List<String> tables) throws SQLException {
+        if (tables.isEmpty()) {
+            return;
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("TRUNCATE " + String.join(", ", tables) + " CASCADE");
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresParallelFillTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresParallelFillTest.java
@@ -41,8 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Verifies the issue #447 reproducibility-under-parallelism guarantee: a parallel fill
  * ({@link DatabaseFiller.Builder#Builder(javax.sql.DataSource, DatabaseConfiguration)} with
- * {@link DatabaseFiller.Builder#threads(int)}) produces byte-for-byte the same data as the
- * sequential single-connection fill for the same seed.
+ * {@link DatabaseFiller.Builder#threads(int)}) produces the same row content as the sequential
+ * single-connection fill for the same seed. Equality is asserted over a canonical row dump (rows
+ * sorted by every column, temporal columns excluded), i.e. row-content equality independent of
+ * physical insert order rather than on-disk byte equality.
  *
  * <p>A TPC-C schema is used deliberately: its foreign keys span several topological levels, so the
  * parallel walk genuinely fans out and barriers between levels, exercising the path that must stay

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -266,6 +266,52 @@ is unsupported: partitioning a *parent* whose primary key is a plain random gene
 foreign key (partition the child instead, or use the positional key generators). A custom generator
 with internal positional state must implement `IndexedDataGenerator` to stay aligned under partitioning.
 
+### Bulk load — unordered fill with constraints disabled
+
+[Parallel fill](#parallel-fill--topological-levels) barriers between topological levels, which costs
+the most on a **deep, narrow** foreign-key chain: each level holds few tables, so little fans out and
+the fill effectively serializes down the chain.
+[`BulkLoadStrategy.unorderedBulk()`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/db/BulkLoadStrategy.java)
+collapses every level into a single wave — one task per table (or partition), submitted at once with
+no barrier — and disables foreign-key enforcement for the duration.
+
+This is only sound because of [foreign-key fidelity](#filling-a-table--generators-batching-and-fk-fidelity):
+an FK column is seeded from its referenced PK column, so the data is referentially consistent
+*regardless of insert order*. Disabling enforcement removes the per-row check and the ordering
+requirement without changing a single generated value — the result is byte-for-byte identical to an
+ordered fill of the same seed.
+
+```mermaid
+flowchart TD
+    P["probe once: disable + re-enable on a borrowed connection"] -->|privilege ok| W
+    P -->|BulkLoadUnsupportedException| FB["fall back to ordered level-parallel fill"]
+    subgraph W["single wave — every table at once, no barrier"]
+        direction LR
+        T1["worker: disable → fill table → re-enable (finally)"]
+        T2["worker: disable → fill table → re-enable (finally)"]
+        T3["worker: disable → fill partition → re-enable (finally)"]
+    end
+```
+
+The mechanism is database-specific and lives behind two
+[`DatabaseSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/DatabaseSupport.java)
+SPI methods, `disableConstraints` / `enableConstraints`, guarded by `supportsBulkLoad()`:
+
+| Support | Mechanism (per session) | Notes |
+| --- | --- | --- |
+| PostgreSQL | `SET session_replication_role = replica` → `origin` | needs a superuser/`rds_superuser` role; privilege failure raises `BulkLoadUnsupportedException` |
+| MySQL | `SET FOREIGN_KEY_CHECKS=0`/`UNIQUE_CHECKS=0` → `1` | no special privilege |
+| CockroachDB | unsupported (`supportsBulkLoad()` is `false`) | no `session_replication_role`; falls back to ordered |
+
+Because these settings are **per connection** and each worker borrows its own from the pool, the
+disable/enable runs inside every worker task, wrapped in a `try/finally` that restores the session
+*before* the connection returns to the pool — so a constraint-disabled connection never leaks to
+other pool users, even if a fill throws. Privilege is probed **once** up front on a throwaway
+connection; if it fails, the engine logs a warning and runs the ordered level-parallel path instead
+of fanning out half-disabled. Bulk mode only applies to the `DataSource` + `threads > 1` path; it is
+ignored with a warning elsewhere. The default `BulkLoadStrategy.ordered()` keeps the dependency-ordered
+behavior with constraints always enforced.
+
 ## Reproducibility — deterministic seeds from schema identity
 
 Bloviate datasets are **reproducible across JVM runs, machines, and time** — run it twice against

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -102,6 +102,7 @@ Output lines look like:
 | `bench.batch` | 1000 | JDBC batch size (`DatabaseConfiguration.batchSize`) |
 | `bench.threads` | 1 | worker threads; `1` = sequential baseline, `>1` = parallel `DataSource` path |
 | `bench.partitions` | `max(2, threads)` | intra-table partitions for the **single** schema |
+| `bench.bulk` | `false` | unordered bulk load (disable constraints, fill barrier-free); needs `bench.threads > 1` |
 | `bench.rewriteBatched` | `true` | Postgres driver batch rewrite; set `false` for the naive baseline |
 | `bench.commit` | `none` | commit strategy for **single**: `none`, `perTable`, or `everyN:K` |
 | `bench.rows` | 50000 | default row count for the **wide**/**single** schema (per table) |
@@ -234,6 +235,27 @@ date/time/timestamp columns. `PostgresParallelFillTest` asserts a parallel fill 
 sequential fill byte-for-byte across a TPC-C schema, comparing every column except the few that use
 wall-clock time *by design* (e.g. the order-line delivery date), which are intentionally
 non-deterministic. See [Reproducibility — deterministic seeds from schema identity](./ARCHITECTURE.md#reproducibility--deterministic-seeds-from-schema-identity).
+
+### Unordered bulk load (deep FK chains)
+
+The modest TPC-C gains above come from the level barrier: a deep, narrow foreign-key chain leaves
+little to parallelize within any one level. [Unordered bulk load](./CONFIGURATION.md#bulk-load-unordered-fill)
+(`BulkLoadStrategy.unorderedBulk()`) targets exactly that case — it disables foreign-key enforcement,
+fills every table in a single barrier-free wave, and re-enables enforcement, producing data identical
+to the ordered fill. It is therefore the lever to reach for on TPC-C-shaped schemas; the FK-free
+`wide` and single-table fixtures are negative controls expected to stay roughly flat (one level
+already, nothing to disable). Measure it with `-Dbench.bulk=true` on the parallel path:
+
+```bash
+BASE="./mvnw -pl bloviate-benchmarks -am -Pbench test -Dbench.threads=8"
+$BASE -Dtest='PostgresFillBenchmark#tpcc'                      # ordered baseline (level barrier)
+$BASE -Dtest='PostgresFillBenchmark#tpcc' -Dbench.bulk=true    # unordered bulk load
+```
+
+> Figures depend heavily on schema shape (chain depth, table sizes) and on the database, so they are
+> not tabulated here — run the commands above on your target environment to see the effect. The win
+> grows with chain depth; PostgreSQL requires a superuser/`rds_superuser` role and CockroachDB falls
+> back to the ordered path.
 
 ## Switching the RNG
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -260,6 +260,49 @@ applies there too.
 > correctly-parameterized URL if you construct the `DataSource` yourself. CockroachDB ignores the
 > parameter, so no warning is emitted there.
 
+## Bulk load (unordered fill)
+
+The parallel path normally barriers between topological levels, so a **deep, narrow foreign-key
+chain** (each table depending on the previous) serializes — there is little within any one level to
+run concurrently. `BulkLoadStrategy.unorderedBulk()` removes that barrier: it disables foreign-key
+enforcement, fills **every** table at once, then re-enables enforcement.
+
+```java
+import io.bloviate.db.*;
+import io.bloviate.ext.PostgresSupport;
+
+DatabaseConfiguration config = new DatabaseConfiguration(
+    1000, 100_000, new PostgresSupport(), null, 42L,
+    null,                              // CommitStrategy (null = default)
+    BulkLoadStrategy.unorderedBulk()); // disable constraints, fill barrier-free, re-enable
+
+new DatabaseFiller.Builder(dataSource, config).threads(8).build().fill();
+```
+
+This is safe because Bloviate's data is **referentially consistent by construction**: a foreign-key
+column is seeded from its referenced primary-key column, so child and parent generate identical key
+values regardless of insert order. Disabling enforcement therefore changes nothing about
+correctness — the result is byte-for-byte identical to an ordered fill of the same seed — it only
+removes the ordering constraint and the per-row foreign-key checks. The win is largest on deep
+chains (e.g. TPC-C's `warehouse → district → customer → open_order → order_line`); wide, FK-free
+schemas already saturate their workers in one level and see little change.
+
+Requirements and fallback:
+
+- Only effective on the parallel path (a `DataSource` with `threads > 1`); it is ignored with a
+  warning on the single-`Connection` and single-thread paths, which fill in dependency order.
+- Supported on **PostgreSQL** (`SET session_replication_role = replica`, which needs a
+  superuser/`rds_superuser` role) and **MySQL** (`SET FOREIGN_KEY_CHECKS=0`/`UNIQUE_CHECKS=0`, no
+  special privilege). **CockroachDB** does not support it and transparently falls back to the
+  ordered level-parallel path.
+- Each worker disables enforcement on its own pooled connection and restores it in a `finally`
+  before returning the connection to the pool, so no connection ever leaks back with checks
+  suppressed. If enforcement cannot be disabled (e.g. the role lacks privilege), the engine logs a
+  warning and falls back to the ordered path rather than running half-disabled.
+
+The default, `BulkLoadStrategy.ordered()`, preserves today's behavior (dependency-ordered, constraints
+always enforced).
+
 ## Configuration options reference
 
 ### Database configuration options
@@ -275,6 +318,9 @@ applies there too.
   data (defaults to `0`)
 - **Commit Strategy**: How the engine commits — leave autocommit alone (default), commit once per
   table, or commit every N batches
+- **Bulk Load Strategy**: Fill in foreign-key dependency order (default), or `unorderedBulk()` to
+  disable constraint enforcement and fill every table at once with no topological barrier (parallel
+  path only; PostgreSQL/MySQL, with CockroachDB falling back)
 
 Parallelism (worker threads for concurrent table fill) is configured on the
 `DatabaseFiller.Builder` via `threads(n)` with the `DataSource` constructor.


### PR DESCRIPTION
Adds an opt-in parallelization strategy that exploits Bloviate's
referential-consistency-by-construction (foreign-key columns are seeded
from the referenced primary-key column, so child and parent generate
identical key values regardless of insert order). When enabled, the
engine disables foreign-key enforcement per worker connection, fills
every table at once with no topological-level barrier, and restores
enforcement afterward. This removes the serialization cost of deep,
narrow dependency chains (e.g. TPC-C's warehouse -> district ->
customer -> open_order -> order_line).

- BulkLoadStrategy (ORDERED default / UNORDERED_BULK) on
  DatabaseConfiguration, mirroring CommitStrategy with additive
  constructor overloads.
- DatabaseSupport SPI: supportsBulkLoad / disableConstraints /
  enableConstraints, with BulkLoadHandle and BulkLoadUnsupportedException.
  PostgreSQL uses session_replication_role=replica (privilege failure
  degrades gracefully); MySQL uses FOREIGN_KEY_CHECKS/UNIQUE_CHECKS;
  CockroachDB stays unsupported and falls back to the ordered path.
- DatabaseFiller: barrier-free fillUnordered with a one-time
  privilege probe and fallback; per-worker disable/enable wrapped in
  try/finally so no constraint-disabled connection leaks back to the pool.
- Benchmarks: -Dbench.bulk wired centrally through runBenchmark.
- Tests: Postgres/MySQL integration tests assert the bulk fill produces
  identical row content to a traditional dependency-ordered fill of the
  same seed, leaves all FKs valid, and resets each pooled session;
  BulkLoadStrategyTest covers config/SPI defaults without a container.

Equivalence guarantee: for a given seed, an unordered bulk fill yields
the same row content as an ordered fill across every deterministic
column. The integration tests assert this over a canonical row dump
(rows sorted by every column, temporal columns excluded) -- so it is
row-content equality independent of physical insert order, not on-disk
byte equality. Physical row order may differ, and non-deterministic
columns (wall-clock temporal generators, external-state custom plugins)
are only as reproducible as their generator. Positional key/foreign-key
columns remain byte-identical, being pure functions of the absolute row
index.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019xi9tRii3oxJp5v6cqUUgo