### PR TITLE
ci: restrict dependabot auto-merge to patch/minor and gate website builds

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,6 +14,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Single source of truth for which Maven groups/artifacts may auto-merge. Space-
+# separated substrings matched against Dependabot's dependency names (primary
+# path) and the PR branch name (fallback path), so the two paths can't drift.
+# Only patch & minor updates auto-merge; majors are always left for review.
+env:
+  MAVEN_ALLOWLIST: "com.zaxxer org.apache.commons com.fasterxml.jackson org.slf4j org.junit.jupiter org.testcontainers org.postgresql mysql org.jgrapht org.apache.maven.plugins org.codehaus.mojo"
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest
@@ -25,18 +32,39 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-merge Dependabot PRs
-        if: contains(steps.metadata.outputs.dependency-names, 'com.zaxxer') || contains(steps.metadata.outputs.dependency-names, 'org.apache.commons') || contains(steps.metadata.outputs.dependency-names, 'com.fasterxml.jackson') || contains(steps.metadata.outputs.dependency-names, 'org.slf4j') || contains(steps.metadata.outputs.dependency-names, 'org.junit.jupiter') || contains(steps.metadata.outputs.dependency-names, 'org.testcontainers') || contains(steps.metadata.outputs.dependency-names, 'org.postgresql') || contains(steps.metadata.outputs.dependency-names, 'mysql') || contains(steps.metadata.outputs.dependency-names, 'org.jgrapht') || contains(steps.metadata.outputs.dependency-names, 'org.apache.maven.plugins') || contains(steps.metadata.outputs.dependency-names, 'org.codehaus.mojo')
-        run: gh pr merge --auto --squash "$PR_URL"
+      # Maven deps: auto-merge patch & minor for allowlisted groups only. Majors
+      # (semver-major) are excluded and left for manual review, mirroring the npm
+      # policy below — a major bump of any dependency or build plugin can change
+      # behavior in ways `mvn verify` won't necessarily catch.
+      - name: Auto-merge allowlisted Maven patch & minor updates
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'maven' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
         env:
+          NAMES: ${{ steps.metadata.outputs.dependency-names }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for tok in $MAVEN_ALLOWLIST; do
+            case "$NAMES" in
+              *"$tok"*)
+                echo "Allowlisted dependency matched '$tok'; enabling auto-merge."
+                gh pr merge --auto --squash "$PR_URL"
+                exit 0
+                ;;
+            esac
+          done
+          echo "No allowlisted dependency in: $NAMES"
 
       # Website (npm/pnpm) deps: auto-merge patch & minor only; majors are left
-      # for manual review. --auto waits for required checks, so the Build website
-      # check gates the merge.
+      # for manual review. --auto waits for required checks, so the required
+      # "build-website" check gates the merge.
       - name: Auto-merge website (npm) patch & minor updates
-        if: steps.metadata.outputs.package-ecosystem == 'npm' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'npm' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -46,6 +74,8 @@ jobs:
   # fetch-metadata can't run on workflow_run events (no pull_request payload), so
   # the allowlist is re-applied by matching the Dependabot branch name, which
   # encodes "<group>-<artifact>" (e.g. dependabot/maven/com.fasterxml.jackson...).
+  # npm branches never match the Maven allowlist, so website PRs are handled only
+  # by the primary path above.
   auto-merge-retry:
     runs-on: ubuntu-latest
     if: >
@@ -61,17 +91,35 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          case "$HEAD_BRANCH" in
-            *com.zaxxer*|*org.apache.commons*|*com.fasterxml.jackson*|*org.slf4j*|*org.junit.jupiter*|*org.testcontainers*|*org.postgresql*|*mysql*|*org.jgrapht*|*org.apache.maven.plugins*|*org.codehaus.mojo*) ;;
-            *)
-              echo "Branch '$HEAD_BRANCH' is not in the auto-merge allowlist; skipping."
-              exit 0
-              ;;
-          esac
+          matched=
+          for tok in $MAVEN_ALLOWLIST; do
+            case "$HEAD_BRANCH" in *"$tok"*) matched=1; break;; esac
+          done
+          if [ -z "$matched" ]; then
+            echo "Branch '$HEAD_BRANCH' is not in the auto-merge allowlist; skipping."
+            exit 0
+          fi
 
           PR_URL=$(gh pr list --head "$HEAD_BRANCH" --state open --json url --jq '.[0].url')
           if [ -z "$PR_URL" ]; then
             echo "No open PR found for branch '$HEAD_BRANCH'; nothing to do."
