### PR TITLE
fix: quote and schema-qualify insert identifiers, guard nullable column sizes

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -49,7 +49,8 @@ jobs:
           EOF
 
       - name: Validate PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
-
-      - name: Validate current commits
-        run: npx commitlint --from=HEAD~1 --to=HEAD --verbose
+        # The title is attacker-controlled; pass it via env instead of interpolating it
+        # into the script to avoid shell injection on the runner.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -71,6 +71,12 @@ jobs:
           cat ~/.m2/settings.xml || echo "No settings.xml found"
           echo "GitHub actor: ${{ github.actor }}"
 
+      # Gate the release on a full build: publishCmd below deploys with -DskipTests
+      # (the artifacts were just verified here), so without this step a direct push
+      # to main could publish untested jars.
+      - name: Verify build before release
+        run: ./mvnw -B -ntp verify
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:

--- a/bloviate-core/src/main/java/io/bloviate/db/Table.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/Table.java
@@ -45,25 +45,63 @@ import java.util.StringJoiner;
 public record Table(String name, PrimaryKey primaryKey, List<Column> columns, List<ForeignKey> foreignKeys) {
 
     /**
-     * Generates an SQL INSERT statement template for this table.
-     * 
-     * <p>Creates a parameterized INSERT statement using question mark placeholders
-     * for all non-auto-increment columns. Auto-increment columns are excluded
-     * as they are populated automatically by the database.
-     * 
+     * Generates an SQL INSERT statement template for this table with unquoted identifiers.
+     *
+     * <p>Equivalent to {@link #insertString(String) insertString(null)}. Prefer the quoting
+     * variant when a {@link java.sql.DatabaseMetaData#getIdentifierQuoteString() quote string}
+     * is available; unquoted identifiers break on reserved words, mixed-case names, and names
+     * containing special characters.
+     *
      * @return a parameterized SQL INSERT statement string
      */
     public String insertString() {
+        return insertString(null);
+    }
+
+    /**
+     * Generates an SQL INSERT statement template for this table.
+     *
+     * <p>Creates a parameterized INSERT statement using question mark placeholders
+     * for all non-auto-increment columns. Auto-increment columns are excluded
+     * as they are populated automatically by the database.
+     *
+     * <p>The table and column names come from database metadata and are emitted quoted with
+     * the supplied identifier quote string (embedded quote characters doubled), so reserved
+     * words, mixed-case, and otherwise exotic identifiers round-trip exactly as the catalog
+     * reported them and cannot alter the statement's structure. The table name is qualified
+     * with the schema its columns were introspected from, so the fill targets the introspected
+     * table even when the connection's current schema or search path differs.
+     *
+     * @param identifierQuote the identifier quote string reported by
+     *                        {@link java.sql.DatabaseMetaData#getIdentifierQuoteString()};
+     *                        {@code null} or blank (JDBC reports a single space when quoting
+     *                        is unsupported) emits unquoted identifiers
+     * @return a parameterized SQL INSERT statement string
+     */
+    public String insertString(String identifierQuote) {
         StringJoiner nameJoiner = new StringJoiner(",");
         StringJoiner valueJoiner = new StringJoiner(",");
 
         for (Column column : filteredColumns()) {
-            nameJoiner.add(column.name());
+            nameJoiner.add(quote(column.name(), identifierQuote));
             valueJoiner.add("?");
         }
 
-        return String.format("insert into %s (%s) values (%s)", name, nameJoiner, valueJoiner);
+        return String.format("insert into %s (%s) values (%s)", qualifiedName(identifierQuote), nameJoiner, valueJoiner);
 
+    }
+
+    private String qualifiedName(String identifierQuote) {
+        String schema = columns.isEmpty() ? null : columns.getFirst().schema();
+        String quotedName = quote(name, identifierQuote);
+        return schema == null ? quotedName : quote(schema, identifierQuote) + "." + quotedName;
+    }
+
+    private static String quote(String identifier, String identifierQuote) {
+        if (identifierQuote == null || identifierQuote.isBlank()) {
+            return identifier;
+        }
+        return identifierQuote + identifier.replace(identifierQuote, identifierQuote + identifierQuote) + identifierQuote;
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/db/Table.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/Table.java
@@ -45,17 +45,27 @@ import java.util.StringJoiner;
 public record Table(String name, PrimaryKey primaryKey, List<Column> columns, List<ForeignKey> foreignKeys) {
 
     /**
-     * Generates an SQL INSERT statement template for this table with unquoted identifiers.
+     * Generates an SQL INSERT statement template for this table with unquoted, unqualified
+     * identifiers.
      *
-     * <p>Equivalent to {@link #insertString(String) insertString(null)}. Prefer the quoting
-     * variant when a {@link java.sql.DatabaseMetaData#getIdentifierQuoteString() quote string}
-     * is available; unquoted identifiers break on reserved words, mixed-case names, and names
-     * containing special characters.
+     * <p>This legacy form emits the bare table name (no schema qualification) and raw column
+     * names, exactly as earlier releases did. Prefer {@link #insertString(String)} when a
+     * {@link java.sql.DatabaseMetaData#getIdentifierQuoteString() quote string} is available;
+     * unquoted identifiers break on reserved words, mixed-case names, and names containing
+     * special characters.
      *
      * @return a parameterized SQL INSERT statement string
      */
     public String insertString() {
-        return insertString(null);
+        StringJoiner nameJoiner = new StringJoiner(",");
+        StringJoiner valueJoiner = new StringJoiner(",");
+
+        for (Column column : filteredColumns()) {
+            nameJoiner.add(column.name());
+            valueJoiner.add("?");
+        }
+
+        return String.format("insert into %s (%s) values (%s)", name, nameJoiner, valueJoiner);
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/TableFiller.java
@@ -98,7 +98,7 @@ public class TableFiller implements Fillable {
     @Override
     public void fill() throws SQLException {
 
-        String sql = table.insertString();
+        String sql = table.insertString(connection.getMetaData().getIdentifierQuoteString());
 
         logger.trace("{}", sql);
 

--- a/bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/AbstractDatabaseSupport.java
@@ -73,10 +73,13 @@ public abstract class AbstractDatabaseSupport implements DatabaseSupport {
 
     private void registerDefaults(Map<JDBCType, GeneratorFactory> map) {
         map.put(JDBCType.BIT, (column, random) -> {
-            if (1 == column.maxSize()) {
+            // COLUMN_SIZE is nullable metadata; an unreported size is treated as the SQL
+            // default of BIT(1), matching how a bare BIT column is declared
+            Integer maxSize = column.maxSize();
+            if (maxSize == null || maxSize == 1) {
                 return new BitGenerator.Builder(random).build();
             }
-            return new BitStringGenerator.Builder(random).size(column.maxSize()).build();
+            return new BitStringGenerator.Builder(random).size(maxSize).build();
         });
 
         map.put(JDBCType.TINYINT, (column, random) -> new ShortGenerator.Builder(random).start(0).end(255).build());
@@ -93,8 +96,15 @@ public abstract class AbstractDatabaseSupport implements DatabaseSupport {
         map.put(JDBCType.NUMERIC, bigDecimal);
         map.put(JDBCType.DECIMAL, bigDecimal);
 
-        GeneratorFactory string = (column, random) ->
-                new SimpleStringGenerator.Builder(random).size(column.maxSize()).build();
+        GeneratorFactory string = (column, random) -> {
+            // COLUMN_SIZE is nullable metadata; fall back to the generator's default length
+            Integer maxSize = column.maxSize();
+            SimpleStringGenerator.Builder builder = new SimpleStringGenerator.Builder(random);
+            if (maxSize != null && maxSize > 0) {
+                builder.size(maxSize);
+            }
+            return builder.build();
+        };
         map.put(JDBCType.CHAR, string);
         map.put(JDBCType.NCHAR, string);
         map.put(JDBCType.VARCHAR, string);
@@ -112,8 +122,15 @@ public abstract class AbstractDatabaseSupport implements DatabaseSupport {
         map.put(JDBCType.TIMESTAMP, timestamp);
         map.put(JDBCType.TIMESTAMP_WITH_TIMEZONE, timestamp);
 
-        GeneratorFactory bytes = (column, random) ->
-                new ByteGenerator.Builder(random).size(column.maxSize()).build();
+        GeneratorFactory bytes = (column, random) -> {
+            // COLUMN_SIZE is nullable metadata; fall back to the generator's default length
+            Integer maxSize = column.maxSize();
+            ByteGenerator.Builder builder = new ByteGenerator.Builder(random);
+            if (maxSize != null && maxSize > 0) {
+                builder.size(maxSize);
+            }
+            return builder.build();
+        };
         map.put(JDBCType.BINARY, bytes);
         map.put(JDBCType.VARBINARY, bytes);
         map.put(JDBCType.LONGVARBINARY, bytes);

--- a/bloviate-core/src/main/java/io/bloviate/ext/H2Support.java
+++ b/bloviate-core/src/main/java/io/bloviate/ext/H2Support.java
@@ -70,7 +70,13 @@ public class H2Support extends AbstractDatabaseSupport {
             if ("uuid".equalsIgnoreCase(column.typeName())) {
                 return new UUIDGenerator.Builder(random).build();
             }
-            return new ByteGenerator.Builder(random).size(column.maxSize()).build();
+            // COLUMN_SIZE is nullable metadata; fall back to the generator's default length
+            Integer maxSize = column.maxSize();
+            ByteGenerator.Builder builder = new ByteGenerator.Builder(random);
+            if (maxSize != null && maxSize > 0) {
+                builder.size(maxSize);
+            }
+            return builder.build();
         });
 
         // H2 JSON surfaces as OTHER (type name "JSON"); H2 parses the value, so generate valid JSON.

--- a/bloviate-core/src/test/java/io/bloviate/db/TableTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/TableTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.db;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TableTest {
+
+    private static Column column(String name, String schema, Boolean autoIncrement) {
+        return new Column(name, "t", schema, null, JDBCType.INTEGER, 10, null, "int4", autoIncrement, true, null, 1);
+    }
+
+    @Test
+    void insertStringWithoutQuoteStringEmitsBareIdentifiers() {
+        Table table = new Table("orders", null,
+                List.of(column("id", null, false), column("qty", null, false)), List.of());
+
+        assertEquals("insert into orders (id,qty) values (?,?)", table.insertString());
+    }
+
+    @Test
+    void insertStringQuotesAndSchemaQualifiesIdentifiers() {
+        Table table = new Table("order", null,
+                List.of(column("user", "public", false), column("desc", "public", false)), List.of());
+
+        assertEquals("insert into \"public\".\"order\" (\"user\",\"desc\") values (?,?)",
+                table.insertString("\""));
+    }
+
+    @Test
+    void insertStringSupportsNonStandardQuoteStrings() {
+        Table table = new Table("order", null, List.of(column("desc", null, false)), List.of());
+
+        assertEquals("insert into `order` (`desc`) values (?)", table.insertString("`"));
+    }
+
+    @Test
+    void insertStringDoublesEmbeddedQuoteCharacters() {
+        Table table = new Table("we\"ird", null, List.of(column("col\"umn", null, false)), List.of());
+
+        assertEquals("insert into \"we\"\"ird\" (\"col\"\"umn\") values (?)", table.insertString("\""));
+    }
+
+    @Test
+    void insertStringTreatsBlankQuoteStringAsUnsupported() {
+        // JDBC drivers report a single space when identifier quoting is unsupported
+        Table table = new Table("orders", null, List.of(column("id", "public", false)), List.of());
+
+        assertEquals("insert into public.orders (id) values (?)", table.insertString(" "));
+    }
+
+    @Test
+    void insertStringExcludesAutoIncrementColumns() {
+        Table table = new Table("orders", null,
+                List.of(column("id", null, true), column("qty", null, false)), List.of());
+
+        assertEquals("insert into orders (qty) values (?)", table.insertString(null));
+    }
+}

--- a/bloviate-core/src/test/java/io/bloviate/db/TableTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/db/TableTest.java
@@ -38,6 +38,15 @@ class TableTest {
     }
 
     @Test
+    void noArgInsertStringStaysUnqualifiedWhenSchemaPresent() {
+        // the legacy no-arg form must keep emitting the bare table name for compatibility,
+        // even when column metadata carries a schema
+        Table table = new Table("orders", null, List.of(column("id", "public", false)), List.of());
+
+        assertEquals("insert into orders (id) values (?)", table.insertString());
+    }
+
+    @Test
     void insertStringQuotesAndSchemaQualifiesIdentifiers() {
         Table table = new Table("order", null,
                 List.of(column("user", "public", false), column("desc", "public", false)), List.of());

--- a/bloviate-core/src/test/java/io/bloviate/ext/DatabaseSupportTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/ext/DatabaseSupportTest.java
@@ -58,6 +58,23 @@ class DatabaseSupportTest {
     }
 
     @Test
+    void defaultSupportToleratesNullColumnSize() {
+        DatabaseSupport support = new DefaultSupport();
+
+        // COLUMN_SIZE is nullable metadata; the defaults must not unbox it
+        assertInstanceOf(BitGenerator.class, generatorFor(support, JDBCType.BIT, null, "bit"));
+        assertInstanceOf(SimpleStringGenerator.class, generatorFor(support, JDBCType.VARCHAR, null, "varchar"));
+        assertInstanceOf(ByteGenerator.class, generatorFor(support, JDBCType.VARBINARY, null, "varbinary"));
+    }
+
+    @Test
+    void h2ToleratesNullColumnSizeForBinary() {
+        DatabaseSupport support = new H2Support();
+
+        assertInstanceOf(ByteGenerator.class, generatorFor(support, JDBCType.BINARY, null, "binary"));
+    }
+
+    @Test
     void defaultSupportThrowsForUnregisteredType() {
         DatabaseSupport support = new DefaultSupport();
 


### PR DESCRIPTION
## Summary

First batch of fixes from a full-project review (security, performance, best practices):

- **Quote and schema-qualify INSERT identifiers** — `Table.insertString` interpolated raw metadata identifiers, so reserved-word, mixed-case, or special-character names produced broken SQL, and a hostile identifier (e.g. a table named `t (a int); drop table ...; --`) could alter statement structure when filled by a privileged account. Identifiers are now quoted with `DatabaseMetaData.getIdentifierQuoteString()` (embedded quotes doubled) and the table is qualified with its introspected schema, so fills target the introspected table even when the connection's current schema differs. The no-arg `insertString()` keeps its unquoted behavior for compatibility.
- **Guard nullable `Column.maxSize`** — the cross-database BIT/CHAR/BINARY generator defaults (and H2 BINARY) unboxed the nullable `COLUMN_SIZE` and threw a context-free NPE when a driver reports none; they now fall back to generator defaults, matching the existing guards in `PostgresSupport`/`MySQLSupport`.
- **CI: commit-lint script injection** — the attacker-controlled PR title was interpolated into a `run:` script; it is now passed via `env`. Also removed the no-op "Validate current commits" step (it linted only the synthetic merge commit, which commitlint ignores).
- **CI: gate releases on a green build** — the release job deploys with `-DskipTests`; it now runs `./mvnw -B -ntp verify` first so a direct push to main cannot publish untested jars.

## Testing

- New `TableTest` covering quoting, quote-doubling, schema qualification, blank quote strings (JDBC "unsupported" signal), and auto-increment exclusion; new null-`COLUMN_SIZE` cases in `DatabaseSupportTest`.
- Full `./mvnw -B -ntp verify` green locally, including all Testcontainers integration suites (Postgres, MySQL, MariaDB, CockroachDB) and JaCoCo coverage gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)