### PR TITLE
fix(gen): render array generators as PostgreSQL array literals in generateAsString

### DIFF
--- a/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntegerArrayGenerator.java
@@ -17,6 +17,7 @@
 package io.bloviate.gen;
 
 import java.sql.*;
+import java.util.StringJoiner;
 import java.util.random.RandomGenerator;
 
 /**
@@ -40,6 +41,22 @@ public class IntegerArrayGenerator extends AbstractDataGenerator<Integer[]> {
 
         return randomArray;
 
+    }
+
+    /**
+     * Renders the generated array as a PostgreSQL array literal — e.g. {@code {1,-42,7}} — so
+     * flat-file output (the only consumer of {@code generateAsString}) carries the element values
+     * rather than an {@code Integer[]} identity string.
+     */
+    @Override
+    public String generateAsString() {
+        StringJoiner joiner = new StringJoiner(",", "{", "}");
+
+        for (Integer element : generate()) {
+            joiner.add(element == null ? "NULL" : element.toString());
+        }
+
+        return joiner.toString();
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/StringArrayGenerator.java
@@ -17,6 +17,7 @@
 package io.bloviate.gen;
 
 import java.sql.*;
+import java.util.StringJoiner;
 import java.util.random.RandomGenerator;
 
 /**
@@ -44,9 +45,21 @@ public class StringArrayGenerator extends AbstractDataGenerator<String[]> {
 
     }
 
+    /**
+     * Renders the generated array as a PostgreSQL array literal — e.g. {@code {abc,def,ghi}} —
+     * so flat-file output (the only consumer of {@code generateAsString}) carries the element
+     * values rather than a {@code String[]} identity string. Elements are plain alphabetic
+     * strings, so no element quoting or escaping is required.
+     */
     @Override
     public String generateAsString() {
-        return null;
+        StringJoiner joiner = new StringJoiner(",", "{", "}");
+
+        for (String element : generate()) {
+            joiner.add(element == null ? "NULL" : element);
+        }
+
+        return joiner.toString();
     }
 
     @Override

--- a/bloviate-core/src/test/java/io/bloviate/gen/ArrayGeneratorAsStringTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/ArrayGeneratorAsStringTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for {@code generateAsString()} on the array generators — the form used for
+ * flat-file output. Previously {@link StringArrayGenerator} returned {@code null} (empty cell) and
+ * {@link IntegerArrayGenerator} inherited {@code Integer[].toString()} (a Java identity string such
+ * as {@code [Ljava.lang.Integer;@5a07e868}), so array columns were silently broken in CSV/TSV/pipe
+ * output. Both must now emit a PostgreSQL array literal carrying the element values.
+ */
+class ArrayGeneratorAsStringTest {
+
+    @Test
+    void integerArrayRendersAsPostgresArrayLiteral() {
+        IntegerArrayGenerator generator = new IntegerArrayGenerator.Builder(new Random())
+                .length(5).build();
+
+        for (int i = 0; i < 200; i++) {
+            String value = generator.generateAsString();
+
+            assertNotNull(value, "generateAsString must not be null");
+            assertFalse(value.contains("[L") || value.contains("@"),
+                    "must not be a Java array identity string: " + value);
+            assertTrue(value.startsWith("{") && value.endsWith("}"),
+                    "expected a {..} array literal: " + value);
+
+            String[] elements = value.substring(1, value.length() - 1).split(",");
+            assertEquals(5, elements.length, "expected 5 elements: " + value);
+            for (String element : elements) {
+                assertDoesNotThrow(() -> Integer.parseInt(element),
+                        "each element must be an integer: " + value);
+            }
+        }
+    }
+
+    @Test
+    void stringArrayRendersAsPostgresArrayLiteral() {
+        StringArrayGenerator generator = new StringArrayGenerator.Builder(new Random())
+                .length(4).elementLength(8).build();
+
+        for (int i = 0; i < 200; i++) {
+            String value = generator.generateAsString();
+
+            assertNotNull(value, "generateAsString must not be null");
+            assertFalse(value.contains("[L") || value.contains("@"),
+                    "must not be a Java array identity string: " + value);
+            assertTrue(value.startsWith("{") && value.endsWith("}"),
+                    "expected a {..} array literal: " + value);
+
+            String[] elements = value.substring(1, value.length() - 1).split(",");
+            assertEquals(4, elements.length, "expected 4 elements: " + value);
+            for (String element : elements) {
+                assertEquals(8, element.length(), "each element keeps its length: " + value);
+                assertTrue(element.chars().allMatch(Character::isLetter),
+                        "each element is alphabetic: " + value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

`generateAsString()` is the form used for flat-file output (`FlatFileGenerator` is its only consumer). Two array generators produced broken output there:

| Generator | Before | After |
|-----------|--------|-------|
| `StringArrayGenerator` | `null` (empty cell) | `{abc,def,ghi}` |
| `IntegerArrayGenerator` | inherited `Integer[].toString()` → `[Ljava.lang.Integer;@5a07e868` | `{1,-42,7}` |

So **every CSV/TSV/pipe file with an array column was silently broken** — empty cells for text arrays, Java identity-string garbage for integer arrays. Both now emit a PostgreSQL array literal carrying the element values (the natural target, since these are PostgreSQL array types and the file is meant for bulk loading), with a `NULL` guard for null elements.

Verified output:
```
int[]  -> {-1170105035,234785527,-1360544799,205897768}
text[] -> {aRNqDp,aaIgUE,wiLZor}
```

## Related Issues

Surfaced by the new array-type coverage in the benchmark suite (#527) — `TEXT_ARRAY`'s `generateAsString` benchmarked absurdly fast because it returned `null` and did no work. The fix itself is in `bloviate-core` and independent of #527.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Affected Module(s)

- [x] `bloviate-core`

## How Has This Been Tested?

New `ArrayGeneratorAsStringTest` (2 tests × 200 iterations) asserts both generators produce a valid `{..}` literal with the correct element count and typed contents, and explicitly that the output is **neither `null` nor a Java array identity string** (`[L` / `@`) — so neither regression can return.

Run on JDK 25: the new test, `FlatFileTest`, and the existing string-generator tests all pass (`bloviate-core` targeted run). I did **not** run the full `./mvnw verify` (Testcontainers integration suite) locally — CI covers that.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://conventionalcommits.org/) format
- [ ] `./mvnw verify` passes locally — ran targeted unit tests on JDK 25; full verify deferred to CI
- [x] I have added or updated tests covering my changes
- [x] My changes follow the existing code style and conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)