### PR TITLE
fix(engine): harden fill engine against memory/resource issues at scale (#526)

### DIFF
--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseConfiguration.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseConfiguration.java
@@ -44,7 +44,7 @@ import java.util.Set;
  * {@link io.bloviate.util.DatabaseUtils#columnSeed(Column, long)} for how per-column seeds are
  * derived.
  *
- * @param batchSize the number of rows to include in each batch INSERT operation
+ * @param batchSize the number of rows to include in each batch INSERT operation; must be {@code >= 1}
  * @param defaultRowCount the default number of rows to generate for each table
  * @param databaseSupport the database-specific support implementation
  * @param tableConfigurations optional per-table configuration overrides
@@ -73,6 +73,9 @@ public record DatabaseConfiguration(int batchSize, long defaultRowCount, Databas
      * applies whenever a caller does not specify them.
      */
     public DatabaseConfiguration {
+        if (batchSize < 1) {
+            throw new IllegalArgumentException("batchSize must be >= 1: " + batchSize);
+        }
         if (commitStrategy == null) {
             commitStrategy = CommitStrategy.connectionDefault();
         }

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -270,10 +270,12 @@ public class DatabaseFiller implements Fillable {
         DatabaseSupport support = configuration.databaseSupport();
 
         // probe once: if we can't disable+re-enable constraints on a borrowed connection, fall back to
-        // the ordered path instead of fanning out into a partially-disabled state
+        // the ordered path instead of fanning out into a partially-disabled state. As in the worker
+        // bodies, a failed re-enable aborts the connection rather than returning it to the pool still
+        // in its constraint-disabled state (see restoreConstraints).
         try (Connection conn = dataSource.getConnection()) {
             BulkLoadHandle handle = support.disableConstraints(conn, database);
-            support.enableConstraints(conn, database, handle);
+            restoreConstraints(support, conn, database, handle);
         } catch (BulkLoadUnsupportedException e) {
             logger.warn("UNORDERED_BULK requested but constraints could not be disabled ({}); "
                     + "falling back to the ordered level-parallel path", e.getMessage());
@@ -415,8 +417,9 @@ public class DatabaseFiller implements Fillable {
      * Borrows a connection from the pool and runs {@code body} on it. When {@code bulk} is true,
      * foreign-key enforcement is disabled on the connection's session before {@code body} and restored
      * in a {@code finally} <em>before</em> the connection returns to the pool — so a constraint-disabled
-     * connection never leaks to other pool users, even if the fill throws. The disable/enable mechanism
-     * is database-specific (see {@link DatabaseSupport#disableConstraints}).
+     * connection never leaks to other pool users, even if the fill throws. If the restore itself fails,
+     * the connection is aborted rather than returned to the pool (see {@link #restoreConstraints}). The
+     * disable/enable mechanism is database-specific (see {@link DatabaseSupport#disableConstraints}).
      */
     private void fillOnPooledConnection(Database database, boolean bulk, ConnectionFill body) throws SQLException {
         DatabaseSupport support = configuration.databaseSupport();
@@ -426,9 +429,33 @@ public class DatabaseFiller implements Fillable {
                 body.fill(conn);
             } finally {
                 if (bulk) {
-                    support.enableConstraints(conn, database, handle);
+                    restoreConstraints(support, conn, database, handle);
                 }
             }
+        }
+    }
+
+    /**
+     * Re-enables the foreign-key enforcement that {@link DatabaseSupport#disableConstraints} turned off
+     * on {@code conn}. If the restore itself fails, the connection is still in its constraint-disabled
+     * session state (e.g. PostgreSQL {@code session_replication_role=replica}); connection pools do not
+     * reset arbitrary session variables on return, so returning it would silently skip FK enforcement
+     * for whatever borrows it next. To prevent that, the connection is {@link Connection#abort aborted}
+     * so the pool discards the physical connection instead of reusing it, and the failure is rethrown
+     * loudly rather than swallowed.
+     */
+    private void restoreConstraints(DatabaseSupport support, Connection conn, Database database, BulkLoadHandle handle) throws SQLException {
+        try {
+            support.enableConstraints(conn, database, handle);
+        } catch (SQLException e) {
+            logger.error("failed to re-enable constraints [{}] on a bulk-load connection; aborting it so the "
+                    + "constraint-disabled session is not returned to the pool", handle, e);
+            try {
+                conn.abort(Runnable::run);
+            } catch (SQLException abortFailure) {
+                e.addSuppressed(abortFailure);
+            }
+            throw e;
         }
     }
 

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -47,7 +47,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -84,6 +86,22 @@ import java.util.concurrent.Future;
 public class DatabaseFiller implements Fillable {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseFiller.class);
+
+    /**
+     * The commit cadence the parallel/bulk path uses when the caller leaves the commit strategy on
+     * {@link CommitStrategy.Mode#CONNECTION_DEFAULT}: commit every this-many JDBC batches rather than
+     * once per whole table/partition. This bounds the size of an open server-side transaction (WAL/undo
+     * growth and lock accumulation) on a very large partition, which a single per-table commit would
+     * not. See {@link #effectiveParallelCommitStrategy()}.
+     */
+    private static final int DEFAULT_PARALLEL_COMMIT_BATCHES = 64;
+
+    /**
+     * The largest DOT graph (in characters) for which {@link #visualizeGraph} renders a GraphvizOnline
+     * link at INFO. Beyond this the URL-encoded link (encoding can roughly triple the length) is too
+     * long to be useful, so the link is skipped and only the DOT itself is logged at DEBUG.
+     */
+    private static final int MAX_GRAPH_LINK_CHARS = 8_000;
 
     /** A caller-managed connection for the sequential path; null when filling from a {@link DataSource}. */
     private final Connection connection;
@@ -233,10 +251,10 @@ public class DatabaseFiller implements Fillable {
                     addTableTasks(tasks, database, table, false);
                 }
 
-                // barrier: every table in this level must finish before the next level may start
-                for (Future<Void> future : executor.invokeAll(tasks)) {
-                    awaitFuture(future);
-                }
+                // barrier: every table in this level must finish before the next level may start.
+                // Submitted with backpressure so queued tasks stay bounded even for a level whose
+                // tables carry a large partition count (see runWithBackpressure).
+                runWithBackpressure(executor, tasks, poolSize);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -296,9 +314,9 @@ public class DatabaseFiller implements Fillable {
                 graph.vertexSet().size(), poolSize);
 
         try (ExecutorService executor = Executors.newFixedThreadPool(poolSize)) {
-            for (Future<Void> future : executor.invokeAll(tasks)) {
-                awaitFuture(future);
-            }
+            // submitted with backpressure so queued tasks stay bounded even when the schema (or a
+            // partitioned table) produces far more tasks than worker threads (see runWithBackpressure)
+            runWithBackpressure(executor, tasks, poolSize);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new SQLException("bulk table fill was interrupted", e);
@@ -326,6 +344,35 @@ public class DatabaseFiller implements Fillable {
         }
         logger.warn("JDBC driver batch rewrite is not enabled; add '{}=true' to the JDBC URL for a "
                 + "potentially large fill speedup (see io.bloviate.util.JdbcUrls#withBatchRewrite)", parameter);
+    }
+
+    /**
+     * Runs every task on {@code executor} but keeps at most {@code ~2 × poolSize} in flight at once,
+     * draining a completed task before submitting the next. This bounds the executor's work queue (and
+     * the outstanding {@link Future}s) to a small multiple of the pool size rather than letting them
+     * scale with the total task count — important when a large {@code partitions} value (or many
+     * partitioned tables) produces far more tasks than worker threads, which an eager
+     * {@code invokeAll(allTasks)} would queue all at once. All tasks still complete before this returns,
+     * preserving the level barrier in {@link #fillParallel}. The first task failure is rethrown; the
+     * surrounding {@code try-with-resources} on the executor then drains the in-flight tasks on close.
+     */
+    private void runWithBackpressure(ExecutorService executor, List<Callable<Void>> tasks, int poolSize) throws SQLException, InterruptedException {
+        CompletionService<Void> completionService = new ExecutorCompletionService<>(executor);
+        int inFlightCap = Math.max(1, 2 * poolSize);
+        int next = 0;
+
+        // prime the pipeline up to the in-flight cap
+        while (next < tasks.size() && next < inFlightCap) {
+            completionService.submit(tasks.get(next++));
+        }
+
+        // for each completion, surface any failure and top the pipeline back up
+        for (int completed = 0; completed < tasks.size(); completed++) {
+            awaitFuture(completionService.take());
+            if (next < tasks.size()) {
+                completionService.submit(tasks.get(next++));
+            }
+        }
     }
 
     /** Unwraps a worker future, re-throwing the underlying {@link SQLException} or runtime failure. */
@@ -512,14 +559,18 @@ public class DatabaseFiller implements Fillable {
 
     /**
      * The commit strategy used by parallel workers. A pooled worker connection must not be left on
-     * the connection's autocommit (that would commit per batch and lose the per-table transaction),
-     * so {@link CommitStrategy.Mode#CONNECTION_DEFAULT} maps to {@link CommitStrategy#perTable()};
-     * any explicitly configured strategy (e.g. {@link CommitStrategy#everyNBatches(int)}) is honored.
+     * the connection's autocommit (that would commit per batch and lose the engine-managed
+     * transaction), so {@link CommitStrategy.Mode#CONNECTION_DEFAULT} maps to a bounded
+     * {@link CommitStrategy#everyNBatches(int)} of {@value #DEFAULT_PARALLEL_COMMIT_BATCHES} batches
+     * rather than {@link CommitStrategy#perTable()}: a single per-table commit would hold an entire
+     * large partition open in one server-side transaction (unbounded WAL/undo growth and lock
+     * accumulation), which is the scale failure the parallel/bulk path most needs to avoid. Any
+     * explicitly configured strategy (including {@link CommitStrategy#perTable()}) is honored as-is.
      */
     private CommitStrategy effectiveParallelCommitStrategy() {
         CommitStrategy configured = configuration.commitStrategy();
         return configured.mode() == CommitStrategy.Mode.CONNECTION_DEFAULT
-                ? CommitStrategy.perTable()
+                ? CommitStrategy.everyNBatches(DEFAULT_PARALLEL_COMMIT_BATCHES)
                 : configured;
     }
 
@@ -649,6 +700,13 @@ public class DatabaseFiller implements Fillable {
      * @param databaseName the name of the database for graph labeling
      */
     private void visualizeGraph(Graph<Table, DefaultEdge> graph, String databaseName) {
+        // both the DOT string and the (longer) URL-encoded link are schema-scaled allocations; skip
+        // them entirely when neither level that consumes them is enabled
+        boolean info = logger.isInfoEnabled();
+        if (!info && !logger.isDebugEnabled()) {
+            return;
+        }
+
         DOTExporter<Table, DefaultEdge> exporter = new DOTExporter<>(Table::name);
         exporter.setVertexAttributeProvider((v) -> {
             Map<String, Attribute> map = new LinkedHashMap<>();
@@ -664,6 +722,18 @@ public class DatabaseFiller implements Fillable {
         String graphAsString = writer.toString();
 
         logger.debug("database graph in DOT notation:\n\n{}", graphAsString);
+
+        if (!info) {
+            return;
+        }
+
+        // for a very large schema the URL-encoded DOT is too long to be a usable link; skip the
+        // encode (which can roughly triple the length) and point the reader at the DEBUG DOT instead
+        if (graphAsString.length() > MAX_GRAPH_LINK_CHARS) {
+            logger.info("database graph has {} chars of DOT notation — too large for a GraphvizOnline link; "
+                    + "enable DEBUG logging for {} to see the DOT itself", graphAsString.length(), DatabaseFiller.class.getName());
+            return;
+        }
 
         String encodedDiagram = URLEncoder.encode(graphAsString, StandardCharsets.UTF_8).replace("+", "%20");
 

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -229,6 +229,9 @@ public class TableFiller implements Fillable {
             connection.setAutoCommit(false);
         }
 
+        // captures a fill/rollback failure so autocommit restore (below) can attach to it rather than
+        // replace it; null when the fill succeeds
+        SQLException failure = null;
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
 
             if (partitioned) {
@@ -262,6 +265,11 @@ public class TableFiller implements Fillable {
 
                 if (++produced % batchSize == 0) {
                     ps.executeBatch();
+                    // explicit clearBatch after executeBatch: the JDBC spec already clears the batch,
+                    // but this makes the O(batchSize) in-flight bound explicit and is cheap insurance
+                    // against drivers / rewriteBatchedInserts paths that might otherwise retain the
+                    // submitted row references
+                    ps.clearBatch();
                     if (commitStrategy.mode() == CommitStrategy.Mode.EVERY_N_BATCHES
                             && ++batchesSinceCommit % commitStrategy.batches() == 0) {
                         connection.commit();
@@ -270,26 +278,69 @@ public class TableFiller implements Fillable {
             }
 
             ps.executeBatch();
+            ps.clearBatch();
 
             if (manageTransaction) {
                 // commit the final partial batch (and any whole batches not yet committed under EVERY_N_BATCHES)
                 connection.commit();
             }
         } catch (SQLException e) {
+            failure = e;
             if (manageTransaction) {
-                connection.rollback();
+                // roll back, but never let a rollback failure replace the original cause
+                try {
+                    connection.rollback();
+                } catch (SQLException rollbackFailure) {
+                    e.addSuppressed(rollbackFailure);
+                }
             }
-            throw e;
-        } finally {
-            if (manageTransaction) {
-                connection.setAutoCommit(previousAutoCommit);
-            }
+        }
+
+        // restore autocommit outside the try/finally so a restore failure can neither mask a primary
+        // fill exception nor return a wrong-state connection to the pool (see restoreAutoCommit)
+        if (manageTransaction) {
+            failure = restoreAutoCommit(previousAutoCommit, failure);
+        }
+
+        if (failure != null) {
+            throw failure;
         }
 
         tableWatch.stop();
 
         logger.debug("{}", tableWatch);
 
+    }
+
+    /**
+     * Restores the connection's prior autocommit setting after an engine-managed transaction. A failure
+     * here must neither replace a primary fill exception nor return a connection in an unknown
+     * autocommit state to the pool, so on failure the connection is {@link Connection#abort aborted}
+     * (the pool then discards it) and the restore failure is attached to {@code primary} when one
+     * exists, or becomes the failure to throw otherwise.
+     *
+     * @param previousAutoCommit the autocommit value to restore
+     * @param primary            the in-flight fill failure, or null if the fill succeeded
+     * @return the exception the caller should throw (possibly {@code primary}), or null if none
+     */
+    private SQLException restoreAutoCommit(boolean previousAutoCommit, SQLException primary) {
+        try {
+            connection.setAutoCommit(previousAutoCommit);
+            return primary;
+        } catch (SQLException restoreFailure) {
+            logger.error("failed to restore autocommit [{}] after fill; aborting the connection so it is "
+                    + "not reused in an unknown transaction state", previousAutoCommit, restoreFailure);
+            try {
+                connection.abort(Runnable::run);
+            } catch (SQLException abortFailure) {
+                restoreFailure.addSuppressed(abortFailure);
+            }
+            if (primary != null) {
+                primary.addSuppressed(restoreFailure);
+                return primary;
+            }
+            return restoreFailure;
+        }
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/file/FlatFileGenerator.java
@@ -104,7 +104,7 @@ public class FlatFileGenerator implements FileGenerator {
 
             printHeader(csvPrinter);
 
-            for (int i = 0; i < rows; i++) {
+            for (long i = 0; i < rows; i++) {
                 for (ColumnDefinition columnDefinition : columnDefinitions) {
                     csvPrinter.print(columnDefinition.dataGenerator().generateAsString());
                 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
@@ -43,7 +43,8 @@ public class BitStringGenerator extends AbstractDataGenerator<String> {
         // bit string. Clamp to the range [1, 25].
         int maxSize = Math.clamp(size, 1, 25);
 
-        StringBuilder builder = new StringBuilder();
+        // pre-size to the exact bit count so the buffer never has to grow/recopy
+        StringBuilder builder = new StringBuilder(maxSize);
 
         for (int i = 0; i < maxSize; i++) {
             builder.append(bitGenerator.generate());

--- a/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ZipfianIntegerGenerator.java
@@ -37,6 +37,15 @@ import java.util.random.RandomGenerator;
  */
 public class ZipfianIntegerGenerator extends AbstractDataGenerator<Integer> {
 
+    /**
+     * The largest supported {@link Builder#size(int)}. Construction precomputes a cumulative table of
+     * {@code size} {@code double}s ({@code 8 * size} bytes), so an unbounded {@code size} would OOM the
+     * JVM at construction time (e.g. {@code size = 2_000_000_000} would request ~16&nbsp;GB). This cap
+     * keeps the table to ~400&nbsp;MB and fails fast with a clear message above it; the distribution is
+     * intended for value spaces of thousands to low millions anyway.
+     */
+    public static final int MAX_SIZE = 50_000_000;
+
     private final int start;
     private final double[] cumulativeWeights;
     private final double totalWeight;
@@ -86,7 +95,7 @@ public class ZipfianIntegerGenerator extends AbstractDataGenerator<Integer> {
         }
 
         /**
-         * The number of distinct values; required and must be {@code >= 1}.
+         * The number of distinct values; required and must be in {@code [1, }{@link #MAX_SIZE}{@code ]}.
          *
          * @param size the count of distinct ranks
          * @return this builder, for chaining
@@ -111,6 +120,9 @@ public class ZipfianIntegerGenerator extends AbstractDataGenerator<Integer> {
         public ZipfianIntegerGenerator build() {
             if (size < 1) {
                 throw new IllegalArgumentException("size must be >= 1: " + size);
+            }
+            if (size > MAX_SIZE) {
+                throw new IllegalArgumentException("size must be <= " + MAX_SIZE + ": " + size);
             }
             if (exponent < 0) {
                 throw new IllegalArgumentException("exponent must be non-negative: " + exponent);

--- a/bloviate-core/src/main/java/io/bloviate/util/DatabaseUtils.java
+++ b/bloviate-core/src/main/java/io/bloviate/util/DatabaseUtils.java
@@ -17,6 +17,8 @@
 package io.bloviate.util;
 
 import io.bloviate.db.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.sql.*;
@@ -49,6 +51,8 @@ import java.util.*;
  * @see DatabaseFiller
  */
 public class DatabaseUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseUtils.class);
 
     /** Static utility holder — not instantiable. */
     private DatabaseUtils() {
@@ -320,6 +324,23 @@ public class DatabaseUtils {
      * @return the root primary key column, or null if no foreign key relationship exists
      */
     public static Column getAssociatedPrimaryKeyColumn(Database database, Table table, Column column) {
+        return getAssociatedPrimaryKeyColumn(database, table, column, new HashSet<>());
+    }
+
+    /**
+     * Cycle-safe implementation of {@link #getAssociatedPrimaryKeyColumn(Database, Table, Column)}.
+     * {@code visited} accumulates the columns already resolved on the current foreign-key chain (a
+     * {@link Column} carries its owning table name, so it identifies a table/column pair); if one
+     * recurs (a circular FK schema, e.g. A&rarr;B&rarr;A) the traversal stops and returns {@code null}
+     * instead of recursing without bound to a {@link StackOverflowError}.
+     */
+    private static Column getAssociatedPrimaryKeyColumn(Database database, Table table, Column column, Set<Column> visited) {
+
+        if (!visited.add(column)) {
+            logger.warn("circular foreign-key reference detected at [{}.{}]; stopping primary-key resolution",
+                    table.name(), column.name());
+            return null;
+        }
 
         // get this tables foreign keys
         List<ForeignKey> foreignKeys = table.foreignKeys();
@@ -354,7 +375,7 @@ public class DatabaseUtils {
 
                                 Column primaryKeyColumnColumn = primaryKeyColumn.column();
 
-                                Column possibleRoot = getAssociatedPrimaryKeyColumn(database, primaryTable, primaryKeyColumnColumn);
+                                Column possibleRoot = getAssociatedPrimaryKeyColumn(database, primaryTable, primaryKeyColumnColumn, visited);
 
                                 if (possibleRoot != null) {
                                     return possibleRoot;

--- a/bloviate-core/src/test/java/io/bloviate/db/DatabaseConfigurationTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/DatabaseConfigurationTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.JDBCType;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DatabaseConfigurationTest {
 
@@ -44,5 +46,19 @@ class DatabaseConfigurationTest {
         DatabaseConfiguration configuration = new DatabaseConfiguration(128, 100, new DefaultSupport(), null, registry);
 
         assertSame(registry, configuration.generatorRegistry());
+    }
+
+    @Test
+    void rejectsZeroBatchSize() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new DatabaseConfiguration(0, 100, new DefaultSupport(), null));
+
+        assertEquals("batchSize must be >= 1: 0", e.getMessage());
+    }
+
+    @Test
+    void rejectsNegativeBatchSize() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new DatabaseConfiguration(-5, 100, new DefaultSupport(), null));
     }
 }

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadRestoreFailureTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresBulkLoadRestoreFailureTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.BulkLoadHandle;
+import io.bloviate.ext.PostgresSupport;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the bulk-load failure path: when re-enabling constraints throws, the borrowed connection is
+ * still in its constraint-disabled session state ({@code session_replication_role = replica}) and must
+ * not be returned to the pool, or whatever borrows it next would silently skip foreign-key enforcement
+ * (issue #526, H2). The fix aborts the physical connection so the pool discards it.
+ *
+ * <p>The pool is capped at a single connection, so the connection re-borrowed after the failed fill is
+ * necessarily the same physical one the fill poisoned — had it been returned rather than aborted, the
+ * assertion below would observe {@code replica}.
+ */
+class PostgresBulkLoadRestoreFailureTest extends BaseDatabaseTestCase {
+
+    /** A {@link PostgresSupport} whose constraint restore always fails, simulating a transient error. */
+    private static final class RestoreFailingSupport extends PostgresSupport {
+        @Override
+        public void enableConstraints(Connection connection, Database database, BulkLoadHandle handle) throws SQLException {
+            throw new SQLException("simulated failure re-enabling constraints");
+        }
+    }
+
+    @Test
+    void abortsConnectionWhenConstraintRestoreFails() throws SQLException {
+        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
+                .withDatabaseName("bloviate")) {
+
+            database.start();
+
+            HikariConfig hikariConfig = new HikariConfig();
+            hikariConfig.setJdbcUrl(database.getJdbcUrl());
+            hikariConfig.setUsername(database.getUsername());
+            hikariConfig.setPassword(database.getPassword());
+            hikariConfig.setDriverClassName(database.getDriverClassName());
+            // a single connection: the one re-borrowed after the fill is the very one the fill used
+            hikariConfig.setMaximumPoolSize(1);
+
+            try (HikariDataSource dataSource = new HikariDataSource(hikariConfig)) {
+
+                try (Connection connection = dataSource.getConnection();
+                     Statement statement = connection.createStatement()) {
+                    statement.execute("create table widget (id integer primary key, label varchar(32))");
+                }
+
+                DatabaseConfiguration configuration = new DatabaseConfiguration(
+                        16, 10, new RestoreFailingSupport(), null, 42L, null, BulkLoadStrategy.unorderedBulk());
+
+                // the restore failure must surface, not be swallowed
+                assertThrows(SQLException.class, () ->
+                        new DatabaseFiller.Builder(dataSource, configuration).threads(2).build().fill());
+
+                // the poisoned connection must have been discarded: a freshly borrowed connection from
+                // the size-1 pool reports the restored role, not the bulk-load 'replica' state
+                try (Connection connection = dataSource.getConnection();
+                     Statement statement = connection.createStatement();
+                     ResultSet resultSet = statement.executeQuery("show session_replication_role")) {
+                    resultSet.next();
+                    assertEquals("origin", resultSet.getString(1),
+                            "a connection whose constraint restore failed must not be returned to the pool");
+                }
+            }
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/PostgresPartitionBackpressureTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/PostgresPartitionBackpressureTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.bloviate.ext.PostgresSupport;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Set;
+
+/**
+ * Verifies the bounded, backpressured task submission on the parallel path (issue #526, M4): when a
+ * table is split into far more partitions than there are worker threads, every partition task must
+ * still run to completion even though only a small multiple of the pool size is ever in flight at once
+ * (see {@code DatabaseFiller#runWithBackpressure}). A dropped or never-submitted task would leave the
+ * table short of its configured row count.
+ */
+class PostgresPartitionBackpressureTest extends BaseDatabaseTestCase {
+
+    private static final long ROWS = 100;
+    private static final int PARTITIONS = 16; // >> 2 * threads, so the submission loop must refill
+    private static final int THREADS = 2;
+
+    @Test
+    void everyPartitionRunsWhenPartitionsFarExceedThreads() throws SQLException {
+        try (PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:18-alpine")
+                .withDatabaseName("bloviate")) {
+
+            database.start();
+
+            try (HikariDataSource dataSource = (HikariDataSource) getDataSource(database)) {
+
+                try (Connection connection = dataSource.getConnection();
+                     Statement statement = connection.createStatement()) {
+                    statement.execute("create table widget (id integer)");
+                }
+
+                Set<TableConfiguration> tables = Set.of(new TableConfiguration("widget", ROWS, PARTITIONS));
+                DatabaseConfiguration configuration = new DatabaseConfiguration(8, 0, new PostgresSupport(), tables);
+
+                new DatabaseFiller.Builder(dataSource, configuration).threads(THREADS).build().fill();
+
+                // all PARTITIONS range tasks ran: the partitions sum back to exactly ROWS
+                try (Connection connection = dataSource.getConnection()) {
+                    assertRowCount(connection, "widget", ROWS);
+                }
+            }
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/TableFillerAutoCommitRestoreTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/TableFillerAutoCommitRestoreTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import io.bloviate.ext.H2Support;
+import io.bloviate.util.DatabaseUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies the {@link TableFiller} autocommit-restore failure path (issue #526, L2): when the engine
+ * manages the transaction and restoring the connection's prior autocommit setting throws, that failure
+ * must surface rather than be swallowed, and the connection — now in an unknown transaction state —
+ * must be aborted so a pool discards it instead of reusing it.
+ *
+ * <p>Uses an in-memory H2 connection wrapped in a proxy that fails only the {@code setAutoCommit(true)}
+ * restore (the initial {@code setAutoCommit(false)} and all other calls delegate normally), so no
+ * container is needed.
+ */
+class TableFillerAutoCommitRestoreTest extends BaseEmbeddedTest {
+
+    @Test
+    void abortsConnectionAndSurfacesFailureWhenAutoCommitRestoreFails() throws SQLException {
+        try (Connection real = DriverManager.getConnection("jdbc:h2:mem:autocommit_restore;DB_CLOSE_DELAY=-1")) {
+            try (Statement statement = real.createStatement()) {
+                statement.execute("create table widget (id integer)");
+            }
+
+            Database database = DatabaseUtils.getMetadata(real);
+            Table table = database.getTable("widget");
+
+            AtomicBoolean aborted = new AtomicBoolean(false);
+            Connection proxy = throwingOnAutoCommitRestore(real, aborted);
+
+            // perTable => the engine manages the transaction (autocommit off, commit, then restore)
+            DatabaseConfiguration configuration =
+                    new DatabaseConfiguration(16, 5, new H2Support(), null, 1L, CommitStrategy.perTable());
+
+            // the fill itself succeeds, but restoring autocommit throws — that failure must surface
+            SQLException thrown = assertThrows(SQLException.class, () ->
+                    new TableFiller.Builder(proxy, database, configuration)
+                            .table(table)
+                            .commitStrategy(CommitStrategy.perTable())
+                            .build().fill());
+
+            assertTrue(thrown.getMessage().contains("simulated"), "the restore failure should surface, not be swallowed");
+            assertTrue(aborted.get(), "the connection must be aborted when its autocommit cannot be restored");
+        }
+    }
+
+    /**
+     * Wraps {@code real} so {@code setAutoCommit(true)} (the restore) throws while
+     * {@code setAutoCommit(false)} and every other call delegate normally; records whether
+     * {@link Connection#abort} was invoked.
+     */
+    private static Connection throwingOnAutoCommitRestore(Connection real, AtomicBoolean aborted) {
+        return (Connection) Proxy.newProxyInstance(
+                TableFillerAutoCommitRestoreTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "setAutoCommit" -> {
+                            if (Boolean.TRUE.equals(args[0])) {
+                                throw new SQLException("simulated autocommit restore failure");
+                            }
+                            return invoke(method, real, args);
+                        }
+                        case "abort" -> {
+                            aborted.set(true);
+                            return null; // record only; leave the in-memory connection usable for cleanup
+                        }
+                        default -> {
+                            return invoke(method, real, args);
+                        }
+                    }
+                });
+    }
+
+    private static Object invoke(Method method, Object target, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/file/FlatFileTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/file/FlatFileTest.java
@@ -19,9 +19,14 @@ package io.bloviate.file;
 import io.bloviate.gen.*;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FlatFileTest {
 
@@ -66,5 +71,30 @@ class FlatFileTest {
         pipe.yaml();
 
         //new FlatFile.Builder("target/large-csv-test").output(new CsvFile()).addAll(definitions).rows(1000000).build().generate();
+    }
+
+    /**
+     * Guards the row loop bound. The counter is a {@code long} (not an {@code int}) so a row count
+     * past {@link Integer#MAX_VALUE} cannot overflow to {@link Integer#MIN_VALUE} and loop forever;
+     * a literal multi-billion-row run is infeasible to assert, so this pins the exact-count contract
+     * the widened loop preserves.
+     */
+    @Test
+    public void generatesExactRowCount() throws IOException {
+        Random random = new Random();
+        List<ColumnDefinition> definitions = List.of(
+                new ColumnDefinition("integer_col", new IntegerGenerator.Builder(random).build()));
+
+        long requestedRows = 5;
+        FlatFileGenerator csv = new FlatFileGenerator.Builder("target/exact-row-count-test")
+                .addAll(definitions)
+                .rows(requestedRows)
+                .build();
+        csv.generate();
+
+        long lines = Files.lines(Path.of("target/exact-row-count-test.csv")).count();
+
+        // one header line plus exactly the requested number of data rows
+        assertEquals(requestedRows + 1, lines);
     }
 }

--- a/bloviate-core/src/test/java/io/bloviate/gen/DistributionGeneratorsTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/DistributionGeneratorsTest.java
@@ -164,6 +164,9 @@ class DistributionGeneratorsTest {
                 () -> new NormalIntegerGenerator.Builder(random).min(10).max(0).build());
         assertThrows(IllegalArgumentException.class,
                 () -> new ZipfianIntegerGenerator.Builder(random).size(0).build());
+        // size above the cap fails fast instead of OOM-ing on a multi-gigabyte cumulative table
+        assertThrows(IllegalArgumentException.class,
+                () -> new ZipfianIntegerGenerator.Builder(random).size(ZipfianIntegerGenerator.MAX_SIZE + 1).build());
         assertThrows(IllegalArgumentException.class,
                 () -> new SkewedTimestampGenerator.Builder(random).skew(0).build());
     }

--- a/bloviate-core/src/test/java/io/bloviate/util/AssociatedPrimaryKeyColumnTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/util/AssociatedPrimaryKeyColumnTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.JDBCType;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -122,5 +123,25 @@ class AssociatedPrimaryKeyColumnTest {
         // sequence 2 on the child FK must resolve to the sequence-2 PK column, not sequence 1
         assertSame(pkB, DatabaseUtils.getAssociatedPrimaryKeyColumn(database, child, fkB));
         assertSame(pkA, DatabaseUtils.getAssociatedPrimaryKeyColumn(database, child, fkA));
+    }
+
+    @Test
+    void terminatesOnCircularForeignKeyChainInsteadOfStackOverflow() {
+        // A.id is the PK of A and a FK to B.id; B.id is the PK of B and a FK to A.id — a cycle A->B->A.
+        Column aId = col("id", "a");
+        Column bId = col("id", "b");
+
+        ForeignKey aToB = new ForeignKey(List.of(new KeyColumn(1, aId)), singleColumnPk("b", bId));
+        Table a = new Table("a", singleColumnPk("a", aId), List.of(aId), List.of(aToB));
+
+        ForeignKey bToA = new ForeignKey(List.of(new KeyColumn(1, bId)), singleColumnPk("a", aId));
+        Table b = new Table("b", singleColumnPk("b", bId), List.of(bId), List.of(bToA));
+
+        Database database = new Database("test", "1", null, null, List.of(a, b));
+
+        // the visited-set guard must break the cycle rather than recurse without bound
+        Column resolved = assertDoesNotThrow(
+                () -> DatabaseUtils.getAssociatedPrimaryKeyColumn(database, a, aId));
+        assertSame(aId, resolved);
     }
 }


### PR DESCRIPTION
Addresses all findings in #526 — the audit of the fill engine, generators, and file writer for memory/resource issues under heavy load and very large datasets. Lands as a single PR covering every acceptance-criteria item (H1/H2, M1–M5, L1–L4).

## High
- **H1** — `FlatFileGenerator` row loop counter widened `int → long`; row counts past `Integer.MAX_VALUE` can no longer overflow into an infinite write.
- **H2** — A throwing `enableConstraints` now aborts the borrowed connection so the pool discards it instead of returning a constraint-disabled, FK-skipping session. Fixed in **both** the worker body and the `fillUnordered` probe (which had the same leak) via a shared `restoreConstraints` helper.

## Medium
- **M1** — `DatabaseConfiguration` rejects `batchSize < 1` with a clear message.
- **M2** — The parallel/bulk path defaults `CONNECTION_DEFAULT` to a bounded `everyNBatches(64)` commit instead of `perTable`, so a very large partition no longer holds one unbounded server-side transaction (WAL/undo growth, lock accumulation). An explicitly configured strategy (incl. `perTable`) is still honored.
- **M3** — `ZipfianIntegerGenerator.MAX_SIZE` (50M) enforced and documented; an oversized `size` fails fast instead of OOM-ing on a multi-gigabyte cumulative table. `WeightedCategoricalGenerator` needs no cap — its arrays scale with caller-supplied entries (to get N values you already hold N in memory), so there is no independent numeric knob that OOMs at construction.
- **M4** — Parallel and unordered-bulk submission run through `runWithBackpressure`, keeping at most ~`2 × poolSize` tasks in flight via an `ExecutorCompletionService` rather than `invokeAll`-ing every task at once; queued `FutureTask`s/`Future`s now scale with the pool size, not total partition/task count.
- **M5** — `getAssociatedPrimaryKeyColumn` carries a visited-set; a circular FK schema warns and returns `null` instead of `StackOverflowError`.

## Low / hardening
- **L1** — `visualizeGraph` skips the DOT string + URL-encoded link unless the consuming log level is enabled, and skips the (encode-tripled) link entirely for schemas whose DOT exceeds `MAX_GRAPH_LINK_CHARS`.
- **L2** — Autocommit restore moved out of `finally`; a rollback or restore failure is attached via `addSuppressed` instead of masking the original cause, and a connection whose autocommit can't be restored is aborted so a pool discards it.
- **L3** — Explicit `clearBatch()` after every `executeBatch()`.
- **L4** — Pre-sized the `BitStringGenerator` `StringBuilder`. The array generators' boxing is intrinsic to their `Byte[]`/`Integer[]`/`String[]` value types and JDBC `createArrayOf`, so it is left as-is.

## Tests
New coverage: exact-row-count guard, `batchSize` rejection, FK-cycle termination, Zipfian size cap, a Testcontainers test proving a failed constraint restore evicts the connection, an H2-backed test proving a failed autocommit restore aborts the connection and surfaces (not masks) the failure, and a Postgres test proving every partition task runs when partitions far exceed worker threads.

Full `bloviate-core` suite (231 tests) plus the `bloviate-junit` and `bloviate-testcontainers` modules pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)