+            exit 0
+          fi
+
+          # Version guard: this path has no fetch-metadata, so derive the bump
+          # type from the PR title ("... from X to Y"). Skip majors and anything
+          # we can't parse, leaving them for manual review — mirrors the primary
+          # path's patch/minor-only policy so the fallback can't merge a major
+          # the primary path deliberately declined.
+          TITLE=$(gh pr view "$PR_URL" --json title --jq '.title')
+          FROM=$(printf '%s' "$TITLE" | sed -n 's/.* from \([0-9][^ ]*\) to .*/\1/p')
+          TO=$(printf '%s' "$TITLE" | sed -n 's/.* to \([0-9][^ ]*\).*/\1/p')
+          if [ -z "$FROM" ] || [ -z "$TO" ]; then
+            echo "Could not parse versions from title '$TITLE'; leaving for manual review."
+            exit 0
+          fi
+          if [ "${FROM%%.*}" != "${TO%%.*}" ]; then
+            echo "Major update ($FROM -> $TO); leaving for manual review."
             exit 0
           fi
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           NAMES: ${{ steps.metadata.outputs.dependency-names }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for tok in $MAVEN_ALLOWLIST; do
             case "$NAMES" in
@@ -68,7 +68,7 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Fallback: re-attempt auto-merge after the CI workflow completes successfully.
   # fetch-metadata can't run on workflow_run events (no pull_request payload), so
@@ -89,7 +89,7 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           matched=
           for tok in $MAVEN_ALLOWLIST; do

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Detect website changes
         id: changes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -1,8 +1,10 @@
 name: Build website
 
-# Verifies the docs site builds. Runs on PRs that touch the site or its content
-# so a dependency bump (or content change) can't merge — or auto-merge — if it
-# breaks the build. Cloudflare deploys the same `pnpm build` on push to main.
+# Verifies the docs site builds. Runs on every PR to main so it can be a
+# required status check that gates auto-merge, but only does the heavy pnpm
+# build when website/docs actually changed; otherwise it exits green
+# immediately, keeping the check fast for code-only PRs. Cloudflare deploys the
+# same `pnpm build` on push to main.
 
 on:
   push:
@@ -11,38 +13,62 @@ on:
       - 'website/**'
       - 'docs/**'
       - '.github/workflows/website-build.yml'
+  # No paths filter here: the job must run (and report its status) on every PR
+  # so branch protection can require it. Relevance is decided inside the job.
   pull_request:
     branches: [ main ]
-    paths:
-      - 'website/**'
-      - 'docs/**'
-      - '.github/workflows/website-build.yml'
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
 
 jobs:
-  build:
+  # Named "build-website" (not "build") to avoid colliding with the Maven CI
+  # job's "build" status context, which made the required check ambiguous.
+  build-website:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: website
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # On pull_request, skip the build unless the site or its content changed,
+      # so this required check stays fast for code-only PRs. On push the paths
+      # filter above already guarantees relevance, so always run.
+      - name: Detect website changes
+        id: changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh pr view "${{ github.event.pull_request.number }}" --json files --jq '.files[].path')
+          if printf '%s\n' "$FILES" | grep -qE '^(website/|docs/|\.github/workflows/website-build\.yml)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No website/docs changes; skipping build."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.changes.outputs.run == 'true'
         with:
           node-version-file: website/.node-version
 
       # pnpm version comes from the `packageManager` pin in website/package.json.
       - name: Enable corepack
+        if: steps.changes.outputs.run == 'true'
         run: corepack enable
 
       - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
+        working-directory: website
         run: pnpm install --frozen-lockfile
 
       - name: Build site
+        if: steps.changes.outputs.run == 'true'
+        working-directory: website
         run: pnpm build


### PR DESCRIPTION
## Why

Review of the Dependabot auto-merge automation surfaced three gaps in what actually gates a merge:

1. **Maven bumps auto-merged any version, including majors.** The npm path was restricted to patch/minor, but the Maven path had no `update-type` guard — a major bump of Jackson/JUnit/Testcontainers/SLF4J or any Maven **build plugin** would auto-merge as long as `mvn verify` passed, which won't necessarily catch a breaking semantic change.
2. **The website build didn't reliably gate.** Both `maven.yml` and `website-build.yml` named their job `build`, so both emitted a status context literally named `build`, making the required check ambiguous. The comment claimed "the Build website check gates the merge," but it was never a required check.
3. **The allowlist was duplicated** across the primary (`contains(...)`) and fallback (branch-name `case`) paths and could silently drift.

## Changes

- **Maven patch/minor only.** Guard the Maven auto-merge on `semver-patch`/`semver-minor`, mirroring the npm policy. Applied on **both** paths — the fallback (which has no `fetch-metadata`) derives the bump type from the PR title's `from X to Y` and skips majors / unparseable titles, so it can't merge a major the primary path declined.
- **Single allowlist source.** Collapse the two copies into one `MAVEN_ALLOWLIST` env var read by both paths.
- **Real website gate.** Rename the website job `build` → `build-website` (removing the context collision) and run it on every PR with in-job change detection, so it can become a required check that gates website dep auto-merges **without** stranding code-only PRs.

## Follow-up (not in this PR)

After merge, `build-website` must be added to `main`'s required status checks, and the three open npm PRs (#532–534) rebased first so they carry the renamed job. `strict` (require branches up-to-date) was left off — worth considering given the daily multi-PR cadence, but it's a churn trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)