### PR TITLE
docs: list MariaDB, H2, and SQLite in supported-database copy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -381,7 +381,10 @@ classDiagram
     AbstractDatabaseSupport <|-- DefaultSupport
     AbstractDatabaseSupport <|-- PostgresSupport
     AbstractDatabaseSupport <|-- MySQLSupport
+    AbstractDatabaseSupport <|-- H2Support
+    AbstractDatabaseSupport <|-- SQLiteSupport
     PostgresSupport <|-- CockroachDBSupport
+    MySQLSupport <|-- MariaDBSupport
 ```
 
 | Implementation | Adds on top of the JDBC defaults |
@@ -389,7 +392,10 @@ classDiagram
 | [`DefaultSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/DefaultSupport.java) | Nothing — cross-database JDBC types only |
 | [`PostgresSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/PostgresSupport.java) | `uuid`, `json`/`jsonb`, `inet`, `cidr`, `macaddr`/`macaddr8`, `interval`, `bit`/`varbit`, `xml`, and `text`/`int` arrays |
 | [`MySQLSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/MySQLSupport.java) | `JSON` columns generate valid JSON instead of arbitrary text |
+| [`MariaDBSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/MariaDBSupport.java) | Extends `MySQLSupport` — MariaDB columns surface through JDBC essentially as MySQL's |
 | [`CockroachDBSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/CockroachDBSupport.java) | Extends `PostgresSupport` (CockroachDB is PG wire-compatible) |
+| [`H2Support`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/H2Support.java) | Signed `TINYINT` (`-128..127`), `UUID` (reported as `BINARY`), and valid `JSON` |
+| [`SQLiteSupport`](https://github.com/timveil/bloviate/blob/main/bloviate-core/src/main/java/io/bloviate/ext/SQLiteSupport.java) | Nothing — SQLite's affinity types collapse onto `INTEGER`/`FLOAT`/`VARCHAR`, already covered by the defaults |
 
 You don't have to pick manually. `DatabaseSupport.forConnection(connection)` reads
 `DatabaseMetaData.getDatabaseProductName()` and selects the right strategy by substring match,
@@ -579,8 +585,8 @@ These principles aren't abstract — they show up as concrete quality properties
 - **A dependency-free core.** `bloviate-core` keeps its dependency surface small and pushes JUnit and
   Testcontainers to `provided` scope, so integrating Bloviate doesn't drag a testing framework into
   your runtime classpath, and you bring your own versions.
-- **Tested against real databases.** Integration tests run against actual PostgreSQL, MySQL, and
-  CockroachDB instances via Testcontainers — not mocks — over real benchmark schemas (TPC-C,
+- **Tested against real databases.** Integration tests run against actual PostgreSQL, MySQL, MariaDB,
+  and CockroachDB instances via Testcontainers — plus embedded H2 and SQLite — not mocks — over real benchmark schemas (TPC-C,
   AuctionMark, Wikipedia). Behavior is verified end-to-end, including the FK ordering and round-trip
   read-back through each generator's `get(ResultSet, ...)`.
 - **Reproducibility as a guarantee, not a hope.** Because seeds are pure functions of schema identity,

--- a/website/src/content/docs/reference/index.mdx
+++ b/website/src/content/docs/reference/index.mdx
@@ -35,7 +35,7 @@ The package links open the Javadoc in a new tab.
 		href="/apidocs/io/bloviate/ext/package-summary.html"
 		target="_blank"
 		rel="noopener noreferrer"
-		description="Per-database support: DatabaseSupport plus PostgresSupport, MySQLSupport, CockroachDBSupport, and DefaultSupport."
+		description="Per-database support: DatabaseSupport plus PostgresSupport, MySQLSupport, MariaDBSupport, CockroachDBSupport, H2Support, SQLiteSupport, and DefaultSupport."
 	/>
 	<LinkCard
 		title="io.bloviate.gen"


### PR DESCRIPTION
## Summary

Commit 0bc0a04 added MariaDB/H2/SQLite support and #522 updated the homepage and comparison copy, but two supported-database lists were still stale, naming only PostgreSQL, MySQL, and CockroachDB:

- **`docs/ARCHITECTURE.md`** — the `DatabaseSupport` class-hierarchy diagram and the "adds on top of JDBC defaults" implementation table gain `MariaDBSupport` (extends `MySQLSupport`), `H2Support`, and `SQLiteSupport` (both extend `AbstractDatabaseSupport`); the "tested against real databases" line now covers MariaDB via Testcontainers plus embedded H2 and SQLite.
- **`website/src/content/docs/reference/index.mdx`** — the `io.bloviate.ext` package summary now names all the support classes instead of just four.

The website `guides/*.md` mirror and `llms*.txt` regenerate from these canonical sources via `sync-docs.mjs`, so only the source files are committed.

## Verification

- All three new DBs have real integration tests (`H2FillerTest`, `MariaDbFillerTest`, `SQLiteFillerTest`) and support classes, so the architecture claims are accurate.
- H2/SQLite are embedded/in-process (not Testcontainers), worded accordingly.
- Astro site build passes (`npm run build` → 12 pages, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)