### PR TITLE
test(benchmarks): add JMH coverage for under-benchmarked subsystems

### DIFF
--- a/bloviate-benchmarks/pom.xml
+++ b/bloviate-benchmarks/pom.xml
@@ -61,6 +61,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- in-memory database for the metadata-introspection JMH benchmark (no Docker) -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+
         <!-- JMH (CPU micro-benchmarks) -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/bloviate-benchmarks/pom.xml
+++ b/bloviate-benchmarks/pom.xml
@@ -54,6 +54,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- realistic-value module under test (Datafaker providers + correlated row projection) -->
+        <dependency>
+            <groupId>io.bloviate</groupId>
+            <artifactId>bloviate-datafaker</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- JMH (CPU micro-benchmarks) -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/BenchColumns.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/BenchColumns.java
@@ -64,4 +64,23 @@ final class BenchColumns {
                 column("external_id", JDBCType.OTHER, "uuid", null, null),
                 column("payload", JDBCType.OTHER, "jsonb", null, null));
     }
+
+    /**
+     * A portable row of standard SQL types only — the ones every {@link io.bloviate.ext.DatabaseSupport}
+     * resolves through the shared cross-database defaults (no PostgreSQL extension types). Used by the
+     * cross-support resolution benchmark (so every support can resolve every column) and by the bind
+     * benchmark (so a plain {@code CREATE TABLE} of these types accepts the generated values). The
+     * column types are mirrored by {@code BindBenchmark}'s DDL, in this order.
+     */
+    static List<Column> standardRow() {
+        return List.of(
+                column("c_int", JDBCType.INTEGER, "int", null, null),
+                column("c_bigint", JDBCType.BIGINT, "bigint", null, null),
+                column("c_double", JDBCType.DOUBLE, "double", null, null),
+                column("c_numeric", JDBCType.NUMERIC, "numeric", 12, 2),
+                column("c_varchar", JDBCType.VARCHAR, "varchar", 64, null),
+                column("c_bool", JDBCType.BOOLEAN, "boolean", null, null),
+                column("c_date", JDBCType.DATE, "date", null, null),
+                column("c_ts", JDBCType.TIMESTAMP, "timestamp", null, null));
+    }
 }

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/BindBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/BindBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Column;
+import io.bloviate.ext.H2Support;
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-row cost of the real per-cell bind in {@link io.bloviate.db.TableFiller#fill()} — the
+ * {@code dataGenerator.generateAndSet(connection, ps, col)} at {@code TableFiller.java:258} — isolated
+ * from the database round-trip. The end-to-end fill benchmarks fold generation, parameter binding, and
+ * the JDBC wire into one number; this keeps the first two and drops the third by binding against an
+ * in-memory <strong>H2</strong> {@link PreparedStatement} and never executing it (so there is no Docker
+ * and no network).
+ *
+ * <p>Each op walks the {@linkplain BenchColumns#standardRow() portable standard-type row}, calling
+ * {@code generateAndSet} on every column's generator (resolved through {@link H2Support}, exactly as
+ * the engine resolves it) to bind a freshly generated value into the statement, then
+ * {@link PreparedStatement#clearParameters()} to reset for the next op. The result is the generation +
+ * JDBC bind cost per row; compared with {@link RowDispatchBenchmark} (generation only, no bind) the
+ * delta is the parameter-binding cost the wire normally hides.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class BindBenchmark {
+
+    /** Fixed seed so every column's generator emits the same value stream — reproducibility over time. */
+    private static final long SEED = 42L;
+
+    /** H2 column types matching {@link BenchColumns#standardRow()}, in the same order. */
+    private static final String DDL =
+            "CREATE TABLE bind_t (" +
+                    "c_int INTEGER, c_bigint BIGINT, c_double DOUBLE, c_numeric NUMERIC(12,2), " +
+                    "c_varchar VARCHAR(64), c_bool BOOLEAN, c_date DATE, c_ts TIMESTAMP)";
+
+    private Connection connection;
+    private PreparedStatement statement;
+    private DataGenerator<?>[] generators;
+
+    @Setup(Level.Trial)
+    public void setup() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:h2:mem:bindbench;DB_CLOSE_DELAY=-1");
+        try (Statement ddl = connection.createStatement()) {
+            ddl.execute(DDL);
+        }
+        statement = connection.prepareStatement(
+                "INSERT INTO bind_t VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+
+        // resolve one seeded generator per column, the same path TableFiller uses
+        H2Support support = new H2Support();
+        List<Column> columns = BenchColumns.standardRow();
+        generators = new DataGenerator<?>[columns.size()];
+        long seed = SEED;
+        for (int i = 0; i < columns.size(); i++) {
+            generators[i] = support.getDataGenerator(columns.get(i), RandomGenerators.create(seed++));
+        }
+    }
+
+    /** Generate and bind every column of one row into the prepared statement, then reset — no execute. */
+    @Benchmark
+    public void bindRow() throws SQLException {
+        for (int col = 0; col < generators.length; col++) {
+            generators[col].generateAndSet(connection, statement, col + 1);
+        }
+        statement.clearParameters();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws SQLException {
+        if (statement != null) {
+            statement.close();
+        }
+        if (connection != null) {
+            connection.close();
+        }
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/DatafakerBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/DatafakerBenchmark.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.datafaker.DatafakerStringGenerator;
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
+import net.datafaker.Faker;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Raw per-cell throughput of the {@code bloviate-datafaker} realistic-value layer — the
+ * previously-unbenchmarked, and most expensive, way the engine can fill a cell. Each case resolves a
+ * {@link DatafakerStringGenerator} over one Datafaker provider (the same providers
+ * {@code DatafakerGeneratorPlugin} wires by column name) and times a single
+ * {@link DatafakerStringGenerator#generate()}, so the numbers are directly comparable to the
+ * type-driven generators in {@link GeneratorBenchmark} — i.e. "what does turning on semantic data cost
+ * per column?"
+ *
+ * <p>The correlated multi-column path (one shared entity projected by several columns) is measured
+ * separately by {@link DatafakerProjectionBenchmark}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class DatafakerBenchmark {
+
+    /** Fixed seed so every run draws the same realistic value stream — reproducibility over time. */
+    private static final long SEED = 42L;
+
+    /** Fixed locale (not the JVM default), matching the module's reproducibility contract. */
+    private static final Locale LOCALE = Locale.ENGLISH;
+
+    /** A representative spread of the providers {@code DatafakerGeneratorPlugin} maps by column name. */
+    public enum Provider {
+        EMAIL(f -> f.internet().safeEmailAddress()),
+        FIRST_NAME(f -> f.name().firstName()),
+        FULL_NAME(f -> f.name().fullName()),
+        PHONE(f -> f.regexify("\\([0-9]{3}\\) 555-01[0-9]{2}")),
+        COMPANY(f -> f.company().name()),
+        CITY(f -> f.address().city()),
+        STREET_ADDRESS(f -> f.address().streetAddress());
+
+        private final Function<Faker, String> valueFunction;
+
+        Provider(Function<Faker, String> valueFunction) {
+            this.valueFunction = valueFunction;
+        }
+    }
+
+    @Param
+    public Provider provider;
+
+    private DataGenerator<String> generator;
+
+    @Setup
+    public void setup() {
+        generator = new DatafakerStringGenerator(RandomGenerators.create(SEED), LOCALE, 255, provider.valueFunction);
+    }
+
+    @Benchmark
+    public String generate() {
+        return generator.generate();
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/DatafakerProjectionBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/DatafakerProjectionBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.datafaker.People;
+import io.bloviate.datafaker.Person;
+import io.bloviate.datafaker.RowContext;
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Cost of the issue-#473 correlated row projection in {@code bloviate-datafaker}: several columns
+ * projecting fields of one coherent per-row entity ({@link Person}). A "row" here materializes a
+ * {@link Person} (a Datafaker build) and projects five fields from it.
+ *
+ * <p>The two benchmarks are a before/after on the shared-entity design, mirroring how
+ * {@link RowDispatchBenchmark} contrasts map vs indexed dispatch:
+ * <ul>
+ *   <li>{@link #projectRowShared(Blackhole)} — five sibling projections of <em>one</em>
+ *       {@link RowContext}. The first projection builds the row's {@link Person}; the other four hit
+ *       the context's per-row cache. This is what the engine pays for five correlated person columns.</li>
+ *   <li>{@link #projectRowUncorrelated(Blackhole)} — the same five columns, but each backed by its
+ *       <em>own</em> context, so every column rebuilds its own {@link Person} every row (five Datafaker
+ *       builds per row). This is the cost without the correlation cache.</li>
+ * </ul>
+ * The gap between them is exactly the work the shared-entity memo removes.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class DatafakerProjectionBenchmark {
+
+    /** Fixed seed so every run materializes the same identities — reproducibility over time. */
+    private static final long SEED = 42L;
+
+    /** Fixed locale (not the JVM default), matching the module's reproducibility contract. */
+    private static final Locale LOCALE = Locale.ENGLISH;
+
+    // five sibling projections of ONE shared person context: one entity build per row, four cache hits
+    private DataGenerator<?>[] sharedProjections;
+
+    // five projections, each backed by its OWN context: five entity builds per row (no correlation cache)
+    private DataGenerator<?>[] uncorrelatedProjections;
+
+    @Setup
+    public void setup() {
+        RowContext<Person> shared = People.context(SEED, LOCALE);
+        sharedProjections = new DataGenerator<?>[]{
+                projection(shared, Person::firstName),
+                projection(shared, Person::lastName),
+                projection(shared, Person::fullName),
+                projection(shared, Person::email),
+                projection(shared, Person::username)
+        };
+
+        // distinct seeds so the contexts are genuinely independent (no accidental shared cache)
+        uncorrelatedProjections = new DataGenerator<?>[]{
+                projection(People.context(SEED, LOCALE), Person::firstName),
+                projection(People.context(SEED + 1, LOCALE), Person::lastName),
+                projection(People.context(SEED + 2, LOCALE), Person::fullName),
+                projection(People.context(SEED + 3, LOCALE), Person::email),
+                projection(People.context(SEED + 4, LOCALE), Person::username)
+        };
+    }
+
+    /**
+     * One correlated row through five sibling projections of a single shared context: the first
+     * projection materializes the {@link Person}, the remaining four hit the per-row cache.
+     */
+    @Benchmark
+    public void projectRowShared(Blackhole blackhole) {
+        for (DataGenerator<?> projection : sharedProjections) {
+            blackhole.consume(projection.generate());
+        }
+    }
+
+    /**
+     * The same five columns with no shared context, so each column rebuilds its own {@link Person}
+     * every row. Compare against {@link #projectRowShared(Blackhole)} to isolate what the shared-entity
+     * memo saves.
+     */
+    @Benchmark
+    public void projectRowUncorrelated(Blackhole blackhole) {
+        for (DataGenerator<?> projection : uncorrelatedProjections) {
+            blackhole.consume(projection.generate());
+        }
+    }
+
+    private static DataGenerator<?> projection(RowContext<Person> context, Function<Person, String> selector) {
+        // project(...) returns a ColumnGeneratorFactory; the per-column random is ignored by the projection
+        return context.project(selector).create(RandomGenerators.create(SEED));
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/DistributionGeneratorBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/DistributionGeneratorBenchmark.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.gen.NormalDoubleGenerator;
+import io.bloviate.gen.NormalIntegerGenerator;
+import io.bloviate.gen.SkewedTimestampGenerator;
+import io.bloviate.gen.WeightedCategoricalGenerator;
+import io.bloviate.gen.ZipfianIntegerGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.function.Function;
+import java.util.random.RandomGenerator;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-draw throughput of the <em>distribution</em> generators — the non-uniform shapes you reach for
+ * to make data realistic (skewed foreign-key references, weighted categories, bell-curve numerics,
+ * recency-biased timestamps). {@link GeneratorBenchmark} covers only uniform type-driven generators;
+ * these are config-driven (opt-in per column), so they are resolved by their own builders rather than
+ * through {@code DatabaseSupport.getDataGenerator}, and benchmarked here.
+ *
+ * <p>What it isolates is the per-draw sampling cost each distribution adds over a plain uniform draw:
+ * the cumulative-weight binary search for {@link ZipfianIntegerGenerator} (over a large key space, its
+ * CDF is built once at construction — in {@link #setup()}, not timed) and
+ * {@link WeightedCategoricalGenerator}, the {@code nextGaussian}/clamp of the normal generators, and
+ * the {@code pow}-reshape plus {@link java.sql.Timestamp} construction of
+ * {@link SkewedTimestampGenerator}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class DistributionGeneratorBenchmark {
+
+    /** Fixed seed so every run draws the same value stream — reproducibility over time. */
+    private static final long SEED = 42L;
+
+    /** A representative key-space size for the rank-based generators (Zipfian builds its CDF over this). */
+    private static final int KEY_SPACE = 1_000_000;
+
+    /** Distribution generators, each built directly since they are configured, not type-resolved. */
+    public enum DistCase {
+        // classic Zipf and a steeper variant — exercises the cumulative-weight binary search per draw
+        ZIPFIAN(r -> new ZipfianIntegerGenerator.Builder(r).start(1).size(KEY_SPACE).exponent(1.0).build()),
+        ZIPFIAN_STEEP(r -> new ZipfianIntegerGenerator.Builder(r).start(1).size(KEY_SPACE).exponent(1.5).build()),
+        // a small weighted category set, the common "status"/"type" column shape
+        WEIGHTED_CATEGORICAL(DistributionGeneratorBenchmark::weightedCategorical),
+        // bell-curve numerics: nextGaussian + clamp, integer and double
+        NORMAL_DOUBLE(r -> new NormalDoubleGenerator.Builder(r).mean(100).standardDeviation(15).min(0).max(200).build()),
+        NORMAL_INTEGER(r -> new NormalIntegerGenerator.Builder(r).mean(100).standardDeviation(15).min(0).max(200).build()),
+        // recency-biased timestamps: pow-reshape of a uniform draw across the default window
+        SKEWED_TIMESTAMP(r -> new SkewedTimestampGenerator.Builder(r).skew(3.0).build());
+
+        private final Function<RandomGenerator, DataGenerator<?>> factory;
+
+        DistCase(Function<RandomGenerator, DataGenerator<?>> factory) {
+            this.factory = factory;
+        }
+    }
+
+    @Param
+    public DistCase distCase;
+
+    private DataGenerator<?> generator;
+
+    @Setup
+    public void setup() {
+        generator = distCase.factory.apply(RandomGenerators.create(SEED));
+    }
+
+    @Benchmark
+    public Object generate() {
+        return generator.generate();
+    }
+
+    @Benchmark
+    public String generateAsString() {
+        return generator.generateAsString();
+    }
+
+    /** A small, representative weighted category set (skewed toward the head category). */
+    private static DataGenerator<?> weightedCategorical(RandomGenerator random) {
+        return new WeightedCategoricalGenerator.Builder<String>(random)
+                .add("NEW", 50)
+                .add("OPEN", 25)
+                .add("PENDING", 12)
+                .add("CLOSED", 8)
+                .add("CANCELLED", 3)
+                .add("ARCHIVED", 2)
+                .build();
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/FileGenBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/FileGenBenchmark.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Column;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.file.ColumnDefinition;
+import io.bloviate.file.CsvFile;
+import io.bloviate.file.FileDefinition;
+import io.bloviate.file.FlatFileGenerator;
+import io.bloviate.file.PipeDelimitedFile;
+import io.bloviate.file.TabDelimitedFile;
+import io.bloviate.gen.StaticStringGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * End-to-end throughput of the flat-file subsystem ({@link FlatFileGenerator#generate()}) — the only
+ * benchmark that exercises {@link io.bloviate.file} at all. Each measured op writes a full file of
+ * {@link #ROWS} rows to a real (temp) path, so the timing covers everything a CLI/file user actually
+ * pays: per-cell {@code generateAsString()}, Commons-CSV formatting and quoting, and buffered IO.
+ *
+ * <p>Two axes are crossed:
+ * <ul>
+ *   <li>{@link Format} — the three delimiters the subsystem supports (CSV, tab, pipe), so a change to
+ *       {@code CSVFormat} selection or delimiter handling shows up per format.</li>
+ *   <li>{@link Content} — what the cells contain. {@code MIXED} is a realistic wide row (real
+ *       type-driven generators resolved exactly as {@link io.bloviate.db.TableFiller} resolves them),
+ *       giving the headline "rows/second to disk" number. {@code PLAIN} and {@code ESCAPED} are
+ *       constant-string rows that differ <em>only</em> in whether the value embeds the delimiter and a
+ *       quote: with generation cost held flat between them, {@code PLAIN} vs {@code ESCAPED} isolates
+ *       the cost of Commons-CSV's quoting/escaping path.</li>
+ * </ul>
+ *
+ * <p>Tunable via {@code -Dfile.rows} (default 5,000 rows per file).
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class FileGenBenchmark {
+
+    /** Fixed seed so the realistic ({@code MIXED}) generators emit the same value stream every run. */
+    private static final long SEED = 42L;
+
+    /** Rows written per measured op; small enough to stay quick, large enough to amortize file open. */
+    private static final long ROWS = Long.getLong("file.rows", 5_000L);
+
+    /** The three delimited formats {@link FlatFileGenerator} supports. */
+    public enum Format {
+        CSV,
+        TDV,
+        PIPE
+    }
+
+    /**
+     * What every cell holds. {@code MIXED} drives realistic, type-varied generators (the common case);
+     * {@code PLAIN} and {@code ESCAPED} are constant strings of identical generation cost that differ
+     * only in needing CSV quoting, isolating the escape path.
+     */
+    public enum Content {
+        MIXED,
+        PLAIN,
+        ESCAPED
+    }
+
+    /** A constant value with no delimiter or quote — never triggers Commons-CSV quoting. */
+    private static final String PLAIN_VALUE = "abcdefghijklmnop";
+
+    /** A constant value embedding every delimiter and a quote — forces quoting/escaping in all formats. */
+    private static final String ESCAPED_VALUE = "a,b\tc|d \"quoted\" e";
+
+    @Param
+    public Format format;
+
+    @Param
+    public Content content;
+
+    private FlatFileGenerator generator;
+    private Path tempDir;
+    private String baseName;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+        tempDir = Files.createTempDirectory("bloviate-filebench");
+        // FlatFileGenerator appends the format extension to this base name itself
+        baseName = tempDir.resolve("out").toString();
+
+        generator = new FlatFileGenerator.Builder(baseName)
+                .output(fileDefinition(format))
+                .addAll(columns(content))
+                .rows(ROWS)
+                .build();
+    }
+
+    @Benchmark
+    public void generate() {
+        generator.generate();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws IOException {
+        // remove the written file(s) and the temp directory
+        if (tempDir != null) {
+            try (var paths = Files.walk(tempDir)) {
+                paths.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+            }
+        }
+    }
+
+    private static FileDefinition fileDefinition(Format format) {
+        return switch (format) {
+            case CSV -> new CsvFile();
+            case TDV -> new TabDelimitedFile();
+            case PIPE -> new PipeDelimitedFile();
+        };
+    }
+
+    /**
+     * Builds the column definitions for a content mode. {@code MIXED} reuses {@link BenchColumns#wideRow()}
+     * with real generators (so the file write pays realistic generation cost); the constant-string modes
+     * keep the same column count but emit a fixed value, holding generation cost flat so the format/escape
+     * cost is what varies.
+     */
+    private static List<ColumnDefinition> columns(Content content) {
+        if (content == Content.MIXED) {
+            PostgresSupport support = new PostgresSupport();
+            long seed = SEED;
+            List<ColumnDefinition> definitions = new ArrayList<>();
+            for (Column column : BenchColumns.wideRow()) {
+                definitions.add(new ColumnDefinition(column.name(),
+                        support.getDataGenerator(column, RandomGenerators.create(seed++))));
+            }
+            return definitions;
+        }
+
+        String value = content == Content.ESCAPED ? ESCAPED_VALUE : PLAIN_VALUE;
+        int width = BenchColumns.wideRow().size();
+        List<ColumnDefinition> definitions = new ArrayList<>();
+        for (int i = 0; i < width; i++) {
+            StaticStringGenerator generator = new StaticStringGenerator.Builder(RandomGenerators.create(SEED))
+                    .value(value)
+                    .build();
+            definitions.add(new ColumnDefinition("c" + i, generator));
+        }
+        return definitions;
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/ForeignKeyGeneratorBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/ForeignKeyGeneratorBenchmark.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.gen.ChildCardinality;
+import io.bloviate.gen.ChildCountGenerator;
+import io.bloviate.gen.ChildKeyComponentGenerator;
+import io.bloviate.gen.CompositeKeyComponentGenerator;
+import io.bloviate.gen.DataGenerator;
+import io.bloviate.util.RandomGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.random.RandomGenerator;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-row cost of the cross-table key generation that referentially-correct fills pay and FK-free
+ * fills don't — the work that makes a TPC-C-shaped fill more expensive per row than the {@code wide}
+ * fixture. It is pure CPU (the key generators reproduce the parent key space arithmetically and never
+ * read parent rows back), so it is isolated here with no JDBC.
+ *
+ * <p>The model is a TPC-C {@code orders} → {@code order_line} relationship keyed on
+ * {@code (w_id, d_id, o_id[, ol_number])}: a parent {@code orders} row carries a composite key plus a
+ * "number of children" column, and each child {@code order_line} row reproduces its parent's composite
+ * key and adds a per-parent sequence number. A single shared {@link ChildCardinality} is the source of
+ * truth for how many children each parent owns, exactly as the engine wires it.
+ *
+ * <ul>
+ *   <li>{@link #parentKeyRow(Blackhole)} — one parent row: three {@link CompositeKeyComponentGenerator}
+ *       key dimensions plus a {@link ChildCountGenerator} (which calls {@code cardinality.count}).</li>
+ *   <li>{@link #childKeyRow(Blackhole)} — one child row: three parent-reproducing
+ *       {@link ChildKeyComponentGenerator} dimensions plus a sequence-mode one. These share the
+ *       cardinality and advance in lockstep (the engine generates each key column once per row), so a
+ *       call to all four is exactly one child row; each {@code generate()} is {@code synchronized} and
+ *       walks the per-parent child count.</li>
+ * </ul>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class ForeignKeyGeneratorBenchmark {
+
+    /** Fixed seed so the cardinality (and thus the whole walk) is identical every run. */
+    private static final long SEED = 42L;
+
+    // a modest TPC-C-shaped scale; the per-row cost is arithmetic + a hash, so exact sizes barely move it
+    private static final int WAREHOUSES = 10;
+    private static final int DISTRICTS = 10;
+    private static final int ORDERS = 3_000;        // orders per district
+    private static final int MIN_LINES = 5;
+    private static final int MAX_LINES = 15;
+
+    /** Parent composite-key dimensions plus the parent's child-count column. */
+    private DataGenerator<?>[] parentRow;
+
+    /** Child key: parent-reproducing dimensions plus the per-parent sequence number. */
+    private DataGenerator<?>[] childRow;
+
+    @Setup
+    public void setup() {
+        // one shared cardinality: how many order_lines each order owns
+        ChildCardinality cardinality = new ChildCardinality(MIN_LINES, MAX_LINES, SEED);
+
+        // parent orders key (w_id, d_id, o_id), o_id innermost, plus o_ol_cnt (the child-count column)
+        parentRow = new DataGenerator<?>[]{
+                composite(1L, WAREHOUSES, (long) ORDERS * DISTRICTS),                 // w_id
+                composite(1L, DISTRICTS, ORDERS),                                     // d_id
+                composite(1L, ORDERS, 1L),                                            // o_id (innermost)
+                new ChildCountGenerator.Builder(rng()).cardinality(cardinality).build()
+        };
+
+        // child order_line key: reproduce the parent (w_id, d_id, o_id), then the sequence ol_number
+        childRow = new DataGenerator<?>[]{
+                childComponent(cardinality, 1, WAREHOUSES, (long) ORDERS * DISTRICTS), // ol_w_id
+                childComponent(cardinality, 1, DISTRICTS, ORDERS),                     // ol_d_id
+                childComponent(cardinality, 1, ORDERS, 1L),                            // ol_o_id
+                new ChildKeyComponentGenerator.Builder(rng()).cardinality(cardinality).sequence().start(1).build()
+        };
+    }
+
+    /** One parent {@code orders} row's key columns plus its child-count column. */
+    @Benchmark
+    public void parentKeyRow(Blackhole blackhole) {
+        for (DataGenerator<?> component : parentRow) {
+            blackhole.consume(component.generate());
+        }
+    }
+
+    /** One child {@code order_line} row's foreign-key columns (parent reproduction + sequence). */
+    @Benchmark
+    public void childKeyRow(Blackhole blackhole) {
+        for (DataGenerator<?> component : childRow) {
+            blackhole.consume(component.generate());
+        }
+    }
+
+    private static CompositeKeyComponentGenerator composite(long start, int cycle, long repeat) {
+        return new CompositeKeyComponentGenerator.Builder(rng())
+                .start((int) start).cycle(cycle).repeat(repeat).build();
+    }
+
+    private static ChildKeyComponentGenerator childComponent(ChildCardinality cardinality, int start, int cycle, long repeat) {
+        return new ChildKeyComponentGenerator.Builder(rng())
+                .cardinality(cardinality).start(start).cycle(cycle).repeat(repeat).build();
+    }
+
+    /** The key generators ignore their random source (keys are positional), but the builders require one. */
+    private static RandomGenerator rng() {
+        return RandomGenerators.create(SEED);
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/GeneratorBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/GeneratorBenchmark.java
@@ -68,7 +68,16 @@ public class GeneratorBenchmark {
         TIMESTAMP(BenchColumns.column("c", JDBCType.TIMESTAMP, "timestamp", null, null)),
         BIT(BenchColumns.column("c", JDBCType.BIT, "bit", 8, null)),
         UUID(BenchColumns.column("c", JDBCType.OTHER, "uuid", null, null)),
-        JSONB(BenchColumns.column("c", JDBCType.OTHER, "jsonb", null, null));
+        JSONB(BenchColumns.column("c", JDBCType.OTHER, "jsonb", null, null)),
+        // structured / extension types — typically the most expensive cells, dispatched on type name
+        XML(BenchColumns.column("c", JDBCType.SQLXML, "xml", null, null)),
+        INET(BenchColumns.column("c", JDBCType.OTHER, "inet", null, null)),
+        CIDR(BenchColumns.column("c", JDBCType.OTHER, "cidr", null, null)),
+        MACADDR(BenchColumns.column("c", JDBCType.OTHER, "macaddr", null, null)),
+        INTERVAL(BenchColumns.column("c", JDBCType.OTHER, "interval", null, null)),
+        VARBIT(BenchColumns.column("c", JDBCType.OTHER, "varbit", 16, null)),
+        INT_ARRAY(BenchColumns.column("c", JDBCType.ARRAY, "_int4", null, null)),
+        TEXT_ARRAY(BenchColumns.column("c", JDBCType.ARRAY, "_text", null, null));
 
         private final Column column;
 

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/MetadataBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/MetadataBenchmark.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Database;
+import io.bloviate.util.DatabaseUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Cost of JDBC metadata introspection — {@link DatabaseUtils#getMetadata(Connection)}, which walks
+ * {@link java.sql.DatabaseMetaData} to build the {@link Database}/{@code Table}/{@code Column} model
+ * the fill is planned from. The end-to-end fill benchmarks fold this into total time, where it is
+ * invisible because it scales with <em>schema size</em> (table / column / FK count), not row count: on
+ * a 16-table fixture it is noise, but on a several-hundred-table schema it can dominate a small fill.
+ * This isolates it so that growth is measurable.
+ *
+ * <p>Runs against an in-memory <strong>H2</strong> database (no Docker): {@link #setup()} creates a
+ * synthetic schema of {@link #TABLES} tables, each with {@link #COLUMNS} typed columns, a primary key,
+ * and a foreign key into the previous table (a dependency chain, so the FK-metadata path is exercised
+ * too). Each measured op re-reads the full metadata. Scale the schema with {@code -Dmeta.tables} and
+ * {@code -Dmeta.columns}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class MetadataBenchmark {
+
+    /** Tables in the synthetic schema; metadata cost grows with this. */
+    private static final int TABLES = Integer.getInteger("meta.tables", 50);
+
+    /** Typed columns per table (beyond the {@code id} primary key and the {@code ref_id} foreign key). */
+    private static final int COLUMNS = Integer.getInteger("meta.columns", 16);
+
+    /** A spread of column types so {@code getColumns} returns varied type metadata, cycled per column. */
+    private static final String[] TYPES = {
+            "INTEGER", "BIGINT", "VARCHAR(64)", "VARCHAR(256)", "NUMERIC(12,2)",
+            "DOUBLE", "BOOLEAN", "TIMESTAMP", "DATE", "UUID"
+    };
+
+    private Connection connection;
+
+    @Setup(Level.Trial)
+    public void setup() throws SQLException {
+        // in-memory; DB_CLOSE_DELAY=-1 keeps the database alive for the connection's lifetime
+        connection = DriverManager.getConnection("jdbc:h2:mem:metabench;DB_CLOSE_DELAY=-1");
+        try (Statement statement = connection.createStatement()) {
+            for (int t = 0; t < TABLES; t++) {
+                statement.execute(createTableDdl(t));
+            }
+        }
+    }
+
+    @Benchmark
+    public Database getMetadata() throws SQLException {
+        return DatabaseUtils.getMetadata(connection);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    /**
+     * Builds the DDL for table {@code t}: an {@code id} primary key, {@link #COLUMNS} typed columns, and
+     * (for every table after the first) a {@code ref_id} foreign key into table {@code t-1}, forming a
+     * dependency chain.
+     */
+    private static String createTableDdl(int t) {
+        StringBuilder ddl = new StringBuilder("CREATE TABLE t").append(t).append(" (id INTEGER PRIMARY KEY");
+        for (int c = 0; c < COLUMNS; c++) {
+            ddl.append(", c").append(c).append(' ').append(TYPES[c % TYPES.length]);
+        }
+        if (t > 0) {
+            ddl.append(", ref_id INTEGER, CONSTRAINT fk_t").append(t)
+                    .append(" FOREIGN KEY (ref_id) REFERENCES t").append(t - 1).append("(id)");
+        }
+        return ddl.append(')').toString();
+    }
+}

--- a/bloviate-benchmarks/src/main/java/io/bloviate/bench/SupportResolutionBenchmark.java
+++ b/bloviate-benchmarks/src/main/java/io/bloviate/bench/SupportResolutionBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.bench;
+
+import io.bloviate.db.Column;
+import io.bloviate.ext.CockroachDBSupport;
+import io.bloviate.ext.DatabaseSupport;
+import io.bloviate.ext.DefaultSupport;
+import io.bloviate.ext.H2Support;
+import io.bloviate.ext.MariaDBSupport;
+import io.bloviate.ext.MySQLSupport;
+import io.bloviate.ext.PostgresSupport;
+import io.bloviate.ext.SQLiteSupport;
+import io.bloviate.util.RandomGenerators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.random.RandomGenerator;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Generator-<em>resolution</em> dispatch across every {@link DatabaseSupport} — the
+ * {@code getDataGenerator(column, random)} registry lookup plus builder construction that
+ * {@link io.bloviate.db.TableFiller} pays once per column when it sets a table up. {@link GeneratorBenchmark}
+ * only ever resolves through {@link PostgresSupport}; this crosses all seven supports so the per-support
+ * dispatch cost is comparable and every support's resolution path is exercised.
+ *
+ * <p>It resolves the {@linkplain BenchColumns#standardRow() portable standard-type row} only: those
+ * types resolve through the shared cross-database defaults, so every support can resolve every column
+ * and the numbers compare like-for-like. The database-specific extension types (PostgreSQL {@code uuid},
+ * {@code jsonb}, arrays, …) are not portable across supports and are covered, per type, by
+ * {@link GeneratorBenchmark}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class SupportResolutionBenchmark {
+
+    /** Fixed seed; the random is only captured by the resolved generators, not consumed during resolution. */
+    private static final long SEED = 42L;
+
+    /** Every built-in {@link DatabaseSupport}; JMH expands a value-less {@link Param} over each constant. */
+    public enum SupportCase {
+        POSTGRES(new PostgresSupport()),
+        MYSQL(new MySQLSupport()),
+        COCKROACH(new CockroachDBSupport()),
+        MARIADB(new MariaDBSupport()),
+        H2(new H2Support()),
+        SQLITE(new SQLiteSupport()),
+        DEFAULT(new DefaultSupport());
+
+        private final DatabaseSupport support;
+
+        SupportCase(DatabaseSupport support) {
+            this.support = support;
+        }
+    }
+
+    @Param
+    public SupportCase supportCase;
+
+    private List<Column> columns;
+    private RandomGenerator random;
+
+    @Setup
+    public void setup() {
+        columns = BenchColumns.standardRow();
+        random = RandomGenerators.create(SEED);
+    }
+
+    /** Resolves a generator for every column of the standard row — the per-row resolution cost. */
+    @Benchmark
+    public void resolveRow(Blackhole blackhole) {
+        DatabaseSupport support = supportCase.support;
+        for (Column column : columns) {
+            blackhole.consume(support.getDataGenerator(column, random));
+        }
+    }
+}

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -25,7 +25,7 @@ to the library.
 
 ## CPU micro-benchmarks (JMH)
 
-Pure-CPU, no Docker. The benchmarks resolve generators exactly the way `TableFiller` does
+No Docker. The benchmarks resolve generators exactly the way `TableFiller` does
 (`DatabaseSupport.getDataGenerator(column, random)`), so the numbers reflect real engine cost.
 
 - `GeneratorBenchmark` — throughput of `generate()` / `generateAsString()` across a spread of
@@ -33,6 +33,19 @@ Pure-CPU, no Docker. The benchmarks resolve generators exactly the way `TableFil
 - `RowDispatchBenchmark` — models the inner loop of `TableFiller.fill()`: the per-cell
   `generatorMap.get(column)` HashMap lookup plus `generate()` over a wide row. This is the
   baseline for the "index generators by array position" change.
+- `FileGenBenchmark` — end-to-end throughput of the flat-file subsystem
+  (`FlatFileGenerator.generate()`) writing a full file to a temp path: per-cell
+  `generateAsString()`, Commons-CSV formatting/quoting, and buffered IO. Crosses the three
+  delimited formats (`CSV`/`TDV`/`PIPE`) with cell content that is realistic (`MIXED`) or
+  constant strings that do/don't need escaping (`PLAIN`/`ESCAPED`), isolating the quoting cost.
+  Tune file size with `-Dfile.rows` (default 5,000).
+- `DatafakerBenchmark` — raw per-cell cost of the `bloviate-datafaker` realistic-value layer:
+  one `DatafakerStringGenerator.generate()` across a spread of providers (email, name, phone,
+  company, address, …), directly comparable to the type-driven generators above.
+- `DatafakerProjectionBenchmark` — the correlated row projection (one shared per-row entity
+  projected by several columns): `projectRowShared` (one `Person` build per row, the rest cache
+  hits) vs `projectRowUncorrelated` (every column rebuilds its own entity), isolating what the
+  shared-entity cache saves.
 
 Build the runnable uber-jar and run it:
 
@@ -50,6 +63,14 @@ java -jar bloviate-benchmarks/target/benchmarks.jar RowDispatchBenchmark
 # restrict GeneratorBenchmark to specific column types
 java -jar bloviate-benchmarks/target/benchmarks.jar GeneratorBenchmark.generate \
     -p genCase=UUID,VARCHAR_SHORT
+
+# flat-file write, CSV only, bigger files (JMH forks JVMs, so pass -Dfile.rows via -jvmArgsAppend)
+java -jar bloviate-benchmarks/target/benchmarks.jar FileGenBenchmark \
+    -p format=CSV -jvmArgsAppend "-Dfile.rows=50000"
+
+# realistic-value cost for a couple of Datafaker providers
+java -jar bloviate-benchmarks/target/benchmarks.jar DatafakerBenchmark \
+    -p provider=EMAIL,STREET_ADDRESS
 
 # fewer forks/iterations while iterating locally
 java -jar bloviate-benchmarks/target/benchmarks.jar -f 1 -wi 2 -i 3

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -29,7 +29,13 @@ No Docker. The benchmarks resolve generators exactly the way `TableFiller` does
 (`DatabaseSupport.getDataGenerator(column, random)`), so the numbers reflect real engine cost.
 
 - `GeneratorBenchmark` — throughput of `generate()` / `generateAsString()` across a spread of
-  column types (int, numeric, varchar, timestamp, uuid, jsonb, …).
+  column types: the common scalars (int, numeric, varchar, timestamp, uuid, jsonb, …) plus the
+  heavier structured/extension types (xml, inet, cidr, macaddr, interval, varbit, int/text arrays),
+  which are typically the most expensive cells.
+- `DistributionGeneratorBenchmark` — per-draw cost of the non-uniform *distribution* generators
+  (Zipfian, weighted-categorical, normal int/double, recency-skewed timestamp) that
+  `GeneratorBenchmark`'s uniform spread doesn't cover. Isolates the sampling overhead each shape
+  adds — e.g. the cumulative-weight binary search behind Zipfian/categorical draws.
 - `RowDispatchBenchmark` — models the inner loop of `TableFiller.fill()`: the per-cell
   `generatorMap.get(column)` HashMap lookup plus `generate()` over a wide row. This is the
   baseline for the "index generators by array position" change.
@@ -71,6 +77,10 @@ java -jar bloviate-benchmarks/target/benchmarks.jar FileGenBenchmark \
 # realistic-value cost for a couple of Datafaker providers
 java -jar bloviate-benchmarks/target/benchmarks.jar DatafakerBenchmark \
     -p provider=EMAIL,STREET_ADDRESS
+
+# just the Zipfian draws (skewed foreign-key references)
+java -jar bloviate-benchmarks/target/benchmarks.jar DistributionGeneratorBenchmark.generate \
+    -p distCase=ZIPFIAN,ZIPFIAN_STEEP
 
 # fewer forks/iterations while iterating locally
 java -jar bloviate-benchmarks/target/benchmarks.jar -f 1 -wi 2 -i 3

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -25,7 +25,8 @@ to the library.
 
 ## CPU micro-benchmarks (JMH)
 
-No Docker. The benchmarks resolve generators exactly the way `TableFiller` does
+No Docker (the metadata benchmark uses an in-process H2 database; the rest are pure CPU). Where a
+benchmark exercises type-driven generation it resolves generators exactly the way `TableFiller` does
 (`DatabaseSupport.getDataGenerator(column, random)`), so the numbers reflect real engine cost.
 
 - `GeneratorBenchmark` — throughput of `generate()` / `generateAsString()` across a spread of
@@ -52,6 +53,15 @@ No Docker. The benchmarks resolve generators exactly the way `TableFiller` does
   projected by several columns): `projectRowShared` (one `Person` build per row, the rest cache
   hits) vs `projectRowUncorrelated` (every column rebuilds its own entity), isolating what the
   shared-entity cache saves.
+- `ForeignKeyGeneratorBenchmark` — per-row cost of the cross-table key generation that
+  referentially-correct fills pay and FK-free fills don't (the reason a TPC-C row costs more than a
+  `wide` row). Models a TPC-C `orders` → `order_line` relationship with no JDBC: `parentKeyRow`
+  (composite key + child-count column) and `childKeyRow` (parent-reproducing key components + a
+  per-parent sequence number, sharing one `ChildCardinality`).
+- `MetadataBenchmark` — cost of JDBC metadata introspection (`DatabaseUtils.getMetadata`), which
+  scales with *schema size*, not row count, so it is invisible in the end-to-end row/sec numbers.
+  Runs against an in-memory H2 schema of `-Dmeta.tables` (default 50) tables × `-Dmeta.columns`
+  (default 16) columns with a foreign-key chain.
 
 Build the runnable uber-jar and run it:
 
@@ -81,6 +91,10 @@ java -jar bloviate-benchmarks/target/benchmarks.jar DatafakerBenchmark \
 # just the Zipfian draws (skewed foreign-key references)
 java -jar bloviate-benchmarks/target/benchmarks.jar DistributionGeneratorBenchmark.generate \
     -p distCase=ZIPFIAN,ZIPFIAN_STEEP
+
+# metadata introspection on a larger schema (JMH forks JVMs, so pass -D via -jvmArgsAppend)
+java -jar bloviate-benchmarks/target/benchmarks.jar MetadataBenchmark \
+    -jvmArgsAppend "-Dmeta.tables=300 -Dmeta.columns=24"
 
 # fewer forks/iterations while iterating locally
 java -jar bloviate-benchmarks/target/benchmarks.jar -f 1 -wi 2 -i 3

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -25,9 +25,10 @@ to the library.
 
 ## CPU micro-benchmarks (JMH)
 
-No Docker (the metadata benchmark uses an in-process H2 database; the rest are pure CPU). Where a
-benchmark exercises type-driven generation it resolves generators exactly the way `TableFiller` does
-(`DatabaseSupport.getDataGenerator(column, random)`), so the numbers reflect real engine cost.
+No Docker (the metadata and bind benchmarks use an in-process H2 database; the rest are pure CPU).
+Where a benchmark exercises type-driven generation it resolves generators exactly the way
+`TableFiller` does (`DatabaseSupport.getDataGenerator(column, random)`), so the numbers reflect real
+engine cost.
 
 - `GeneratorBenchmark` — throughput of `generate()` / `generateAsString()` across a spread of
   column types: the common scalars (int, numeric, varchar, timestamp, uuid, jsonb, …) plus the
@@ -62,6 +63,14 @@ benchmark exercises type-driven generation it resolves generators exactly the wa
   scales with *schema size*, not row count, so it is invisible in the end-to-end row/sec numbers.
   Runs against an in-memory H2 schema of `-Dmeta.tables` (default 50) tables × `-Dmeta.columns`
   (default 16) columns with a foreign-key chain.
+- `SupportResolutionBenchmark` — generator *resolution* dispatch (`getDataGenerator`: registry lookup
+  + builder construction) across all seven `DatabaseSupport` implementations, over a portable
+  standard-type row. `GeneratorBenchmark` only resolves through PostgreSQL; this compares the
+  per-support dispatch cost and exercises every support's resolution path.
+- `BindBenchmark` — the real per-cell bind in `TableFiller.fill()`
+  (`generateAndSet(connection, ps, col)`), isolated from the database round-trip by binding into an
+  in-memory H2 `PreparedStatement` and never executing it. Compared with `RowDispatchBenchmark`
+  (generation only), the delta is the JDBC parameter-binding cost the wire normally hides.
 
 Build the runnable uber-jar and run it:
 
@@ -95,6 +104,11 @@ java -jar bloviate-benchmarks/target/benchmarks.jar DistributionGeneratorBenchma
 # metadata introspection on a larger schema (JMH forks JVMs, so pass -D via -jvmArgsAppend)
 java -jar bloviate-benchmarks/target/benchmarks.jar MetadataBenchmark \
     -jvmArgsAppend "-Dmeta.tables=300 -Dmeta.columns=24"
+
+# resolution dispatch for a couple of supports, and the isolated JDBC bind cost
+java -jar bloviate-benchmarks/target/benchmarks.jar SupportResolutionBenchmark \
+    -p supportCase=POSTGRES,MYSQL
+java -jar bloviate-benchmarks/target/benchmarks.jar BindBenchmark
 
 # fewer forks/iterations while iterating locally
 java -jar bloviate-benchmarks/target/benchmarks.jar -f 1 -wi 2 -i 3


### PR DESCRIPTION
## Description

Closes coverage gaps in the `bloviate-benchmarks` module. The existing suite measured per-cell generation, row dispatch, and end-to-end fills, but several substantial subsystems and per-cell hot paths had no benchmark at all. This adds seven JMH benchmarks (all no-Docker; two use an in-process H2 database) and broadens the existing generator spread.

New benchmarks:
- **`FileGenBenchmark`** — flat-file subsystem (`FlatFileGenerator.generate()`) across CSV/TDV/PIPE, with realistic vs plain vs escape-forcing content to isolate Commons-CSV quoting cost.
- **`DatafakerBenchmark`** — raw per-cell realistic-value throughput across the providers the name-pattern plugin wires.
- **`DatafakerProjectionBenchmark`** — the correlated row projection (`projectRowShared` vs `projectRowUncorrelated`), isolating what the shared-entity cache saves.
- **`DistributionGeneratorBenchmark`** — per-draw cost of the non-uniform distribution generators (Zipfian, weighted-categorical, normal int/double, recency-skewed timestamp).
- **`ForeignKeyGeneratorBenchmark`** — cross-table key generation (TPC-C `orders` → `order_line`, no JDBC): the per-row cost referentially-correct fills pay and FK-free fills don't.
- **`MetadataBenchmark`** — `DatabaseUtils.getMetadata` introspection, which scales with schema size, not row count (in-memory H2).
- **`SupportResolutionBenchmark`** — `getDataGenerator` resolution dispatch across all seven `DatabaseSupport` implementations.
- **`BindBenchmark`** — the real per-cell `generateAndSet` from `TableFiller.fill()`, isolated from the database round-trip via an in-memory H2 `PreparedStatement` (never executed).

Also: extended `GeneratorBenchmark`'s spread with the structured/extension types (xml, inet, cidr, macaddr, interval, varbit, int/text arrays); added a shared portable-row helper to `BenchColumns`; wired `bloviate-datafaker` and in-memory H2 into the benchmarks pom; documented every new benchmark in `docs/BENCHMARKS.md`.

Only the `bloviate-benchmarks` module is touched (plus its docs). The published artifacts (`bloviate-core`, `bloviate-junit`, `bloviate-testcontainers`, `bloviate-datafaker`) are unchanged.

## Related Issues

None — extends the benchmark suite that backs the issue #447 fill-optimization work.

## Type of Change

- [x] `docs` / `test` / `ci` / `chore` / `style` — no release (`test`)

## Affected Module(s)

- [x] Build / CI / tooling (`bloviate-benchmarks` — measurement harness, never published)

## How Has This Been Tested?

⚠️ **Not compiled or run in this environment.** The project targets `maven.compiler.release=25`, but the environment used to author these changes only had JDK 21, so `./mvnw verify` could not run. Each benchmark was instead verified by source-level review against the actual APIs it calls (builder signatures and return types, `DatabaseSupport.getDataGenerator` / `DataGenerator.generateAndSet`, the H2 setup mirroring `H2FillerTest`'s working in-memory pattern, and that the standard-type defaults resolve across every support). **CI on JDK 25 will be the first real compile — please confirm the build there.**

These are opt-in measurement harnesses: the JMH classes only run via the `benchmarks.jar` uber-jar, and nothing in a normal `./mvnw verify` of the published modules depends on them.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://conventionalcommits.org/) format
- [ ] `./mvnw verify` passes locally (tests included) — see note above; not run (JDK 21 vs required 25)
- [x] I have added or updated tests covering my changes (JMH benchmarks)
- [x] I have updated documentation as needed (`docs/BENCHMARKS.md`)
- [x] My changes follow the existing code style and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtvHNTFvyRRivQNfSpz6XG)_