### PR TITLE
ci: group codeql-action updates in one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       interval: "daily"
     assignees:
       - "timveil"
+    # codeql-action/init and codeql-action/analyze must run the same version,
+    # so bump them together in one PR — separate PRs create a version mismatch
+    # that fails analysis ("Loaded a configuration file for version X, but
+    # running version Y").
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
   # docs site (Astro/Starlight). The npm ecosystem reads the committed
   # pnpm-lock.yaml. Patch/minor bumps here are auto-merged once the website
   # build passes (see .github/workflows/dependabot-auto-merge.yml); majors open


### PR DESCRIPTION
## Problem

Dependabot PRs #536 and #537 both fail CodeQL analysis. The workflow pins `codeql-action/init` and `codeql-action/analyze` to the same version, and CodeQL requires both steps to run the **same** version. But Dependabot treats them as separate dependencies and opened a PR for each, bumping only one step:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

Neither PR can pass on its own.

## Fix

Add a `groups` entry to the `github-actions` ecosystem so all `github/codeql-action*` updates land in a single PR, keeping `init` and `analyze` in lockstep.

## Follow-up

Closing #536 and #537 as stale — Dependabot will reopen a combined PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)