### PR TITLE
fix: propagate reseed to delegate generators and quiet schema-leaking logs

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -49,6 +49,9 @@ jobs:
           };
           EOF
 
+      # Only the PR title is linted, deliberately: the repository squash-merges, so the
+      # title becomes the commit subject on main and individual branch-commit subjects
+      # never reach the history.
       - name: Validate PR title
         # The title is attacker-controlled; pass it via env instead of interpolating it
         # into the script to avoid shell injection on the runner.

--- a/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
+++ b/bloviate-core/src/main/java/io/bloviate/db/DatabaseFiller.java
@@ -100,8 +100,9 @@ public class DatabaseFiller implements Fillable {
 
     /**
      * The largest DOT graph (in characters) for which {@link #visualizeGraph} renders a GraphvizOnline
-     * link at INFO. Beyond this the URL-encoded link (encoding can roughly triple the length) is too
-     * long to be useful, so the link is skipped and only the DOT itself is logged at DEBUG.
+     * link (at DEBUG, like the DOT itself — the link embeds every table name, so it stays out of
+     * default-level logs). Beyond this the URL-encoded link (encoding can roughly triple the length)
+     * is too long to be useful, so only the DOT is logged.
      */
     private static final int MAX_GRAPH_LINK_CHARS = 8_000;
 
@@ -728,10 +729,10 @@ public class DatabaseFiller implements Fillable {
      * @param databaseName the name of the database for graph labeling
      */
     private void visualizeGraph(Graph<Table, DefaultEdge> graph, String databaseName) {
-        // both the DOT string and the (longer) URL-encoded link are schema-scaled allocations; skip
-        // them entirely when neither level that consumes them is enabled
-        boolean info = logger.isInfoEnabled();
-        if (!info && !logger.isDebugEnabled()) {
+        // DEBUG-only: the DOT and the GraphvizOnline link embed the full schema topology (every
+        // table name), which default-level logs shipped to aggregation shouldn't carry — and both
+        // are schema-scaled allocations worth skipping when disabled
+        if (!logger.isDebugEnabled()) {
             return;
         }
 
@@ -751,21 +752,16 @@ public class DatabaseFiller implements Fillable {
 
         logger.debug("database graph in DOT notation:\n\n{}", graphAsString);
 
-        if (!info) {
-            return;
-        }
-
         // for a very large schema the URL-encoded DOT is too long to be a usable link; skip the
-        // encode (which can roughly triple the length) and point the reader at the DEBUG DOT instead
+        // encode (which can roughly triple the length) — the DOT itself was logged above
         if (graphAsString.length() > MAX_GRAPH_LINK_CHARS) {
-            logger.info("database graph has {} chars of DOT notation — too large for a GraphvizOnline link; "
-                    + "enable DEBUG logging for {} to see the DOT itself", graphAsString.length(), DatabaseFiller.class.getName());
+            logger.debug("database graph has {} chars of DOT notation — too large for a GraphvizOnline link", graphAsString.length());
             return;
         }
 
         String encodedDiagram = URLEncoder.encode(graphAsString, StandardCharsets.UTF_8).replace("+", "%20");
 
-        logger.info("Use this link to visualize the database graph:  https://dreampuf.github.io/GraphvizOnline/#{}", encodedDiagram);
+        logger.debug("Use this link to visualize the database graph:  https://dreampuf.github.io/GraphvizOnline/#{}", encodedDiagram);
     }
 
     /**

--- a/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/AbstractDataGenerator.java
@@ -82,6 +82,17 @@ public abstract class AbstractDataGenerator<T> implements DataGenerator<T> {
     public void reseed(long seed) {
         this.random = RandomGenerators.create(seed);
         this.randomUtils = new SeededRandomUtils(random);
+        onReseed();
+    }
+
+    /**
+     * Hook invoked after {@link #reseed(long)} swaps the random source. Generators that hold
+     * delegate generators built from the source must override this to rebuild them; otherwise a
+     * delegate keeps drawing from the pre-reseed sequence and foreign-key replay diverges from
+     * the parent sequence it is meant to track.
+     */
+    protected void onReseed() {
+        // nothing to rebuild by default
     }
 
     @Override

--- a/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BigDecimalGenerator.java
@@ -148,8 +148,7 @@ public class BigDecimalGenerator extends AbstractDataGenerator<BigDecimal> {
     }
 
     @Override
-    public void reseed(long seed) {
-        super.reseed(seed);
+    protected void onReseed() {
         this.doubleGenerator = new DoubleGenerator.Builder(random).build();
     }
 

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitGenerator.java
@@ -28,7 +28,7 @@ import java.util.random.RandomGenerator;
  */
 public class BitGenerator extends AbstractDataGenerator<Integer> {
 
-    private final IntegerGenerator integerGenerator;
+    private IntegerGenerator integerGenerator;
 
     @Override
     public Integer generate() {
@@ -61,7 +61,16 @@ public class BitGenerator extends AbstractDataGenerator<Integer> {
 
     private BitGenerator(Builder builder) {
         super(builder.random);
-
-        this.integerGenerator = new IntegerGenerator.Builder(builder.random).start(0).end(2).build();
+        buildDelegates();
     }
+
+    private void buildDelegates() {
+        this.integerGenerator = new IntegerGenerator.Builder(random).start(0).end(2).build();
+    }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/BitStringGenerator.java
@@ -33,7 +33,7 @@ public class BitStringGenerator extends AbstractDataGenerator<String> {
 
     private final int size;
 
-    private final BitGenerator bitGenerator;
+    private BitGenerator bitGenerator;
 
     @Override
     public String generate() {
@@ -92,6 +92,16 @@ public class BitStringGenerator extends AbstractDataGenerator<String> {
     private BitStringGenerator(Builder builder) {
         super(builder.random);
         this.size = builder.size;
-        this.bitGenerator = new BitGenerator.Builder(builder.random).build();
+        buildDelegates();
     }
+
+    private void buildDelegates() {
+        this.bitGenerator = new BitGenerator.Builder(random).build();
+    }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CharacterGenerator.java
@@ -27,7 +27,7 @@ import java.util.random.RandomGenerator;
  */
 public class CharacterGenerator extends AbstractDataGenerator<Character> {
 
-    private final IntegerGenerator integerGenerator;
+    private IntegerGenerator integerGenerator;
 
 
     @Override
@@ -70,8 +70,16 @@ public class CharacterGenerator extends AbstractDataGenerator<Character> {
 
     private CharacterGenerator(Builder builder) {
         super(builder.random);
-
-        this.integerGenerator = new IntegerGenerator.Builder(random).start(0).end(26).build();
-
+        buildDelegates();
     }
+
+    private void buildDelegates() {
+        this.integerGenerator = new IntegerGenerator.Builder(random).start(0).end(26).build();
+    }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/CidrGenerator.java
@@ -28,7 +28,7 @@ import java.util.random.RandomGenerator;
  */
 public class CidrGenerator extends AbstractDataGenerator<String> {
 
-    private final IntegerGenerator octetGenerator;
+    private IntegerGenerator octetGenerator;
 
     @Override
     public String generate() {
@@ -65,6 +65,16 @@ public class CidrGenerator extends AbstractDataGenerator<String> {
 
     private CidrGenerator(Builder builder) {
         super(builder.random);
+        buildDelegates();
+    }
+
+    private void buildDelegates() {
         this.octetGenerator = new IntegerGenerator.Builder(random).start(1).end(256).build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/DateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/DateGenerator.java
@@ -34,7 +34,9 @@ import java.util.random.RandomGenerator;
 public class DateGenerator extends AbstractDataGenerator<Date> {
 
 
-    private final LongGenerator longGenerator;
+    private final long startMillisInclusive;
+    private final long endMillisExclusive;
+    private LongGenerator longGenerator;
 
     @Override
     public Date generate() {
@@ -99,10 +101,21 @@ public class DateGenerator extends AbstractDataGenerator<Date> {
 
     private DateGenerator(Builder builder) {
         super(builder.random);
+        this.startMillisInclusive = builder.startInclusive.getTime();
+        this.endMillisExclusive = builder.endExclusive.getTime();
+        buildDelegates();
+    }
 
-        this.longGenerator = new LongGenerator.Builder(builder.random)
-                .start(builder.startInclusive.getTime())
-                .end(builder.endExclusive.getTime())
+    private void buildDelegates() {
+        this.longGenerator = new LongGenerator.Builder(random)
+                .start(startMillisInclusive)
+                .end(endMillisExclusive)
                 .build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InetGenerator.java
@@ -29,7 +29,7 @@ import java.util.random.RandomGenerator;
  */
 public class InetGenerator extends AbstractDataGenerator<String> {
 
-    private final IntegerGenerator integerGenerator;
+    private IntegerGenerator integerGenerator;
 
     @Override
     public String generate() {
@@ -66,8 +66,16 @@ public class InetGenerator extends AbstractDataGenerator<String> {
 
     private InetGenerator(Builder builder) {
         super(builder.random);
-
-        this.integerGenerator = new IntegerGenerator.Builder(random).start(1).end(256).build();
-
+        buildDelegates();
     }
+
+    private void buildDelegates() {
+        this.integerGenerator = new IntegerGenerator.Builder(random).start(1).end(256).build();
+    }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/InstantGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/InstantGenerator.java
@@ -32,7 +32,9 @@ import java.util.random.RandomGenerator;
  */
 public class InstantGenerator extends AbstractDataGenerator<Instant> {
 
-    private final LongGenerator longGenerator;
+    private final long startMillisInclusive;
+    private final long endMillisExclusive;
+    private LongGenerator longGenerator;
 
     @Override
     public Instant generate() {
@@ -97,10 +99,21 @@ public class InstantGenerator extends AbstractDataGenerator<Instant> {
 
     private InstantGenerator(Builder builder) {
         super(builder.random);
+        this.startMillisInclusive = builder.startInclusive.toEpochMilli();
+        this.endMillisExclusive = builder.endExclusive.toEpochMilli();
+        buildDelegates();
+    }
 
-        this.longGenerator = new LongGenerator.Builder(builder.random)
-                .start(builder.startInclusive.toEpochMilli())
-                .end(builder.endExclusive.toEpochMilli())
+    private void buildDelegates() {
+        this.longGenerator = new LongGenerator.Builder(random)
+                .start(startMillisInclusive)
+                .end(endMillisExclusive)
                 .build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/IntervalGenerator.java
@@ -30,12 +30,12 @@ import java.util.random.RandomGenerator;
  */
 public class IntervalGenerator extends AbstractDataGenerator<String> {
 
-    private final IntegerGenerator yearGenerator;
-    private final IntegerGenerator monthGenerator;
-    private final IntegerGenerator dayGenerator;
-    private final IntegerGenerator hourGenerator;
-    private final IntegerGenerator minuteGenerator;
-    private final IntegerGenerator secondGenerator;
+    private IntegerGenerator yearGenerator;
+    private IntegerGenerator monthGenerator;
+    private IntegerGenerator dayGenerator;
+    private IntegerGenerator hourGenerator;
+    private IntegerGenerator minuteGenerator;
+    private IntegerGenerator secondGenerator;
 
     @Override
     public String generate() {
@@ -76,11 +76,21 @@ public class IntervalGenerator extends AbstractDataGenerator<String> {
 
     private IntervalGenerator(Builder builder) {
         super(builder.random);
-        this.yearGenerator = new IntegerGenerator.Builder(builder.random).start(1).end(10).build();
-        this.monthGenerator = new IntegerGenerator.Builder(builder.random).start(1).end(12).build();
-        this.dayGenerator = new IntegerGenerator.Builder(builder.random).start(1).end(30).build();
-        this.hourGenerator = new IntegerGenerator.Builder(builder.random).start(1).end(24).build();
-        this.minuteGenerator = new IntegerGenerator.Builder(builder.random).start(1).end(60).build();
-        this.secondGenerator = new IntegerGenerator.Builder(builder.random).start(1).end(60).build();
+        buildDelegates();
     }
+
+    private void buildDelegates() {
+        this.yearGenerator = new IntegerGenerator.Builder(random).start(1).end(10).build();
+        this.monthGenerator = new IntegerGenerator.Builder(random).start(1).end(12).build();
+        this.dayGenerator = new IntegerGenerator.Builder(random).start(1).end(30).build();
+        this.hourGenerator = new IntegerGenerator.Builder(random).start(1).end(24).build();
+        this.minuteGenerator = new IntegerGenerator.Builder(random).start(1).end(60).build();
+        this.secondGenerator = new IntegerGenerator.Builder(random).start(1).end(60).build();
+    }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/MacAddressGenerator.java
@@ -29,7 +29,7 @@ import java.util.random.RandomGenerator;
 public class MacAddressGenerator extends AbstractDataGenerator<String> {
 
     private final int octets;
-    private final IntegerGenerator octetGenerator;
+    private IntegerGenerator octetGenerator;
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
 
@@ -93,6 +93,16 @@ public class MacAddressGenerator extends AbstractDataGenerator<String> {
     private MacAddressGenerator(Builder builder) {
         super(builder.random);
         this.octets = builder.octets;
+        buildDelegates();
+    }
+
+    private void buildDelegates() {
         this.octetGenerator = new IntegerGenerator.Builder(random).start(0).end(256).build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/ShortGenerator.java
@@ -31,7 +31,9 @@ import java.util.random.RandomGenerator;
  */
 public class ShortGenerator extends AbstractDataGenerator<Short> {
 
-    private final IntegerGenerator integerGenerator;
+    private final int startInclusive;
+    private final int endExclusive;
+    private IntegerGenerator integerGenerator;
 
     @Override
     public Short generate() {
@@ -104,6 +106,18 @@ public class ShortGenerator extends AbstractDataGenerator<Short> {
 
     private ShortGenerator(Builder builder) {
         super(builder.random);
-        this.integerGenerator = new IntegerGenerator.Builder(builder.random).start(builder.startInclusive).end(builder.endExclusive).build();
+        this.startInclusive = builder.startInclusive;
+        this.endExclusive = builder.endExclusive;
+        buildDelegates();
     }
+
+    private void buildDelegates() {
+        this.integerGenerator = new IntegerGenerator.Builder(random).start(startInclusive).end(endExclusive).build();
+    }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlDateGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlDateGenerator.java
@@ -30,7 +30,9 @@ import java.util.random.RandomGenerator;
  */
 public class SqlDateGenerator extends AbstractDataGenerator<Date> {
 
-    private final LongGenerator longGenerator;
+    private final long startMillisInclusive;
+    private final long endMillisExclusive;
+    private LongGenerator longGenerator;
 
     @Override
     public Date generate() {
@@ -99,9 +101,21 @@ public class SqlDateGenerator extends AbstractDataGenerator<Date> {
 
     private SqlDateGenerator(Builder builder) {
         super(builder.random);
-        this.longGenerator = new LongGenerator.Builder(builder.random)
-                .start(builder.startInclusive.getTime())
-                .end(builder.endExclusive.getTime())
+        this.startMillisInclusive = builder.startInclusive.getTime();
+        this.endMillisExclusive = builder.endExclusive.getTime();
+        buildDelegates();
+    }
+
+    private void buildDelegates() {
+        this.longGenerator = new LongGenerator.Builder(random)
+                .start(startMillisInclusive)
+                .end(endMillisExclusive)
                 .build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlTimeGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlTimeGenerator.java
@@ -31,7 +31,9 @@ import java.util.random.RandomGenerator;
  */
 public class SqlTimeGenerator extends AbstractDataGenerator<Time> {
 
-    private final LongGenerator longGenerator;
+    private final long startMillisInclusive;
+    private final long endMillisExclusive;
+    private LongGenerator longGenerator;
 
     @Override
     public Time generate() {
@@ -100,10 +102,21 @@ public class SqlTimeGenerator extends AbstractDataGenerator<Time> {
 
     private SqlTimeGenerator(Builder builder) {
         super(builder.random);
+        this.startMillisInclusive = builder.startInclusive.getTime();
+        this.endMillisExclusive = builder.endExclusive.getTime();
+        buildDelegates();
+    }
 
-        this.longGenerator = new LongGenerator.Builder(builder.random)
-                .start(builder.startInclusive.getTime())
-                .end(builder.endExclusive.getTime())
+    private void buildDelegates() {
+        this.longGenerator = new LongGenerator.Builder(random)
+                .start(startMillisInclusive)
+                .end(endMillisExclusive)
                 .build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/SqlTimestampGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/SqlTimestampGenerator.java
@@ -31,7 +31,9 @@ import java.util.random.RandomGenerator;
  */
 public class SqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
 
-    private final LongGenerator longGenerator;
+    private final long startMillisInclusive;
+    private final long endMillisExclusive;
+    private LongGenerator longGenerator;
 
     @Override
     public Timestamp generate() {
@@ -100,10 +102,21 @@ public class SqlTimestampGenerator extends AbstractDataGenerator<Timestamp> {
 
     private SqlTimestampGenerator(Builder builder) {
         super(builder.random);
+        this.startMillisInclusive = builder.startInclusive.toInstant().toEpochMilli();
+        this.endMillisExclusive = builder.endExclusive.toInstant().toEpochMilli();
+        buildDelegates();
+    }
 
-        this.longGenerator = new LongGenerator.Builder(builder.random)
-                .start(builder.startInclusive.toInstant().toEpochMilli())
-                .end(builder.endExclusive.toInstant().toEpochMilli())
+    private void buildDelegates() {
+        this.longGenerator = new LongGenerator.Builder(random)
+                .start(startMillisInclusive)
+                .end(endMillisExclusive)
                 .build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
+++ b/bloviate-core/src/main/java/io/bloviate/gen/XmlGenerator.java
@@ -28,7 +28,7 @@ import java.util.random.RandomGenerator;
  */
 public class XmlGenerator extends AbstractDataGenerator<String> {
 
-    private final SimpleStringGenerator contentGenerator;
+    private SimpleStringGenerator contentGenerator;
 
     @Override
     public String generate() {
@@ -65,6 +65,16 @@ public class XmlGenerator extends AbstractDataGenerator<String> {
 
     private XmlGenerator(Builder builder) {
         super(builder.random);
+        buildDelegates();
+    }
+
+    private void buildDelegates() {
         this.contentGenerator = new SimpleStringGenerator.Builder(random).size(16).letters(true).numbers(true).build();
     }
+
+    @Override
+    protected void onReseed() {
+        buildDelegates();
+    }
+
 }

--- a/bloviate-core/src/test/java/io/bloviate/gen/DelegatingGeneratorReseedTest.java
+++ b/bloviate-core/src/test/java/io/bloviate/gen/DelegatingGeneratorReseedTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Tim Veil
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bloviate.gen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+import java.util.function.Function;
+import java.util.random.RandomGenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Generators that hold delegate generators must rebuild them on {@link DataGenerator#reseed(long)}
+ * (via the {@code onReseed()} hook): two instances constructed from <em>different</em> sources and
+ * then reseeded identically must produce identical sequences. Before the hook existed the delegates
+ * kept drawing from the construction-time source, so foreign-key replay backed by such a generator
+ * diverged from the parent sequence it was meant to track.
+ */
+class DelegatingGeneratorReseedTest {
+
+    private static <T> void assertReseedConverges(Function<RandomGenerator, DataGenerator<T>> factory) {
+        DataGenerator<T> first = factory.apply(new Random(1));
+        DataGenerator<T> second = factory.apply(new Random(2));
+
+        // establish divergent internal state before reseeding
+        first.generate();
+        second.generate();
+        second.generate();
+
+        first.reseed(99L);
+        second.reseed(99L);
+
+        for (int i = 0; i < 25; i++) {
+            assertEquals(first.generate(), second.generate(),
+                    "sequences must be identical after an identical reseed");
+        }
+    }
+
+    @Test
+    void reseedReachesDelegates() {
+        assertReseedConverges(r -> new BitGenerator.Builder(r).build());
+        assertReseedConverges(r -> new BitStringGenerator.Builder(r).size(8).build());
+        assertReseedConverges(r -> new CharacterGenerator.Builder(r).build());
+        assertReseedConverges(r -> new CidrGenerator.Builder(r).build());
+        assertReseedConverges(r -> new DateGenerator.Builder(r).build());
+        assertReseedConverges(r -> new InetGenerator.Builder(r).build());
+        assertReseedConverges(r -> new InstantGenerator.Builder(r).build());
+        assertReseedConverges(r -> new IntervalGenerator.Builder(r).build());
+        assertReseedConverges(r -> new MacAddressGenerator.Builder(r).build());
+        assertReseedConverges(r -> new ShortGenerator.Builder(r).build());
+        assertReseedConverges(r -> new SqlDateGenerator.Builder(r).build());
+        assertReseedConverges(r -> new SqlTimeGenerator.Builder(r).build());
+        assertReseedConverges(r -> new SqlTimestampGenerator.Builder(r).build());
+        assertReseedConverges(r -> new XmlGenerator.Builder(r).build());
+        assertReseedConverges(r -> new BigDecimalGenerator.Builder(r).build());
+    }
+}


### PR DESCRIPTION
## Summary

Final batch from the full-project review (#550–#552 were batches 1–3).

- **`reseed()` now reaches delegate generators.** Fourteen generators (Date/Instant/SqlDate/SqlTime/SqlTimestamp/Short/Bit/BitString/Character/Cidr/Inet/Interval/MacAddress/Xml) built their inner generators once at construction, so a reseed swapped the outer source while the delegate kept drawing from the old sequence — a foreign-key replay column backed by such a generator (e.g. a timestamp PK) silently diverged from its parent. `AbstractDataGenerator.reseed()` gains a protected `onReseed()` hook and each delegating generator rebuilds its delegates from the new source. **Release note:** only fills that actually reseed such a generator (FK wraparound / partition seek) produce different data than earlier releases — and those fills previously violated referential fidelity. Sequential generation is unchanged: the golden dump is byte-identical. `DelegatingGeneratorReseedTest` pins the contract across all fourteen (plus `BigDecimalGenerator`, converted to the hook). The TPCC `OrderLineDeliveryDateGenerator` is deliberately untouched — its delegate is caller-supplied.
- **Dependency-graph visualization demoted to DEBUG.** The GraphvizOnline link embeds every table name; INFO-level logs shipped to aggregation shouldn't carry schema topology (security-review finding).
- **commit-lint** carries a comment recording that linting only the PR title is deliberate (squash-merge repo).
- **`seekGeneratorsTo` O(rows) replay** needs a real design (the LXM RNG isn't jumpable, draw counts are variable) — written up with options in #553 instead of rushing a maximal-blast-radius data change into this batch.

## Testing

- New `DelegatingGeneratorReseedTest`: divergent instances converge to identical sequences after identical reseed, for all fourteen delegating generators.
- Golden dump byte-identical (sequential generation untouched).
- Full `./mvnw clean verify` green (exit code checked): all modules, all Testcontainers suites, JaCoCo gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)