### PR TITLE
refactor: simplify benchmark loop, adopt @NullMarked in bloviate-junit

### DIFF
--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/RowDispatchBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/RowDispatchBenchmark.java
@@ -96,8 +96,8 @@ public class RowDispatchBenchmark {
      */
     @Benchmark
     public void dispatchRowIndexed(Blackhole blackhole) {
-        for (int i = 0; i < generators.length; i++) {
-            blackhole.consume(generators[i].generate());
+        for (DataGenerator<?> generator : generators) {
+            blackhole.consume(generator.generate());
         }
     }
 }

--- a/bloviate-junit/pom.xml
+++ b/bloviate-junit/pom.xml
@@ -54,6 +54,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JSpecify nullness annotations (@NullMarked); compile-time only -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Testing Dependencies -->
 
         <dependency>

--- a/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
+++ b/bloviate-junit/src/main/java/io/bloviate/junit/BloviateExtension.java
@@ -19,6 +19,7 @@ package io.bloviate.junit;
 import io.bloviate.db.DatabaseConfiguration;
 import io.bloviate.db.DatabaseFiller;
 import io.bloviate.ext.DatabaseSupport;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -88,7 +89,7 @@ public class BloviateExtension implements BeforeEachCallback {
         new DatabaseFiller.Builder(connection, configuration).build().fill();
     }
 
-    private FillDatabase resolveAnnotation(ExtensionContext context) {
+    private @Nullable FillDatabase resolveAnnotation(ExtensionContext context) {
         return context.getTestMethod()
                 .flatMap(method -> AnnotationSupport.findAnnotation(method, FillDatabase.class))
                 .orElseGet(() -> AnnotationSupport.findAnnotation(

--- a/bloviate-junit/src/main/java/io/bloviate/junit/package-info.java
+++ b/bloviate-junit/src/main/java/io/bloviate/junit/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JUnit Jupiter integration for Bloviate. Marked {@link org.jspecify.annotations.NullMarked} so
+ * every type usage is non-null by default, matching the JUnit extension API this package overrides.
+ */
+@NullMarked
+package io.bloviate.junit;
+
+import org.jspecify.annotations.NullMarked;

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <jackson.version>2.22.0</jackson.version>
         <slf4j.version>2.0.18</slf4j.version>
         <jgrapht.version>1.5.3</jgrapht.version>
+        <jspecify.version>1.0.0</jspecify.version>
         <junit-jupiter.version>6.1.1</junit-jupiter.version>
         <datafaker.version>2.7.0</datafaker.version>
 
@@ -159,6 +160,11 @@
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-io</artifactId>
                 <version>${jgrapht.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

Two small refactors that started as manual cleanups in the working tree:

- **`RowDispatchBenchmark`** — `dispatchRowIndexed` now uses an enhanced-for over the `generators` array instead of an indexed loop. It's still a plain array read (no `Column` hashing), so the comparison against `dispatchRow` is unchanged; just cleaner.
- **`bloviate-junit`** — adopt JSpecify's `@NullMarked` at the package level (via a new `package-info.java`) rather than a one-off inline `@NonNull` on `beforeEach`. This makes every type usage in the package non-null by default, matching the JUnit extension API it overrides, and is consistent everywhere instead of a single annotated parameter.

JSpecify is now declared as a **direct `provided` dependency** (managed in the parent POM) instead of relying on JUnit's transitive graph.

## Test plan

- `./mvnw -pl bloviate-junit -am compile` — compiles clean
- No behavioral change; annotations are compile-time only and the benchmark loop is semantically equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)