### PR TITLE
docs: list all six databases in homepage and comparison copy

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -73,7 +73,7 @@ Syntho").
 5. **Determinism as a first-class contract.** Same seed + same schema ⇒ byte-identical data, even
    under parallel and partitioned fills (see [reproducibility](./ARCHITECTURE.md#reproducibility--deterministic-seeds-from-schema-identity)).
    Most ML synthesizers cannot offer byte-identical reruns.
-6. **Maintained and multi-DB** — PostgreSQL, MySQL, and CockroachDB, actively released — while synth
+6. **Maintained and multi-DB** — PostgreSQL, MySQL, MariaDB, CockroachDB, H2, and SQLite, actively released — while synth
    is dormant and Benerator CE is frozen.
 
 ## Limitations

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -48,8 +48,8 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 		your classpath, with first-class JUnit 5 and Testcontainers integrations.
 	</Card>
 	<Card title="Multi-database" icon="seti:db">
-		PostgreSQL, MySQL, and CockroachDB today, with an extensible architecture for
-		more — actively maintained and released.
+		PostgreSQL, MySQL, MariaDB, CockroachDB, H2, and SQLite today, with an
+		extensible architecture for more — actively maintained and released.
 	</Card>
 	<Card title="Flat files too" icon="document">
 		Export generated data to CSV, TSV, and pipe-delimited files with full control


### PR DESCRIPTION
Two hand-authored spots still advertised only **PostgreSQL, MySQL, and CockroachDB**, even though MariaDB, H2, and SQLite shipped in #519:

- the homepage **"Multi-database"** card (`website/src/content/docs/index.mdx`)
- the comparison guide's **"Maintained and multi-DB"** line (`docs/COMPARISON.md`)

These edits were written during the #519 work but landed on the branch *after* the PR was merged, so they never reached `main`. This re-applies them on top of current `main`.

The `DATABASE_SUPPORT.md` table and the generated `llms.txt` already list all six (verified `llms.txt` now auto-derives the full list from the table). Once this merges, the live site's homepage and Why-Bloviate page will match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)